### PR TITLE
Uncurry jsPropsToReason

### DIFF
--- a/lib/js/src/ReasonReact.js
+++ b/lib/js/src/ReasonReact.js
@@ -360,8 +360,9 @@ function element($staropt$star, $staropt$star$1, component) {
 }
 
 function wrapReasonForJs(component, jsPropsToReason) {
+  var uncurriedJsPropsToReason = Curry.__1(jsPropsToReason);
   var tmp = component[/* reactClassInternal */1].prototype;
-  tmp.jsPropsToReason = Js_primitive.some(jsPropsToReason);
+  tmp.jsPropsToReason = Js_primitive.some(uncurriedJsPropsToReason);
   return component[/* reactClassInternal */1];
 }
 

--- a/lib/js/src/ReasonReact.js
+++ b/lib/js/src/ReasonReact.js
@@ -2,6 +2,7 @@
 
 var Curry = require("bs-platform/lib/js/curry.js");
 var React = require("react");
+var Js_primitive = require("bs-platform/lib/js/js_primitive.js");
 var Caml_builtin_exceptions = require("bs-platform/lib/js/caml_builtin_exceptions.js");
 var ReasonReactOptimizedCreateClass = require("./ReasonReactOptimizedCreateClass.js");
 
@@ -41,7 +42,7 @@ function convertPropsIfTheyreFromJs(props, jsPropsToReason, debugName) {
   var match = props.reasonProps;
   if (match == null) {
     if (jsPropsToReason !== undefined) {
-      return /* Element */[Curry._1(jsPropsToReason, props)];
+      return /* Element */[Js_primitive.valFromOption(jsPropsToReason)(props)];
     } else {
       throw [
             Caml_builtin_exceptions.invalid_argument,
@@ -360,7 +361,7 @@ function element($staropt$star, $staropt$star$1, component) {
 
 function wrapReasonForJs(component, jsPropsToReason) {
   var tmp = component[/* reactClassInternal */1].prototype;
-  tmp.jsPropsToReason = jsPropsToReason;
+  tmp.jsPropsToReason = Js_primitive.some(jsPropsToReason);
   return component[/* reactClassInternal */1];
 }
 

--- a/src/ReasonReact.re
+++ b/src/ReasonReact.re
@@ -55,6 +55,8 @@ type actionless = unit;
 type element =
   | Element(component('state, 'retainedProps, 'action)): element
 and jsPropsToReason('jsProps, 'state, 'retainedProps, 'action) =
+  'jsProps => component('state, 'retainedProps, 'action)
+and uncurriedJsPropsToReason('jsProps, 'state, 'retainedProps, 'action) =
   (. 'jsProps) => component('state, 'retainedProps, 'action)
 /***
  * Type of hidden field for Reason components that use JS components
@@ -134,7 +136,7 @@ type jsComponentThis('state, 'props, 'retainedProps, 'action) = {
       unit
     ),
   "jsPropsToReason":
-    option(jsPropsToReason('props, 'state, 'retainedProps, 'action)),
+    option(uncurriedJsPropsToReason('props, 'state, 'retainedProps, 'action)),
 }
 /***
  * `totalState` tracks all of the internal reason API bookkeeping.
@@ -687,9 +689,11 @@ let wrapReasonForJs =
   let jsPropsToReason:
     jsPropsToReason(jsProps, 'state, 'retainedProps, 'action) =
     Obj.magic(jsPropsToReason) /* cast 'jsProps to jsProps */;
+  let uncurriedJsPropsToReason: uncurriedJsPropsToReason(jsProps, 'state, 'retainedProps, 'action) =
+    (. jsProps) => jsPropsToReason(jsProps);
   Obj.magic(component.reactClassInternal)##prototype##jsPropsToReason#=(
                                                                     Some(
-                                                                    jsPropsToReason,
+                                                                    uncurriedJsPropsToReason,
                                                                     )
                                                                     );
   component.reactClassInternal;

--- a/src/ReasonReact.re
+++ b/src/ReasonReact.re
@@ -55,7 +55,7 @@ type actionless = unit;
 type element =
   | Element(component('state, 'retainedProps, 'action)): element
 and jsPropsToReason('jsProps, 'state, 'retainedProps, 'action) =
-  'jsProps => component('state, 'retainedProps, 'action)
+  (. 'jsProps) => component('state, 'retainedProps, 'action)
 /***
  * Type of hidden field for Reason components that use JS components
  */
@@ -167,8 +167,7 @@ let convertPropsIfTheyreFromJs = (props, jsPropsToReason, debugName) => {
   let props = Obj.magic(props);
   switch (Js.Nullable.toOption(props##reasonProps), jsPropsToReason) {
   | (Some(props), _) => props
-  /* TODO: annotate with BS to avoid curry overhead */
-  | (None, Some(toReasonProps)) => Element(toReasonProps(props))
+  | (None, Some(toReasonProps)) => Element(toReasonProps(. props))
   | (None, None) =>
     raise(
       Invalid_argument(

--- a/src/ReasonReact.rei
+++ b/src/ReasonReact.rei
@@ -190,7 +190,7 @@ let element:
   reactElement;
 
 type jsPropsToReason('jsProps, 'state, 'retainedProps, 'action) =
-  'jsProps => component('state, 'retainedProps, 'action);
+  (. 'jsProps) => component('state, 'retainedProps, 'action);
 
 
 /***

--- a/src/ReasonReact.rei
+++ b/src/ReasonReact.rei
@@ -192,9 +192,6 @@ let element:
 type jsPropsToReason('jsProps, 'state, 'retainedProps, 'action) =
   'jsProps => component('state, 'retainedProps, 'action);
 
-type uncurriedJsPropsToReason('jsProps, 'state, 'retainedProps, 'action) =
-  (. 'jsProps) => component('state, 'retainedProps, 'action);
-
 
 /***
  * We *under* constrain the kind of component spec this accepts because we actually extend the *originally*

--- a/src/ReasonReact.rei
+++ b/src/ReasonReact.rei
@@ -190,6 +190,9 @@ let element:
   reactElement;
 
 type jsPropsToReason('jsProps, 'state, 'retainedProps, 'action) =
+  'jsProps => component('state, 'retainedProps, 'action);
+
+type uncurriedJsPropsToReason('jsProps, 'state, 'retainedProps, 'action) =
   (. 'jsProps) => component('state, 'retainedProps, 'action);
 
 


### PR DESCRIPTION
- avoid curry overhead when calling jsPropsToReason
- fixes issue with react-hot-loader