### PR TITLE
Update link to reasonml module documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -588,7 +588,7 @@ ReasonReact's equivalent `ReactDOMServerRe` exposes:
 
 ### Pass in Components Class as a Prop
 
-In ReactJS, `<Menu banner=MyBanner />` is easy; in ReasonReact, we can't trivially pass the whole component module ([explanations](https://reasonml.github.io/guide/language/modules)). Solution:
+In ReactJS, `<Menu banner=MyBanner />` is easy; in ReasonReact, we can't trivially pass the whole component module ([explanations](https://reasonml.github.io/guide/language/module)). Solution:
 
 ```reason
 let bannerCallback prop1 prop2 => <MyBanner message=prop1 count=prop2 />;


### PR DESCRIPTION
Updated the link to `Pass in Components Class as a Prop` explanation.
Also might set the record for smallest pr in the history.