### PR TITLE
algolia doc search for many languages

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -217,7 +217,10 @@ const siteConfig = {
   },
   algolia: {
     apiKey: "55156da6520de795d3a2c2d23786f08e",
-    indexName: "react-reason"
+    indexName: "react-reason",
+    algoliaOptions: {
+      facetFilters: ["lang:LANGUAGE"] 
+    }
   },
 };
 


### PR DESCRIPTION
## Notes
Merge only after https://github.com/algolia/docsearch-configs/pull/447 is merged

## Motivation
Based on https://github.com/reasonml/reasonml.github.io/pull/392#issuecomment-395927699

We want to search the correct language in the search bar.

When I'm on chinese, I will only search for chinese documentation.
When I'm on english,, I will only search for user documentation.
