### PR TITLE
Adding Fragment class

### DIFF
--- a/src/ReasonReact.re
+++ b/src/ReasonReact.re
@@ -754,3 +754,10 @@ module WrapProps = {
 };
 
 let wrapJsForReason = WrapProps.wrapJsForReason;
+
+/* reference: https://reactjs.org/docs/fragments.html */
+module Fragment = {
+  [@bs.module "react"] external fragment : ReasonReact.reactClass = "Fragment";
+  let make = (children) =>
+    ReasonReact.wrapJsForReason(~reactClass=fragment, ~props=Js.Obj.empty(), children);
+};


### PR DESCRIPTION
Adding Fragment class that uses `React.Fragment` from https://reactjs.org/docs/fragments.html. Need to add interface definition and compatibility check with older versions of react.