### PR TITLE
Adding Context

### DIFF
--- a/lib/js/src/ReasonReact.js
+++ b/lib/js/src/ReasonReact.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Block = require("bs-platform/lib/js/block.js");
 var Curry = require("bs-platform/lib/js/curry.js");
 var React = require("react");
 var Caml_builtin_exceptions = require("bs-platform/lib/js/caml_builtin_exceptions.js");
@@ -591,90 +590,20 @@ var Router = [
 ];
 
 function CreateContext(funarg) {
-  var passThrough = ( props => props.children );
-  var state = [funarg[/* value */1]];
-  var subscriptions = [/* array */[]];
-  var addSubscription = function (f) {
-    subscriptions[0] = subscriptions[0].concat(/* array */[f]);
-    return (function () {
-        subscriptions[0] = subscriptions[0].filter((function (sub) {
-                return sub !== f;
-              }));
-        return /* () */0;
-      });
-  };
-  var updateState = function (newStateOpt) {
-    var newState = newStateOpt ? newStateOpt[0] : funarg[/* value */1];
-    state[0] = newState;
-    subscriptions[0].forEach((function (f) {
-            return Curry._1(f, newState);
-          }));
-    return /* () */0;
-  };
-  var component = statelessComponent(funarg[/* debugName */0] + "ContextProvider");
+  var context = React.createContext(funarg[/* value */1]);
   var make = function (value, children) {
-    return /* record */[
-            /* debugName */component[/* debugName */0],
-            /* reactClassInternal */component[/* reactClassInternal */1],
-            /* handedOffState */component[/* handedOffState */2],
-            /* willReceiveProps */(function () {
-                return updateState(value);
-              }),
-            /* didMount */(function () {
-                updateState(value);
-                return /* () */0;
-              }),
-            /* didUpdate */component[/* didUpdate */5],
-            /* willUnmount */component[/* willUnmount */6],
-            /* willUpdate */component[/* willUpdate */7],
-            /* shouldUpdate */(function () {
-                return false;
-              }),
-            /* render */(function () {
-                return element(/* None */0, /* None */0, wrapJsForReason(passThrough, { }, children));
-              }),
-            /* initialState */component[/* initialState */10],
-            /* retainedProps */component[/* retainedProps */11],
-            /* reducer */component[/* reducer */12],
-            /* subscriptions */component[/* subscriptions */13],
-            /* jsElementWrapped */component[/* jsElementWrapped */14]
-          ];
+    return wrapJsForReason(context.Provider, {
+                value: value
+              }, children);
   };
-  var component$1 = reducerComponent(funarg[/* debugName */0] + "ContextConsumer");
+  var Provider = /* module */[/* make */make];
   var make$1 = function (children) {
-    return /* record */[
-            /* debugName */component$1[/* debugName */0],
-            /* reactClassInternal */component$1[/* reactClassInternal */1],
-            /* handedOffState */component$1[/* handedOffState */2],
-            /* willReceiveProps */component$1[/* willReceiveProps */3],
-            /* didMount */(function (param) {
-                var send = param[/* send */3];
-                return Curry._1(param[/* onUnmount */4], addSubscription((function (newState) {
-                                  return Curry._1(send, /* ChangeState */[newState]);
-                                })));
-              }),
-            /* didUpdate */component$1[/* didUpdate */5],
-            /* willUnmount */component$1[/* willUnmount */6],
-            /* willUpdate */component$1[/* willUpdate */7],
-            /* shouldUpdate */component$1[/* shouldUpdate */8],
-            /* render */(function (param) {
-                return Curry._1(children, param[/* state */1]);
-              }),
-            /* initialState */(function () {
-                return state[0];
-              }),
-            /* retainedProps */component$1[/* retainedProps */11],
-            /* reducer */(function (action, _) {
-                return /* Update */Block.__(0, [action[0]]);
-              }),
-            /* subscriptions */component$1[/* subscriptions */13],
-            /* jsElementWrapped */component$1[/* jsElementWrapped */14]
-          ];
+    return wrapJsForReason(context.Consumer, { }, children);
   };
+  var Consumer = /* module */[/* make */make$1];
   return [
-          subscriptions,
-          [make],
-          [make$1]
+          Provider,
+          Consumer
         ];
 }
 

