### PR TITLE
Update intro example to use unused prop

### DIFF
--- a/docs/intro-example.md
+++ b/docs/intro-example.md
@@ -10,6 +10,6 @@ let component = ReasonReact.statelessComponent("Greeting");
 /* underscores before names indicate unused variables. We name them for clarity */
 let make = (~name, _children) => {
   ...component,
-  render: (_self) => <button> {ReasonReact.stringToElement("Hello!")} </button>
+  render: (_self) => <button> (ReasonReact.stringToElement("Hello " ++ name ++ "!")) </button>
 };
 ```


### PR DESCRIPTION
The current intro example has a `name` prop. However, the prop is not used. [Copy pasting the example will error unless a `name` prop is defined](https://reasonml.github.io/en/try.html?rrjsx=true&reason=LYewJgrgNgpgBAcQE4xgFwJYDsDmcC8cA3gFBxyxpwDGIwADiFjFlYQEowCGAzk512poAdDzRc0MWDx4BhOo2asAFACJkqTLlUBKANxkK6OMC4BreIWUA-LF2AwANHAD61ABYYoYFFh0EAPmJDcmEw2gYmFjRHELhfMBgkAC44ZRceKQAzf3wggB4AIwg0NCYgogE+LAEhUTQkbBwAFRAAUVgHFVUACSkoEABCXQBfOHyAemLS8sMRg3mSElq0ABEAeQBZTmEEpNaOmC60AHUMNHcASTBlfI10JrgJgOdVehQANwwYAHddPSAA) when using the component, but it's not actually used in the `render` method. This proposed change actually uses the `name` prop (as opposed to entirely removing it).