### PR TITLE
Introduce ReasonReact.Router.replace

### DIFF
--- a/lib/js/src/ReasonReact.js
+++ b/lib/js/src/ReasonReact.js
@@ -490,6 +490,18 @@ function push(path) {
   }
 }
 
+function replace(path) {
+  var match = typeof (history) === "undefined" ? undefined : (history);
+  var match$1 = typeof (window) === "undefined" ? undefined : (window);
+  if (match !== undefined && match$1 !== undefined) {
+    match.replaceState(null, "", path);
+    match$1.dispatchEvent(safeMakeEvent("popstate"));
+    return /* () */0;
+  } else {
+    return /* () */0;
+  }
+}
+
 function url() {
   return /* record */[
           /* path */path(/* () */0),
@@ -525,6 +537,7 @@ function unwatchUrl(watcherID) {
 
 var Router = [
   push,
+  replace,
   watchUrl,
   unwatchUrl,
   url

--- a/src/ReasonReact.re
+++ b/src/ReasonReact.re
@@ -756,6 +756,12 @@ module Router = {
     unit =
     "";
 
+  [@bs.send]
+  external replaceState :
+    (Dom.history, [@bs.as {json|null|json}] _, [@bs.as ""] _, ~href: string) =>
+    unit =
+    "";
+
   [@bs.val] external event : 'a = "Event";
 
   [@bs.new] external makeEventIE11Compatible : string => Dom.event = "Event";
@@ -843,6 +849,14 @@ module Router = {
     | (_, None) => ()
     | (Some((history: Dom.history)), Some((window: Dom.window))) =>
       pushState(history, ~href=path);
+      dispatchEvent(window, safeMakeEvent("popstate"));
+    };
+  let replace = path =>
+    switch ([%external history], [%external window]) {
+    | (None, _)
+    | (_, None) => ()
+    | (Some((history: Dom.history)), Some((window: Dom.window))) =>
+      replaceState(history, ~href=path);
       dispatchEvent(window, safeMakeEvent("popstate"));
     };
   type url = {

--- a/src/ReasonReact.rei
+++ b/src/ReasonReact.rei
@@ -229,6 +229,8 @@ let wrapJsForReason:
 module Router: {
   /** update the url with the string path. Example: `push("/book/1")`, `push("/books#title")` */
   let push: string => unit;
+  /** update the url with the string path. modifies the current history entry instead of creating a new one. Example: `replace("/book/1")`, `replace("/books#title")` */
+  let replace: string => unit;
   type watcherID;
   type url = {
     /* path takes window.location.path, like "/book/title/edit" and turns it into `["book", "title", "edit"]` */


### PR DESCRIPTION
Adds `replaceState` where there was only `pushState`. Fixes #278