### PR TITLE
Update homepage example to Reason 3

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -26,14 +26,11 @@ Button.defaultProps = {
   target: "_self"
 };
 
-const codeExample =`let component = ReasonReact.statelessComponent "Greeting";
+const codeExample =`let component = ReasonReact.statelessComponent("Greeting");
 
-let make ::name _children => {
+let make = (~name, _children) => {
   ...component,
-  render: fun _self =>
-    <button>
-      (ReasonReact.stringToElement "Hello!")
-    </button>
+  render: (_self) => <button> (ReasonReact.stringToElement("Hello!")) </button>
 };`;
 
 const pre = "```";

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -30,7 +30,10 @@ const codeExample =`let component = ReasonReact.statelessComponent("Greeting");
 
 let make = (~name, _children) => {
   ...component,
-  render: (_self) => <button> (ReasonReact.stringToElement("Hello!")) </button>
+  render: (_self) =>
+    <button>
+      (ReasonReact.stringToElement("Hello!"))
+    </button>
 };`;
 
 const pre = "```";


### PR DESCRIPTION
Currently the example on the homepage is written in the outdated Reason syntax.

This within `website/pages/en/index.js` snippet has been run through the `upgradeSyntaxFrom2To3` to provide a, hopefully standard, updated example. 