### PR TITLE
Docs: Remove mention of "two solutions" for install

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,8 +4,6 @@ title: Installation
 
 **Note**: for general Reason + BuckleScript editor setup, see [here](https://reasonml.github.io/docs/en/global-installation.html).
 
-To easily try ReasonReact, we offer two solutions.
-
 ## Bsb
 
 ```sh


### PR DESCRIPTION
As of 8c6b77a0d379244d8d0631a7089d40d1be1f0b30, there's only one solution suggested by the docs