### PR TITLE
Update counter.md

### DIFF
--- a/docs/counter.md
+++ b/docs/counter.md
@@ -28,7 +28,7 @@ let make = _children => {
     ReasonReact.NoUpdate;
   },
   willUnmount: self => {
-    switch (self.timerId^) {
+    switch (self.state.timerId^) {
     | Some(id) => Js.Global.clearInterval(id)
     | None => ()
     }


### PR DESCRIPTION
```bash
  32 ┆ },
  33 ┆ willUnmount: self =>
  34 ┆   switch self.timerId^ {
  35 ┆   | Some(id) => Js.Global.clearInterval(id)
  36 ┆   | None => ()
  
  This record expression is expected to have type
    ReasonReact.componentSpec (state,  'a,  'b,  'c,  action)
  The field timerId does not belong to type ReasonReact.self

```
I followed the code on the example, but it show that there is no this type.
but should it be `self.state.timerId`?