### PR TITLE
crossorigin case and type incorrect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ finalOutput/*.js
 *.log
 .bsb.lock
 /src/*.js
+
+# Editor
+/.idea/

--- a/src/ReactDOMRe.re
+++ b/src/ReactDOMRe.re
@@ -184,7 +184,7 @@ type props = {
   [@bs.optional] charSet: string,
   [@bs.optional] checked: bool,
   [@bs.optional] cite: string, /* uri */
-  [@bs.optional] crossorigin: bool,
+  [@bs.optional] crossOrigin: string,  /* anonymous, use-credentials */
   [@bs.optional] cols: int,
   [@bs.optional] colSpan: int,
   [@bs.optional] content: string,


### PR DESCRIPTION
Currently crossorigin but should be crossOrigin to avoid 
> Warning: Invalid DOM property `crossorigin`. Did you mean `crossOrigin`?

Should be string to avoid:
> If you want to write it to the DOM, pass a string instead: crossOrigin="true" or crossOrigin={value.toString()}.