### PR TITLE
Fix examples on homepage for 0.4.0

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -36,7 +36,7 @@ let make = (~name, _children) => {
   ...component,
   render: _self =>
     <button>
-      {ReasonReact.stringToElement("Hello!")}
+      {ReasonReact.string("Hello!")}
     </button>
 };
 ${pre}`;
@@ -48,7 +48,7 @@ let make = (~name, _children) => {
   ...component,
   render: _self =>
     <button>
-      {ReasonReact.stringToElement("Hello!")}
+      {ReasonReact.string("Hello!")}
     </button>
 };
 ${pre}`;


### PR DESCRIPTION
Did we mention that `stringToElement` is just `string` now?