### PR TITLE
Update link in event.md to point to master version that uses the newer Reason syntax

### DIFF
--- a/docs/event.md
+++ b/docs/event.md
@@ -2,7 +2,7 @@
 title: Event
 ---
 
-ReasonReact events map cleanly to ReactJS [synthetic events](https://reactjs.org/docs/events.html). More info in the [inline docs](https://github.com/reasonml/reason-react/blob/380358e5894d4223e7dd9c1fb2df72f0756231bc/src/reactEventRe.rei#L1).
+ReasonReact events map cleanly to ReactJS [synthetic events](https://reactjs.org/docs/events.html). More info in the [inline docs](https://github.com/reasonml/reason-react/blob/master/src/ReactEventRe.rei#L1).
 
 If you're accessing fields on your event object, like `event.target.value`, you'd use a combination of a `ReactDOMRe` helper and [BuckleScript's `##` object access FFI](https://bucklescript.github.io/docs/en/object.html#accessors):
 


### PR DESCRIPTION
Hello,

Before this change, the link to the inline docs pointed to an older version of ReactEventRe.rei. This version of the file used the older Reason syntax. This change updates the link to point to the version of this file in master. This means that this issue will not happen as the link will always point to the latest version of the file that is in master.