### PR TITLE
Kick broken crra out in favor of reason-scripts

### DIFF
--- a/docs/gettingStarted.html
+++ b/docs/gettingStarted.html
@@ -32,11 +32,11 @@ To easily try ReasonReact, we offer two solutions with different goals in mind.
 
 BuckleScript's [bsb](http://bucklescript.github.io/bucklescript/Manual.html#_bucklescript_build_system_code_bsb_code) build system has an `init` command that generates a project template. The `react` theme offers a lightweight solution optimized for low learning overhead and ease of integration into an existing project.
 
-## Create-Reason-React-App
+## Reason Scripts
 
-For ReactJS users who are familiar with create-react-app already, [create-reason-react-app](https://github.com/knowbody/crra) should feel very familiar.
+For ReactJS users who are familiar with create-react-app already, [reason-scripts](https://github.com/reasonml-community/reason-scripts) should feel very familiar.
 
-The goal of create-reason-react-app is to provide a familiar experience to the ReactJS users who are already familiar with [create-react-app](https://github.com/facebookincubator/create-react-app). It's an all-encompassing solution.
+The goal of reason-scripts is to provide a familiar experience to the ReactJS users who are already familiar with [create-react-app](https://github.com/facebookincubator/create-react-app). It's an all-encompassing solution.
 
   </script>
   <!-- Initializer -->


### PR DESCRIPTION
I could also barely find the getting started guide. It's pretty well hidden at the top there.