### PR TITLE
set "min" property to "string"

### DIFF
--- a/src/ReactDOMRe.re
+++ b/src/ReactDOMRe.re
@@ -223,7 +223,7 @@ type props = {
   [@bs.optional] media: string, /* a valid media query */
   [@bs.optional] mediaGroup: string,
   [@bs.optional] method: string, /* "post" or "get" */
-  [@bs.optional] min: int,
+  [@bs.optional] min: string,
   [@bs.optional] minLength: int,
   [@bs.optional] multiple: bool,
   [@bs.optional] muted: bool,


### PR DESCRIPTION
Related to issue #137.

The `min` property is currently set to be an int - however `min` is used for a variety of input types (number, range, date, etc), and `int` is not always compatible.

This PR sets it to be `string` instead.