### PR TITLE
[docs] Remove duplicated sentence from "Working with Dom" page

### DIFF
--- a/docs/dom.md
+++ b/docs/dom.md
@@ -2,8 +2,6 @@
 title: Working with DOM
 ---
 
-For example, you can dangerously access `event.target.value` as `ReactDOMRe.domElementToObj(ReactEventRe.Form.target(event))##value`.
-
 ### ReactDOM
 
 ReasonReact's ReactDOM module is called `ReactDOMRe`. The module exposes helpers that work with familiar ReactJS idioms. For example, to access `event.target.value`, you can do `ReactDOMRe.domElementToObj(ReactEventRe.Form.target(event))##value`.


### PR DESCRIPTION
I noticed that there is an unexpected sentence at the start of this page of the documentation. Since it's repeated in the subsequent paragraph, i'm assuming that it was an unintentional duplicate.

Love the work you're all doing with ReasonML!