### PR TITLE
Use ReasonReact.string instead of stringToElement

### DIFF
--- a/docs/playground.md
+++ b/docs/playground.md
@@ -2,4 +2,4 @@
 title: Playground
 ---
 
-You can try ReasonReact, with live JS output, in the [Reason Try page](https://reasonml.github.io/en/try.html?rrjsx=true&reason=LYewJgrgNgpgBAcQE4xgFwJYDsDmcC8cA3gFBxyxpwDGIwADiFjFlYQEowCGAzk512poAdDzRc0MWDx4BhOo2asAFACJkqTLlUBKANxkK6OMC4BreIQD61ABYYoYFFgIA+YofLDvtBkxZoADSecM5gMEgAXHA8UgBmbiHkADwARhBoaEzuygJ8WAJComhI2DgAKiAAorDAAWoAElJQIACEujpwyQD06ZnZweQAvgYjJCSFaAAiAPIAspzCYRGVNTB1rADqGGi2AJJgyska6GVw3a6BcKr0KABuGDAA7rp6QA). The template's in the Examples menu.
+You can try ReasonReact, with live JS output, in the [Reason Try page](https://reasonml.github.io/en/try.html?rrjsx=true&reason=LYewJgrgNgpgBAcQE4xgFwJYDsDmcC8cA3gFBxyxpwDGIwADiFjFlYQEowCGAzk512poAdDzRc0MWDx4BhOo2asAFACJkqTLlUBKANxkK6OMC4BreIQD61ABYYoYFFgIA+YofLDvtBkxZoADSecM5gMEgAXHA8UgBmbiHkADwARhBoaEzuygJ8WAJComhI2DhqABJSUCAAhLo6cMkA9OmZ2cHkAL4GPSQkhWgAIgDyALKcwmERACogAKKwwAEA6hhotgCSYMrJGuhlcM2ugXCq9CgAbhgwAO66ekA). The template's in the Examples menu.


### PR DESCRIPTION
As `ReasonReact.stringToElement` is deprecated, we should update our examples to reflect the new API