### PR TITLE
Point to JSX desugaring from the children-as-props special case docs

### DIFF
--- a/docs/children.md
+++ b/docs/children.md
@@ -5,7 +5,7 @@ title: Children
 
 JSX children are typed as `array`. This is problematic, because `<Foo> children </Foo>` where `children` comes from props (aka your `make` function) is really now a wrapped array (`Foo.make [|children|]`) and wouldn't type.
 
-Some people circumvent this with `<Foo> (ReasonReact.arrayToElement children) </Foo>`, but this is wrong; it'll trigger ReactJS' [key warning](https://facebook.github.io/react/docs/lists-and-keys.html#basic-list-component). Instead, you should use the desugared form, `Foo.make children`, which doesn't automatically wrap the children in an array wrapper like JSX does. Learn about desugaring React components [here](https://reasonml.github.io/reason-react/docs/en/jsx.html#capitalized).
+Some people circumvent this with `<Foo> (ReasonReact.arrayToElement children) </Foo>`, but this is wrong; it'll trigger ReactJS' [key warning](https://facebook.github.io/react/docs/lists-and-keys.html#basic-list-component). Instead, you should use the desugared form, `Foo.make children`, which doesn't automatically wrap the children in an array wrapper like JSX does. Learn about desugaring JSX [here](https://reasonml.github.io/reason-react/docs/en/jsx.html#capitalized).
 
 For passing to DOM element, e.g. `<div foo=bar> children </div>` use the following:
 

--- a/docs/children.md
+++ b/docs/children.md
@@ -5,7 +5,7 @@ title: Children
 
 JSX children are typed as `array`. This is problematic, because `<Foo> children </Foo>` where `children` comes from props (aka your `make` function) is really now a wrapped array (`Foo.make [|children|]`) and wouldn't type.
 
-Some people circumvent this with `<Foo> (ReasonReact.arrayToElement children) </Foo>`, but this is wrong; it'll trigger ReactJS' [key warning](https://facebook.github.io/react/docs/lists-and-keys.html#basic-list-component). Instead, you should use the desugared form, `Foo.make children`, which doesn't automatically wrap the children in an array wrapper like JSX does.
+Some people circumvent this with `<Foo> (ReasonReact.arrayToElement children) </Foo>`, but this is wrong; it'll trigger ReactJS' [key warning](https://facebook.github.io/react/docs/lists-and-keys.html#basic-list-component). Instead, you should use the desugared form, `Foo.make children`, which doesn't automatically wrap the children in an array wrapper like JSX does. Learn about desugaring React components [here](https://reasonml.github.io/reason-react/docs/en/jsx.html#capitalized).
 
 For passing to DOM element, e.g. `<div foo=bar> children </div>` use the following:
 

--- a/docs/children.md
+++ b/docs/children.md
@@ -5,7 +5,7 @@ title: Children
 
 JSX children are typed as `array`. This is problematic, because `<Foo> children </Foo>` where `children` comes from props (aka your `make` function) is really now a wrapped array (`Foo.make [|children|]`) and wouldn't type.
 
-Some people circumvent this with `<Foo> (ReasonReact.arrayToElement children) </Foo>`, but this is wrong; it'll trigger ReactJS' [key warning](https://facebook.github.io/react/docs/lists-and-keys.html#basic-list-component). Instead, you should use the desugared form, `Foo.make children`, which doesn't automatically wrap the children in an array wrapper like JSX does. Learn about desugaring JSX [here](https://reasonml.github.io/reason-react/docs/en/jsx.html#capitalized).
+Some people circumvent this with `<Foo> (ReasonReact.arrayToElement children) </Foo>`, but this is wrong; it'll trigger ReactJS' [key warning](https://facebook.github.io/react/docs/lists-and-keys.html#basic-list-component). Instead, you should use the desugared form, `Foo.make children`, which doesn't automatically wrap the children in an array wrapper like JSX does. Learn about desugaring JSX [here](jsx.md#capitalized).
 
 For passing to DOM element, e.g. `<div foo=bar> children </div>` use the following:
 


### PR DESCRIPTION
JSX is usually sufficient to write ReasonReact except when needing to pass
children as props. This is the one of the few times people need to understand
how JSX is de-sugared in Reason, and so a pointer to JSX docs is necessary
when getting stuck.