### PR TITLE
[Suggestion] Add floatToElement

### DIFF
--- a/src/reactRe.rei
+++ b/src/reactRe.rei
@@ -15,6 +15,8 @@ external stringToElement : string => reactElement = "%identity";
 
 external arrayToElement : array reactElement => reactElement = "%identity";
 
+external floatToElement : float => reactElement = "%identity";
+
 let listToElement : list reactElement => reactElement;
 
 external refToJsObj : reactRef => Js.t {..} = "%identity";


### PR DESCRIPTION
First of all, I don't know if this works or not, sorry!

Right now, if we have a `float` value and we wanna show in the DOM, we need to cast types like so:

`ReasonReact.stringToElement(string_of_float myFloatValue);`.

Would be neat if we can use something like `stringToElement` but for float values.

`ReasonReact.floatToElement myFloatValue;`

What do you think?