### PR TITLE
Fix braces typo in docs Callback Handlers

### DIFF
--- a/docs/callback-handlers.md
+++ b/docs/callback-handlers.md
@@ -53,7 +53,7 @@ let make = (~name, ~onClick, _children) => {
   {
     ...component,
     initialState: ...,
-    render: (self) => <button onClick={self.handle(click)} />
+    render: (self) => <button onClick=(self.handle(click)) />
   }
 };
 ```


### PR DESCRIPTION
Replace braces: `render: (self) => <button onClick={self.handle(click)} />` should be     `render: (self) => <button onClick=(self.handle(click)) />`