### PR TITLE
Add ReasonReact.Fragment to support keyed fragments

### DIFF
--- a/lib/js/src/ReasonReact.js
+++ b/lib/js/src/ReasonReact.js
@@ -401,6 +401,10 @@ function wrapJsForReason(reactClass, props, children) {
         ];
 }
 
+var make = React.Fragment;
+
+var Fragment = /* module */[/* make */make];
+
 function safeMakeEvent(eventName) {
   if (typeof Event === "function") {
     return new Event(eventName);
@@ -539,4 +543,5 @@ exports.wrapReasonForJs = wrapReasonForJs;
 exports.createDomElement = createDomElement;
 exports.wrapJsForReason = wrapJsForReason;
 exports.Router = Router;
+exports.Fragment = Fragment;
 /* dummyInteropComponent Not a pure module */

--- a/src/ReasonReact.re
+++ b/src/ReasonReact.re
@@ -729,7 +729,14 @@ module WrapProps = {
 
 let wrapJsForReason = WrapProps.wrapJsForReason;
 
+/* kept for compat as ReasonReact.fragment */
 [@bs.module "react"] external fragment : 'a = "Fragment";
+
+/* ReasonReact.Fragment allows keyed fragment */
+/* https://github.com/reasonml/reason-react/issues/293 */
+module Fragment = {
+  let make = fragment;
+}
 
 module Router = {
   [@bs.get] external location : Dom.window => Dom.location = "";

--- a/src/ReasonReact.rei
+++ b/src/ReasonReact.rei
@@ -256,4 +256,12 @@ module Router: {
   let dangerouslyGetInitialUrl: unit => url;
 };
 
+/* kept for compat as ReasonReact.fragment */
 [@bs.module "react"] external fragment: 'a = "Fragment";
+
+/* ReasonReact.Fragment allows keyed fragment */
+/* https://github.com/reasonml/reason-react/issues/293 */
+module Fragment: {
+  let make: reactClass;
+}
+


### PR DESCRIPTION
Backward compatible as I have untouched `ReasonReact.fragment`.
Or Should I?

Anyway, this PR add support for `<ReasonReact.Fragment key>`.

Closes #293 