### PR TITLE
Add switch parens

### DIFF
--- a/docs/state-actions-reducer.md
+++ b/docs/state-actions-reducer.md
@@ -87,7 +87,7 @@ let make = (_children) => {
     | Click => ReasonReact.Update({...state, count: state.count + 1})
     | Toggle => ReasonReact.Update({...state, show: ! state.show})
     },
-  render: self => {
+  render: (self) => {
     let message = "Clicked " ++ string_of_int(self.state.count) ++ " times(s)";
     <div>
       <MyDialog


### PR DESCRIPTION
I think that the parens were removed by mistake on this commit https://github.com/reasonml/reason-react/commit/eaa4887c7d7352b20f67863c724d5646e0ef38f0 