--- a/lib/js/src/ReasonReact.js
+++ b/lib/js/src/ReasonReact.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Block = require("bs-platform/lib/js/block.js");
 var Curry = require("bs-platform/lib/js/curry.js");
 var React = require("react");
 var Caml_builtin_exceptions = require("bs-platform/lib/js/caml_builtin_exceptions.js");
@@ -589,6 +590,94 @@ var Router = [
   url
 ];
 
+function CreateContext(funarg) {
+  var passThrough = ( props => props.children );
+  var state = [funarg[/* value */1]];
+  var subscriptions = [/* array */[]];
+  var addSubscription = function (f) {
+    subscriptions[0] = subscriptions[0].concat(/* array */[f]);
+    return (function () {
+        subscriptions[0] = subscriptions[0].filter((function (sub) {
+                return sub !== f;
+              }));
+        return /* () */0;
+      });
+  };
+  var updateState = function (newStateOpt) {
+    var newState = newStateOpt ? newStateOpt[0] : funarg[/* value */1];
+    state[0] = newState;
+    subscriptions[0].forEach((function (f) {
+            return Curry._1(f, newState);
+          }));
+    return /* () */0;
+  };
+  var component = statelessComponent(funarg[/* debugName */0] + "ContextProvider");
+  var make = function (value, children) {
+    return /* record */[
+            /* debugName */component[/* debugName */0],
+            /* reactClassInternal */component[/* reactClassInternal */1],
+            /* handedOffState */component[/* handedOffState */2],
+            /* willReceiveProps */(function () {
+                return updateState(value);
+              }),
+            /* didMount */(function () {
+                updateState(value);
+                return /* () */0;
+              }),
+            /* didUpdate */component[/* didUpdate */5],
+            /* willUnmount */component[/* willUnmount */6],
+            /* willUpdate */component[/* willUpdate */7],
+            /* shouldUpdate */(function () {
+                return false;
+              }),
+            /* render */(function () {
+                return element(/* None */0, /* None */0, wrapJsForReason(passThrough, { }, children));
+              }),
+            /* initialState */component[/* initialState */10],
+            /* retainedProps */component[/* retainedProps */11],
+            /* reducer */component[/* reducer */12],
+            /* subscriptions */component[/* subscriptions */13],
+            /* jsElementWrapped */component[/* jsElementWrapped */14]
+          ];
+  };
+  var component$1 = reducerComponent(funarg[/* debugName */0] + "ContextConsumer");
+  var make$1 = function (children) {
+    return /* record */[
+            /* debugName */component$1[/* debugName */0],
+            /* reactClassInternal */component$1[/* reactClassInternal */1],
+            /* handedOffState */component$1[/* handedOffState */2],
+            /* willReceiveProps */component$1[/* willReceiveProps */3],
+            /* didMount */(function (param) {
+                var send = param[/* send */3];
+                return Curry._1(param[/* onUnmount */4], addSubscription((function (newState) {
+                                  return Curry._1(send, /* ChangeState */[newState]);
+                                })));
+              }),
+            /* didUpdate */component$1[/* didUpdate */5],
+            /* willUnmount */component$1[/* willUnmount */6],
+            /* willUpdate */component$1[/* willUpdate */7],
+            /* shouldUpdate */component$1[/* shouldUpdate */8],
+            /* render */(function (param) {
+                return Curry._1(children, param[/* state */1]);
+              }),
+            /* initialState */(function () {
+                return state[0];
+              }),
+            /* retainedProps */component$1[/* retainedProps */11],
+            /* reducer */(function (action, _) {
+                return /* Update */Block.__(0, [action[0]]);
+              }),
+            /* subscriptions */component$1[/* subscriptions */13],
+            /* jsElementWrapped */component$1[/* jsElementWrapped */14]
+          ];
+  };
+  return [
+          subscriptions,
+          [make],
+          [make$1]
+        ];
+}
+
 exports.statelessComponent = statelessComponent;
 exports.statelessComponentWithRetainedProps = statelessComponentWithRetainedProps;
 exports.reducerComponent = reducerComponent;
@@ -599,4 +688,5 @@ exports.createDomElement = createDomElement;
 exports.wrapJsForReason = wrapJsForReason;
 exports.Router = Router;
 exports.Callback = Callback;
+exports.CreateContext = CreateContext;
 /* dummyInteropComponent Not a pure module */

--- a/src/ReasonReact.re
+++ b/src/ReasonReact.re
@@ -930,3 +930,64 @@ module Callback = {
     handlerTwo(payload);
   };
 };
