### PR TITLE
Fix minor router typo

### DIFF
--- a/docs/router.md
+++ b/docs/router.md
@@ -35,7 +35,7 @@ So the url `www.hello.com/book/10/edit#author?name=Jane` is given back as:
 {
   path: ["book", "10", "edit"],
   hash: edit,
-  path: "name=jane"
+  search: "name=jane"
 }
 ```
 


### PR DESCRIPTION
The example url record had a typo. It named the `search` field as `path`.