### PR TITLE
Update bs-platform dep to 2.2.2 and change to_opt => toOption

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://reasonml.github.io/reason-react/",
   "devDependencies": {
-    "bs-platform": "^2.2.1"
+    "bs-platform": "^2.2.2"
   },
   "dependencies": {
     "react": ">=15.0.0 || >=16.0.0",

--- a/src/ReasonReact.re
+++ b/src/ReasonReact.re
@@ -232,7 +232,7 @@ let subscriptionsDefault = _self => [];
 
 let convertPropsIfTheyreFromJs = (props, jsPropsToReason, debugName) => {
   let props = Obj.magic(props);
-  switch (Js.Nullable.to_opt(props##reasonProps), jsPropsToReason) {
+  switch (Js.Nullable.toOption(props##reasonProps), jsPropsToReason) {
   | (Some(props), _) => props
   /* TODO: annotate with BS to avoid curry overhead */
   | (None, Some(toReasonProps)) => Element(toReasonProps(props))
@@ -439,7 +439,7 @@ let createClass =
           let self = Obj.magic(self);
           component.willUnmount(self);
         };
-        switch (Js.Nullable.to_opt(this##subscriptions)) {
+        switch (Js.Nullable.toOption(this##subscriptions)) {
         | None => ()
         | Some(subs) =>
           List.rev(subs) |> List.iter(unsubscribe => unsubscribe())


### PR DESCRIPTION
Now that bsb warns when using `to_opt`, every library / project that depends on ReasonReact shows the warnings on compilation.