### PR TITLE
Clarify ageFromProps in Docs

### DIFF
--- a/docs/creation-props-self.md
+++ b/docs/creation-props-self.md
@@ -84,16 +84,11 @@ switch (ageFromProps) {
 Cumbersome. Fortunately, here's a better way to explicitly pass an optional value:
 
 ```reason
-<Foo name="Reason" age=?ageFromProps />
+<Foo name="Reason" age=?myOptionalAgeProp />
 ```
 
 It says "I understand that `age` is optional and that when I use the label I should pass an int. But I'd like to forward an `option` value explicitly". This isn't a JSX trick we've made up; it's just a language feature! See the section on "Explicitly Passed Optional" in the [Reason docs](https://reasonml.github.io/docs/en/function.html#explicitly-passed-optional).
 
-To clarify, `FromProps` **is not** the feature, its the `?` in front of it. `ageFromProps` can be `style` or `className`, etc:
-
-```reason
-<Foo name="Reason" style=?style />
-```
 
 ## `self`
 

--- a/docs/creation-props-self.md
+++ b/docs/creation-props-self.md
@@ -89,7 +89,6 @@ Cumbersome. Fortunately, here's a better way to explicitly pass an optional valu
 
 It says "I understand that `age` is optional and that when I use the label I should pass an int. But I'd like to forward an `option` value explicitly". This isn't a JSX trick we've made up; it's just a language feature! See the section on "Explicitly Passed Optional" in the [Reason docs](https://reasonml.github.io/docs/en/function.html#explicitly-passed-optional).
 
-
 ## `self`
 
 You might have seen the `render: (self) => ...` part in `make`. The concept of JavaScript `this` doesn't exist in ReasonReact (but can exist in Reason, since it has an optional object system); the `this` equivalent is called `self`. It's a record that contains `state`, `handle` and `send`, which we pass around to the lifecycle events, `render` and a few others, when they need the bag of information. These concepts will be explained later on.

--- a/docs/creation-props-self.md
+++ b/docs/creation-props-self.md
@@ -87,7 +87,11 @@ Cumbersome. Fortunately, here's a better way to explicitly pass an optional valu
 <Foo name="Reason" age=?ageFromProps />
 ```
 
-To clarify, `fromProps` **is not** the feature, its the `?` in front of it. `ageFromProps` can be `style` or `className`, etc.
+To clarify, `FromProps` **is not** the feature, its the `?` in front of it. `ageFromProps` can be `style` or `className`, etc:
+
+```reason
+<Foo name="Reason" style=?style />
+```
 
 It says "I understand that `age` is optional and that when I use the label I should pass an int. But I'd like to forward an `option` value explicitly". This isn't a JSX trick we've made up; it's just a language feature! See the section on "Explicitly Passed Optional" in the [Reason docs](https://reasonml.github.io/docs/en/function.html#explicitly-passed-optional).
 

--- a/docs/creation-props-self.md
+++ b/docs/creation-props-self.md
@@ -87,13 +87,13 @@ Cumbersome. Fortunately, here's a better way to explicitly pass an optional valu
 <Foo name="Reason" age=?ageFromProps />
 ```
 
+It says "I understand that `age` is optional and that when I use the label I should pass an int. But I'd like to forward an `option` value explicitly". This isn't a JSX trick we've made up; it's just a language feature! See the section on "Explicitly Passed Optional" in the [Reason docs](https://reasonml.github.io/docs/en/function.html#explicitly-passed-optional).
+
 To clarify, `FromProps` **is not** the feature, its the `?` in front of it. `ageFromProps` can be `style` or `className`, etc:
 
 ```reason
 <Foo name="Reason" style=?style />
 ```
-
-It says "I understand that `age` is optional and that when I use the label I should pass an int. But I'd like to forward an `option` value explicitly". This isn't a JSX trick we've made up; it's just a language feature! See the section on "Explicitly Passed Optional" in the [Reason docs](https://reasonml.github.io/docs/en/function.html#explicitly-passed-optional).
 
 ## `self`
 


### PR DESCRIPTION
:wave:

Ever since I started using Reason, I thought `FromProps` was the magic. Not the question mark 🙈

Hopefully this clarifies things for others, too.