### PR TITLE
Avoid test "exit 0" in package.json script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
-    "test": "exit 0"
+    "test": "yarn clean && yarn build"
   },
   "keywords": [
     "reasonml",


### PR DESCRIPTION
It's handy to have this (almost universal) shortcut to quickly check that everything is ok when you make a change in the repo. Don't you think?