### PR TITLE
[Docs] Fix mobile navigation styles

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -228,11 +228,21 @@ code {
 .navSearchWrapper {
   align-self: center;
   position: absolute;
-  top: 15px;
+  top: 55px;
   right: 10px;
+  left: 10px;
   display: flex;
   justify-content: center;
   align-items: center;
+  width: auto;
+}
+
+@media only screen and (min-width: 375px) {
+  .navSearchWrapper {
+    top: 16px;
+    left: auto;
+    width: 50%;
+  }
 }
 
 @media only screen and (min-width: 1024px) {
@@ -285,6 +295,7 @@ code {
 }
 
 .navigationSlider .slidingNav {
+  background-color: $primaryColor;
   /* fixed makes this calculation *much* easier */
   box-sizing: border-box;
   position: fixed;
@@ -294,6 +305,11 @@ code {
   bottom: auto;
 }
 
+@media only screen and (max-width: 375px) {
+  .navigationSlider .slidingNav ul {
+    margin-top: 75px;
+  }
+}
 .mainContainer .wrapper .post .postHeader {
   /* used to be 2em. too extreme */
   padding: 1em 0 0;


### PR DESCRIPTION
On mobile devices narrower than 375px, the search navigation and logo overlap a little.

A 320px device currently looks like this:

![current-320](https://user-images.githubusercontent.com/2272928/31320101-3fe7a83e-ac34-11e7-8a61-32350a739934.png)

And my phone which is 360px looks like this:

![current-360](https://user-images.githubusercontent.com/2272928/31320148-38d3c9b4-ac35-11e7-8489-aed5d4ca01f0.png)

Also, the "header title" and the search input are aligned by the baseline (at least on 375):

![current-375](https://user-images.githubusercontent.com/2272928/31320127-c2e48e32-ac34-11e7-8f58-52146f610e2d.png)

So, this PR drops the search between the logo and the rest of the links on its own row, when the viewport is below 375 and moves the search a little bit down to center align it (i think it would look better-ish...).

It would look like this on 320px:

![new-320](https://user-images.githubusercontent.com/2272928/31320198-fdc96512-ac35-11e7-87e6-d954b78f4c67.png)

And like this on 375px:

![new-375](https://user-images.githubusercontent.com/2272928/31320205-158a7c54-ac36-11e7-8a95-c243e4436329.png)

The dropdown goes below the search as expected and would look like:

![dropdown](https://user-images.githubusercontent.com/2272928/31320216-419f9018-ac36-11e7-9080-7e5de171ddb3.png)

PS:
* Devices below 375px account for about 42% of mobile devices (http://gs.statcounter.com/screen-resolution-stats/mobile/worldwide), so i think this fix or something similar would be worth it.
* Docusaurus' (https://docusaurus.io/) repo (https://github.com/facebookexperimental/docusaurus) seems to be private at the moment so i couldn't send the PR there.