### PR TITLE
Fix router incompatibility with IE11.

### DIFF
--- a/lib/js/src/ReasonReact.js
+++ b/lib/js/src/ReasonReact.js
@@ -391,7 +391,9 @@ function createClass(debugName) {
                     return thisJs.setState((function (curTotalState, _) {
                                   var curReasonState = curTotalState.reasonState;
                                   var reasonStateUpdate = Curry._1(partialStateApplication, curReasonState);
-                                  if (reasonStateUpdate) {
+                                  if (reasonStateUpdate === /* NoUpdate */0) {
+                                    return magicNull;
+                                  } else {
                                     var match = $$this.transitionNextTotalState(curTotalState, reasonStateUpdate);
                                     var nextTotalState = match[1];
                                     var performSideEffects = match[0];
@@ -403,8 +405,6 @@ function createClass(debugName) {
                                     } else {
                                       return magicNull;
                                     }
-                                  } else {
-                                    return magicNull;
                                   }
                                 }), $$this.handleMethod((function (_, self) {
                                       return Curry._1(sideEffects[/* contents */0], self);
@@ -503,6 +503,16 @@ function wrapJsForReason(reactClass, props, children) {
   return newrecord;
 }
 
+function safeMakeEvent(eventName) {
+  if (typeof Event === "function") {
+    return new Event(eventName);
+  } else {
+    var $$event = document.createEvent("Event");
+    $$event.initEvent(eventName, true, true);
+    return $$event;
+  }
+}
+
 function path() {
   var match = typeof (window) === "undefined" ? undefined : (window);
   if (match !== undefined) {
@@ -576,7 +586,7 @@ function push(path) {
   var match$1 = typeof (window) === "undefined" ? undefined : (window);
   if (match !== undefined && match$1 !== undefined) {
     match.pushState((null), "", path);
-    match$1.dispatchEvent(new Event("popstate"));
+    match$1.dispatchEvent(safeMakeEvent("popstate"));
     return /* () */0;
   } else {
     return /* () */0;


### PR DESCRIPTION
`element.dispatchEvent(new Event(eventName))` won't work in IE11, see https://stackoverflow.com/questions/27176983/dispatchevent-not-working-in-ie11.

This PR provides a safe `makeEvent` function that works both in modern browsers and in IE11.