### PR TITLE
remove silent update

### DIFF
--- a/lib/js/src/ReasonReact.js
+++ b/lib/js/src/ReasonReact.js
@@ -128,45 +128,19 @@ function createClass(debugName) {
                           return /* tuple */[
                                   /* None */0,
                                   {
-                                    reasonState: reasonStateUpdate[0],
-                                    reasonStateVersion: curTotalState.reasonStateVersion + 1 | 0,
-                                    reasonStateVersionUsedToComputeSubelements: curTotalState.reasonStateVersionUsedToComputeSubelements
+                                    reasonState: reasonStateUpdate[0]
                                   }
                                 ];
                       case 1 : 
                           return /* tuple */[
-                                  /* None */0,
-                                  {
-                                    reasonState: reasonStateUpdate[0],
-                                    reasonStateVersion: curTotalState.reasonStateVersion + 1 | 0,
-                                    reasonStateVersionUsedToComputeSubelements: curTotalState.reasonStateVersionUsedToComputeSubelements + 1 | 0
-                                  }
+                                  /* Some */[reasonStateUpdate[0]],
+                                  curTotalState
                                 ];
                       case 2 : 
                           return /* tuple */[
-                                  /* Some */[reasonStateUpdate[0]],
-                                  {
-                                    reasonState: curTotalState.reasonState,
-                                    reasonStateVersion: curTotalState.reasonStateVersion + 1 | 0,
-                                    reasonStateVersionUsedToComputeSubelements: curTotalState.reasonStateVersionUsedToComputeSubelements + 1 | 0
-                                  }
-                                ];
-                      case 3 : 
-                          return /* tuple */[
                                   /* Some */[reasonStateUpdate[1]],
                                   {
-                                    reasonState: reasonStateUpdate[0],
-                                    reasonStateVersion: curTotalState.reasonStateVersion + 1 | 0,
-                                    reasonStateVersionUsedToComputeSubelements: curTotalState.reasonStateVersionUsedToComputeSubelements
-                                  }
-                                ];
-                      case 4 : 
-                          return /* tuple */[
-                                  /* Some */[reasonStateUpdate[1]],
-                                  {
-                                    reasonState: reasonStateUpdate[0],
-                                    reasonStateVersion: curTotalState.reasonStateVersion + 1 | 0,
-                                    reasonStateVersionUsedToComputeSubelements: curTotalState.reasonStateVersionUsedToComputeSubelements + 1 | 0
+                                    reasonState: reasonStateUpdate[0]
                                   }
                                 ];
                       
@@ -176,11 +150,8 @@ function createClass(debugName) {
               getInitialState: (function () {
                   var thisJs = (this);
                   var convertedReasonProps = convertPropsIfTheyreFromJs(thisJs.props, thisJs.jsPropsToReason, debugName);
-                  var initialReasonState = Curry._1(convertedReasonProps[0][/* initialState */10], /* () */0);
                   return {
-                          reasonState: initialReasonState,
-                          reasonStateVersion: 1,
-                          reasonStateVersionUsedToComputeSubelements: 1
+                          reasonState: Curry._1(convertedReasonProps[0][/* initialState */10], /* () */0)
                         };
                 }),
               componentDidMount: (function () {
@@ -206,7 +177,7 @@ function createClass(debugName) {
                     var match = $$this.transitionNextTotalState(curTotalState, reasonStateUpdate);
                     var nextTotalState = match[1];
                     var performSideEffects = match[0];
-                    var match$1 = +(nextTotalState.reasonStateVersion === curTotalState.reasonStateVersion);
+                    var match$1 = +(nextTotalState === curTotalState);
                     if (match$1 !== 0) {
                       if (performSideEffects) {
                         var performSideEffects$1 = performSideEffects[0];
@@ -330,16 +301,11 @@ function createClass(debugName) {
                     var oldComponent = oldConvertedReasonProps[0];
                     return thisJs.setState((function (curTotalState, _) {
                                   var curReasonState = curTotalState.reasonState;
-                                  var curReasonStateVersion = curTotalState.reasonStateVersion;
                                   var oldSelf = $$this.self(curReasonState, oldComponent[/* retainedProps */11]);
                                   var nextReasonState = Curry._1(newComponent[/* willReceiveProps */3], oldSelf);
-                                  var match = +(nextReasonState !== curReasonState);
-                                  var nextReasonStateVersion = match !== 0 ? curReasonStateVersion + 1 | 0 : curReasonStateVersion;
-                                  if (nextReasonStateVersion !== curReasonStateVersion) {
+                                  if (nextReasonState !== curTotalState) {
                                     return {
-                                            reasonState: nextReasonState,
-                                            reasonStateVersion: nextReasonStateVersion,
-                                            reasonStateVersionUsedToComputeSubelements: curTotalState.reasonStateVersionUsedToComputeSubelements
+                                            reasonState: nextReasonState
                                           };
                                   } else {
                                     return curTotalState;
@@ -353,19 +319,13 @@ function createClass(debugName) {
                   var $$this = this ;
                   var thisJs = (this);
                   var curJsProps = thisJs.props;
-                  var propsWarrantRerender = +(nextJsProps !== curJsProps);
                   var oldConvertedReasonProps = convertPropsIfTheyreFromJs(thisJs.props, thisJs.jsPropsToReason, debugName);
                   var match = +(nextJsProps === curJsProps);
                   var newConvertedReasonProps = match !== 0 ? oldConvertedReasonProps : convertPropsIfTheyreFromJs(nextJsProps, thisJs.jsPropsToReason, debugName);
                   var newComponent = newConvertedReasonProps[0];
-                  var nextReasonStateVersion = nextState.reasonStateVersion;
-                  var nextReasonStateVersionUsedToComputeSubelements = nextState.reasonStateVersionUsedToComputeSubelements;
-                  var stateChangeWarrantsComputingSubelements = +(nextReasonStateVersionUsedToComputeSubelements !== nextReasonStateVersion);
-                  var warrantsUpdate = propsWarrantRerender || stateChangeWarrantsComputingSubelements;
                   var nextReasonState = nextState.reasonState;
                   var newSelf = $$this.self(nextReasonState, newComponent[/* retainedProps */11]);
-                  var ret;
-                  if (warrantsUpdate && newComponent[/* shouldUpdate */8] !== lifecycleReturnTrue) {
+                  if (newComponent[/* shouldUpdate */8] !== lifecycleReturnTrue) {
                     var curState = thisJs.state;
                     var curReasonState = curState.reasonState;
                     var oldSelf_000 = /* handle */newSelf[/* handle */0];
@@ -381,15 +341,13 @@ function createClass(debugName) {
                       oldSelf_004,
                       oldSelf_005
                     ];
-                    ret = Curry._1(newComponent[/* shouldUpdate */8], /* record */[
-                          /* oldSelf */oldSelf,
-                          /* newSelf */newSelf
-                        ]);
+                    return Curry._1(newComponent[/* shouldUpdate */8], /* record */[
+                                /* oldSelf */oldSelf,
+                                /* newSelf */newSelf
+                              ]);
                   } else {
-                    ret = warrantsUpdate;
+                    return /* true */1;
                   }
-                  nextState.reasonStateVersionUsedToComputeSubelements = nextReasonStateVersion;
-                  return ret;
                 }),
               registerMethod: (function (subscription) {
                   var $$this = this ;
@@ -398,7 +356,8 @@ function createClass(debugName) {
                     match.push(subscription);
                     return /* () */0;
                   } else {
-                    return $$this.subscriptions = /* array */[subscription];
+                    $$this.subscriptions = /* array */[subscription];
+                    return /* () */0;
                   }
                 }),
               handleMethod: (function (callback) {
@@ -424,20 +383,20 @@ function createClass(debugName) {
                     return thisJs.setState((function (curTotalState, _) {
                                   var curReasonState = curTotalState.reasonState;
                                   var reasonStateUpdate = Curry._1(partialStateApplication, curReasonState);
-                                  if (reasonStateUpdate) {
+                                  if (reasonStateUpdate === /* NoUpdate */0) {
+                                    return magicNull;
+                                  } else {
                                     var match = $$this.transitionNextTotalState(curTotalState, reasonStateUpdate);
                                     var nextTotalState = match[1];
                                     var performSideEffects = match[0];
                                     if (performSideEffects) {
                                       sideEffects[/* contents */0] = performSideEffects[0];
                                     }
-                                    if (nextTotalState.reasonStateVersion !== curTotalState.reasonStateVersion) {
+                                    if (nextTotalState !== curTotalState) {
                                       return nextTotalState;
                                     } else {
                                       return magicNull;
                                     }
-                                  } else {
-                                    return magicNull;
                                   }
                                 }), $$this.handleMethod((function (_, self) {
                                       return Curry._1(sideEffects[/* contents */0], self);

--- a/src/ReasonReact.rei
+++ b/src/ReasonReact.rei
@@ -9,8 +9,8 @@
 /***
  * TODO: Test Cases (Highest Priority First):
  * -------------------
- * 1. That a silent update will not block received props!
- * 2. That a silent update will not block another state update! (Two different
+ * 1. Unneeded? That a silent update will not block received props!
+ * 2. Unneeded? That a silent update will not block another state update! (Two different
  * DOM nodes having event handlers - one triggering silent, the other
  * triggering loud). Then switch which one is invoked first.
  * 3. Add tests for "handle()". (non state updating callback)
@@ -110,9 +110,6 @@ type update('state, 'retainedProps, 'action) =
   | NoUpdate
   /* Update the state with the given one. */
   | Update('state)
-  /* Update the state with the given one, but don't trigger a re-render.
-     Do not prevent a re-render either, if one was scheduled to happen. */
-  | SilentUpdate('state)
   /* Perform side effects without updating state, and don't trigger a re-render.
      Do not prevent a re-render either, if one was scheduled to happen.
      The side effects function is invoked when all the updates have completed. */
@@ -120,12 +117,6 @@ type update('state, 'retainedProps, 'action) =
   /* Update the state and perform side effects.
      The side effects function is invoked when all the updates have completed. */
   | UpdateWithSideEffects(
-      'state,
-      self('state, 'retainedProps, 'action) => unit,
-    )
-  /* Like UpdateWithSideEffects, but don't trigger a re-render.
-     Do not prevent a re-render either, if one was scheduled to happen. */
-  | SilentUpdateWithSideEffects(
       'state,
       self('state, 'retainedProps, 'action) => unit,
     )


### PR DESCRIPTION
This removes SilentUpdate as discussed a few times before. Right now, React does not provide an API suitable to build out SilentUpdate without bookkeeping and implementing a custom sCU. This isn't a great solution and it might be good to work with the React team to find something that doesn't require bookkeeping on our end.

Pros:
* Removes a lot of complexity in RR and all custom lifecycle bookkeeping.
* SilentUpdate was hard to explain to newcomers
* As implemented, SilentUpdate is not Fiber async safe. Fiber can rollback so you can't use SilentUpdate to store side-effectual stuff like timer ids, DOM refs.
* It isn't documented, so breaking change will not be widespread. In theory codemodding to Update will just be a perf loss (but seems unlikely).
Cons:
* Breaking change.
* For some specific performance cases this API is desirable.