+
+module type ContextConfig = {
+  let debugName: string;
+  /* the type of data in this context */
+  type t;
+  /* The current value of the context */
+  let value: t;
+};
+
+module CreateContext = (C: ContextConfig) => {
+  /* This allows for children to be passed through, createDomElement cannot be */
+  /* used because it couples to the dom and breaks react native */
+  let passThrough = [%bs.raw {| props => props.children |}];
+  type action =
+    | ChangeState(C.t);
+  let state = ref(C.value);
+  let subscriptions = ref([||]);
+  let addSubscription = f => {
+    subscriptions := Js.Array.concat([|f|], subscriptions^);
+    () => subscriptions := Js.Array.filter(sub => sub !== f, subscriptions^);
+  };
+  let updateState = newStateOpt => {
+    let newState =
+      switch (newStateOpt) {
+      | None => C.value
+      | Some(newValue) => newValue
+      };
+    state := newState;
+    Js.Array.forEach(f => f(newState), subscriptions^);
+  };
+  module Provider = {
+    let component = statelessComponent(C.debugName ++ "ContextProvider");
+    let make = (~value=?, children) => {
+      ...component,
+      shouldUpdate: _self => false,
+      willReceiveProps: _self => updateState(value),
+      didMount: _self => {
+        updateState(value);
+        ();
+      },
+      render: _self =>
+        element(
+          wrapJsForReason(~reactClass=passThrough, ~props=Js.Obj.empty(), children),
+        ),
+    };
+  };
+  module Consumer = {
+    let component = reducerComponent(C.debugName ++ "ContextConsumer");
+    let make = children => {
+      ...component,
+      initialState: () => state^,
+      reducer: (action, _state) =>
+        switch (action) {
+        | ChangeState(newState) => Update(newState)
+        },
+      didMount: ({send, onUnmount}) =>
+        (newState => send(ChangeState(newState))) |> addSubscription |> onUnmount,
+      render: ({state}) => children(state),
+    };
+  };
+}

--- a/src/ReasonReact.rei
+++ b/src/ReasonReact.rei
@@ -291,16 +291,11 @@ module type ContextConfig = {let debugName: string; type t; let value: t;};
 module CreateContext:
   (C: ContextConfig) =>
   {
-    type action =
-      | ChangeState(C.t);
-    let subscriptions: ref(array(C.t => unit));
     module Provider: {
       let make:
-        (~value: C.t=?, array(reactElement)) =>
-        componentSpec(
+        (~value: C.t, array(reactElement)) =>
+        component(
           stateless,
-          stateless,
-          noRetainedProps,
           noRetainedProps,
           actionless,
         );
@@ -308,12 +303,10 @@ module CreateContext:
     module Consumer: {
       let make:
         (C.t => reactElement) =>
-        componentSpec(
-          C.t,
-          C.t,
+        component(
+          stateless,
           noRetainedProps,
-          noRetainedProps,
-          action,
+          actionless,
         );
     };
   };

--- a/src/ReasonReact.rei
+++ b/src/ReasonReact.rei
@@ -285,3 +285,35 @@ module Callback: {
   [@deprecated "Please chain your callbacks manually one after another"]
   let chain: ('payload => unit, 'payload => unit) => 'payload => unit;
 };
+
+module type ContextConfig = {let debugName: string; type t; let value: t;};
+
+module CreateContext:
+  (C: ContextConfig) =>
+  {
+    type action =
+      | ChangeState(C.t);
+    let subscriptions: ref(array(C.t => unit));
+    module Provider: {
+      let make:
+        (~value: C.t=?, array(reactElement)) =>
+        componentSpec(
+          stateless,
+          stateless,
+          noRetainedProps,
+          noRetainedProps,
+          actionless,
+        );
+    };
+    module Consumer: {
+      let make:
+        (C.t => reactElement) =>
+        componentSpec(
+          C.t,
+          C.t,
+          noRetainedProps,
+          noRetainedProps,
+          action,
+        );
+    };
+  };


### PR DESCRIPTION
This is an initial attempt to bring the context API to reason-react. This version is implemented in pure Reason and does support working with react 15.

If React 15 support is no longer a priority I believe this can be done through a simple external on the ReactJS context API.

This code is a copy of a library I wrote: https://github.com/Hehk/reason-react-context