### PR TITLE
Add bsb as a prereq

### DIFF
--- a/docs/gettingStarted.html
+++ b/docs/gettingStarted.html
@@ -28,6 +28,9 @@ To easily try ReasonReact, we offer two solutions with different goals in mind.
 
 ## Bsb
 
+### Prerequisites
+- `bsb` (BuckleScript cli should be installed – [installation instructions](http://bucklescript.github.io/bucklescript/Manual.html#_installation))
+
 `bsb -init my-react-app -theme react`
 
 BuckleScript's [bsb](http://bucklescript.github.io/bucklescript/Manual.html#_bucklescript_build_system_code_bsb_code) build system has an `init` command that generates a project template. The `react` theme offers a lightweight solution optimized for low learning overhead and ease of integration into an existing project.

--- a/docs/gettingStarted.html
+++ b/docs/gettingStarted.html
@@ -28,8 +28,7 @@ To easily try ReasonReact, we offer two solutions with different goals in mind.
 
 ## Bsb
 
-### Prerequisites
-- `bsb` (BuckleScript cli should be installed – [installation instructions](http://bucklescript.github.io/bucklescript/Manual.html#_installation))
+**Prerequisites**: having `bsb` installed, through `npm install -g bs-platform`. Further installation instructions [here](http://bucklescript.github.io/bucklescript/Manual.html#_installation).
 
 `bsb -init my-react-app -theme react`
 


### PR DESCRIPTION
hey authors 👋 
was just getting started with reason-react and didn't find any links to `bsb` toolchain on the Getting Started page, added a link to it, lmk if this makes sense, or another link is preferred. 
cheers!