### PR TITLE
Add click counter example; rename timer example

### DIFF
--- a/docs/counter.md
+++ b/docs/counter.md
@@ -1,64 +1,36 @@
 ---
-title: Counter
+title: Click Counter
 ---
 
-Demonstrates calling an async "setState" in ReasonReact.
+Demonstrates working with state and reducer in ReasonReact.
 
 ```reason
 type action =
-  | Tick;
+  | Modify(int)
+  | Reset;
 
 type state = {
-  count: int,
-  timerId: ref(option(Js.Global.intervalId))
+  count: int
 };
 
 let component = ReasonReact.reducerComponent("Counter");
 
-let make = _children => {
-  ...component,
-  initialState: () => {count: 0, timerId: ref(None)},
-  reducer: (action, state) =>
-    switch (action) {
-    | Tick => ReasonReact.Update({...state, count: state.count + 1})
-    },
-  didMount: self => {
-    self.state.timerId :=
-      Some(Js.Global.setInterval(() => self.send(Tick), 1000));
-  },
-  willUnmount: self => {
-    switch (self.state.timerId^) {
-    | Some(id) => Js.Global.clearInterval(id)
-    | None => ()
-    }
-  },
-  render: ({state}) =>
-    <div>{ReasonReact.string(string_of_int(state.count))}</div>
-};
-```
-
-Or, using the [subscriptions helper](subscriptions-helper.md):
-
-```reason
-type action =
-  | Tick;
-
-type state = {count: int};
-
-let component = ReasonReact.reducerComponent("Counter");
+let s = ReasonReact.string; /* Convenience helper */
 
 let make = _children => {
   ...component,
   initialState: () => {count: 0},
-  didMount: self => {
-    let intervalId = Js.Global.setInterval(() => self.send(Tick), 1000);
-    self.onUnmount(() => Js.Global.clearInterval(intervalId));
-  },
   reducer: (action, state) =>
     switch (action) {
-    | Tick => ReasonReact.Update({count: state.count + 1})
+    | Modify(amount) => ReasonReact.Update({ count: state.count + amount })
+    | Reset => ReasonReact.Update({ count: 0 })
     },
-  render: ({state}) =>
-    <div>{ReasonReact.string(string_of_int(state.count))}</div>
+  render: ({state, send}) =>
+    <div>
+      <h3>{s("Clicked: " ++ string_of_int(state.count))}</h3>
+      <button onClick={_event => send(Modify(1))}>{s("Increment")}</button>
+      <button onClick={_event => send(Modify(-1))}>{s("Decrement")}</button>
+      <button onClick={_event => send(Reset)}>{s("Reset")}</button>
+    </div>
 };
 ```

--- a/docs/timer.md
+++ b/docs/timer.md
@@ -1,0 +1,64 @@
+---
+title: Counter
+---
+
+Demonstrates calling an async "setState" in ReasonReact.
+
+```reason
+type action =
+  | Tick;
+
+type state = {
+  count: int,
+  timerId: ref(option(Js.Global.intervalId))
+};
+
+let component = ReasonReact.reducerComponent("Counter");
+
+let make = _children => {
+  ...component,
+  initialState: () => {count: 0, timerId: ref(None)},
+  reducer: (action, state) =>
+    switch (action) {
+    | Tick => ReasonReact.Update({...state, count: state.count + 1})
+    },
+  didMount: self => {
+    self.state.timerId :=
+      Some(Js.Global.setInterval(() => self.send(Tick), 1000));
+  },
+  willUnmount: self => {
+    switch (self.state.timerId^) {
+    | Some(id) => Js.Global.clearInterval(id)
+    | None => ()
+    }
+  },
+  render: ({state}) =>
+    <div>{ReasonReact.string(string_of_int(state.count))}</div>
+};
+```
+
+Or, using the [subscriptions helper](subscriptions-helper.md):
+
+```reason
+type action =
+  | Tick;
+
+type state = {count: int};
+
+let component = ReasonReact.reducerComponent("Counter");
+
+let make = _children => {
+  ...component,
+  initialState: () => {count: 0},
+  didMount: self => {
+    let intervalId = Js.Global.setInterval(() => self.send(Tick), 1000);
+    self.onUnmount(() => Js.Global.clearInterval(intervalId));
+  },
+  reducer: (action, state) =>
+    switch (action) {
+    | Tick => ReasonReact.Update({count: state.count + 1})
+    },
+  render: ({state}) =>
+    <div>{ReasonReact.string(string_of_int(state.count))}</div>
+};
+```

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -42,7 +42,8 @@
   "examples": {
     "Code Snippets": [
       "simple",
-      "counter",
+      "click-counter",
+      "timer",
       "reason-using-js",
       "js-using-reason",
       "example-projects"


### PR DESCRIPTION
This fills in a small void. It's more complicated than the simple example, but simpler than [the reducer docs](docs/state-actions-reducer.md) without introducing timeout management in the current counter example.

I renamed the current counter example to `timer.md` to give it a more appropriate name ("counter" is more common for a click-handling component), and replaced `counter.md` with this new example to avoid any broken links.