### PR TITLE
Update example to working component.

### DIFF
--- a/docs/reason-using-js.md
+++ b/docs/reason-using-js.md
@@ -9,9 +9,13 @@ var ReactDOM = require('react-dom');
 var React = require('react');
 
 var MyBanner = function(props) {
-  return React.createElement('div', null,
-    props.show ? props.message : 'No message here!'
-  );
+   if (props.show) {
+    return React.createElement('div', null,
+      'Here\'s the message from the owner: ' + props.message
+    );
+  } else {
+    return null;
+  }
 };
 
 module.exports = MyBanner;

--- a/docs/reason-using-js.md
+++ b/docs/reason-using-js.md
@@ -7,19 +7,14 @@ title: ReasonReact using ReactJS
 ```javascript
 var ReactDOM = require('react-dom');
 var React = require('react');
-var App = React.createClass({
-  displayName: "MyBanner",
-  render: function() {
-    if (this.props.show) {
-      return React.createElement('div', null,
-        this.props.message
-      );
-    } else {
-      return null;
-    }
-  }
-});
-module.exports = App;
+
+var MyBanner = function(props) {
+  return React.createElement('div', null,
+    props.show ? props.message : 'No message here!'
+  );
+};
+
+module.exports = MyBanner;
 ```
 
 `MyBannerRe.re`


### PR DESCRIPTION
The current documentation uses the [deprecated](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html) `createClass` method, which throws an error.  
Rather than adding another dependency, it seems easier to use a stateless react component.  

credit to: https://reasonml.chat/t/typeerror-react-createclass-is-not-a-function/388/6