### PR TITLE
[Docs] Move event.target.value example

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -520,6 +520,8 @@ For non-DOM components, you need to use valid prop names.
 
 The `ReactDOMRe` module below exposes an unsafe `domElementToObj`. That's all you need.
 
+For example, you can dangerously access `event.target.value` as `(ReactDOMRe.domElementToObj (ReactEventRe.Form.target event))##value`.
+
 ### ReactDOM
 
 ReasonReact's equivalent `ReactDOMRe` exposes:
@@ -534,7 +536,7 @@ ReasonReact's equivalent `ReactDOMRe` exposes:
 
 And two helpers:
 
-- `domElementToObj : Dom.element => Js.t {..}`: turns a DOM element into a Js object whose fields that you can dangerously access: `(ReactDOMRe.domElementToObj (ReactEventRe.Form.target event))##value`.
+- `domElementToObj : Dom.element => Js.t {..}`: turns a DOM element into a Js object whose fields that you can dangerously access.
 
 - `renderToElementWithClassName : ReasonReact.reactElement => string => unit`: convenience. Finds the (first) element of the provided class name and `render` to it.
 


### PR DESCRIPTION
I thought it would be good to move the `event.target.value` example up to the `Working with DOM` section, as it was pretty hard to find previously.

When trying to figure out how to access `event.target.value` most people's flows (like mine) are probably something like this:
1. CMD+F "event"
2. See the `If you’re accessing fields on your event object...` text and click the link.
3. Read the `That’s all you need.` part and be stumped.
4. Give up and search discourse chat history.

Moving this example up a bit would help it catch the reader's eye.