### PR TITLE
add user-defined shouldUpdate support

### DIFF
--- a/src/reasonReact.re
+++ b/src/reasonReact.re
@@ -431,7 +431,6 @@ let createClass (type reasonState) debugName :reactClass =>
         /* Mark ourselves as all caught up! */
         nextState##reasonStateVersionUsedToComputeSubelements#=nextReasonStateVersion;
         ret
-        /* TODO: Call the component's actual shouldUpdate hook if defined. */
       };
       pub enqueueMethod callback => {
         let thisJs: jsComponentThis reasonState element = [%bs.raw "this"];

--- a/src/reasonReact.re
+++ b/src/reasonReact.re
@@ -404,12 +404,30 @@ let createClass (type reasonState) debugName :reactClass =>
          * Typically the answer is "true", except we can detect some "next
          * states" that were simply updates that we performed to work around
          * legacy versions of React.
+         *
+         * If we can detect that props have changed or a non-silent update has occured,
+         * we ask the component's shouldUpdate if it would like to update - defaulting to true.
          */
+        let props = convertPropsIfTheyreFromJs thisJs##props thisJs##jsPropsToReason debugName;
+        let Element component = props;
         let nextReasonStateVersion = nextState##reasonStateVersion;
         let nextReasonStateVersionUsedToComputeSubelements = nextState##reasonStateVersionUsedToComputeSubelements;
         let stateChangeWarrantsComputingSubelements =
           nextReasonStateVersionUsedToComputeSubelements !== nextReasonStateVersion;
-        let ret = propsWarrantRerender || stateChangeWarrantsComputingSubelements;
+        let warrantsUpdate = propsWarrantRerender || stateChangeWarrantsComputingSubelements;
+        let ret =
+          if (warrantsUpdate && component.shouldUpdate !== shouldUpdateDefault) {
+            let curState = thisJs##state;
+            let self = this##self ();
+            let self = Obj.magic self;
+            let curReasonState = curState##reasonState;
+            let curReasonState = Obj.magic curReasonState;
+            let nextReasonState = nextState##reasonState;
+            let nextReasonState = Obj.magic nextReasonState;
+            component.shouldUpdate previousState::curReasonState nextState::nextReasonState self
+          } else {
+            warrantsUpdate
+          };
         /* Mark ourselves as all caught up! */
         nextState##reasonStateVersionUsedToComputeSubelements#=nextReasonStateVersion;
         ret


### PR DESCRIPTION
This adds the actual call to shouldUpdate in the case that a non-silent state update or a props change occurs.

I tried a few ways and I think this is the most readable version of the code. I can rearrange to only call convertPropsIfTheyreFromJs when necessary if we think that function will be expensive, or update with any other readability suggestions.

@chenglou I made a typo while testing this because I expected it to be `::prevState` :P Not sure if it's a breaking change, but I still think it's worth making that move.