### PR TITLE
Fix typos in state-actions-reducer.md

### DIFF
--- a/docs/state-actions-reducer.md
+++ b/docs/state-actions-reducer.md
@@ -17,7 +17,7 @@ let make = (~name, _children) => {
   initialState: () => 0, /* here, state is an `int` */
   render: (self) => {
     let greeting =
-      "Hello " ++ name ++ ". You've clicked the button2  " ++ string_of_int(self.state) ++ " time(s)!";
+      "Hello " ++ name ++ ". You've clicked the button " ++ string_of_int(self.state) ++ " time(s)!";
     <div> {ReasonReact.stringToElement(greeting)} </div>
   }
 };

--- a/docs/state-actions-reducer.md
+++ b/docs/state-actions-reducer.md
@@ -17,7 +17,7 @@ let make = (~name, _children) => {
   initialState: () => 0, /* here, state is an `int` */
   render: (self) => {
     let greeting =
-      "Hello " ++ ". You've clicked the button2  " ++ string_of_int(state.state) ++ " time(s)!";
+      "Hello " ++ name ++ ". You've clicked the button2  " ++ string_of_int(self.state) ++ " time(s)!";
     <div> {ReasonReact.stringToElement(greeting)} </div>
   }
 };


### PR DESCRIPTION
Fix a couple of typos in the first example.

This example still won't compile because ReducerComponent requires an action to be used in the reducer function. Maybe it would be best to remove it?