### PR TITLE
Removing deprecated reducerComponentWithRetainedProps

### DIFF
--- a/src/ReasonReact.re
+++ b/src/ReasonReact.re
@@ -639,17 +639,6 @@ let reducerComponent =
       ) =>
   basicComponent(debugName);
 
-let reducerComponentWithRetainedProps =
-    debugName
-    : componentSpec(
-        'state,
-        stateless,
-        'retainedProps,
-        noRetainedProps,
-        'action,
-      ) =>
-  basicComponent(debugName);
-
 /***
  * Convenience for creating React elements before we have a better JSX transform.  Hopefully this makes it
  * usable to build some components while waiting to migrate the JSX transform to the next API.

--- a/src/ReasonReact.rei
+++ b/src/ReasonReact.rei
@@ -177,10 +177,6 @@ let reducerComponent:
   string =>
   componentSpec('state, stateless, noRetainedProps, noRetainedProps, 'action);
 
-let reducerComponentWithRetainedProps:
-  string =>
-  componentSpec('state, stateless, 'retainedProps, noRetainedProps, 'action);
-
 let element:
   (
     ~key: string=?,


### PR DESCRIPTION
* Updated documentation and example component to reflect deprecation of the function.
* Removed `reducerComponentWithRetainedProps` from `ReasonReact.re` and `ReasonReact.rei`.