### PR TITLE
fix command "npm run webpack" in homepage

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -50,7 +50,7 @@ ${pre}
 Then open another tab and do:
 
 ${pre}bash
-npm run build
+npm run webpack
 ${pre}
 
 Your apps are the html files inside ${code}src/${code}`;


### PR DESCRIPTION
it is not consistent with https://reasonml.github.io/reason-react/docs/en/installation.html