### PR TITLE
Specify which index.html to open

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,4 +16,4 @@ npm run webpack
 
 BuckleScript's [bsb](https://bucklescript.github.io/docs/en/build-overview.html) build system has an `init` command that generates a project template. The `react` theme offers a lightweight solution optimized for low learning overhead and ease of integration into an existing project.
 
-It compiles to straightforward JS files, so you can open `index.html` directly from the file system. No server needed.
+It compiles to straightforward JS files, so you can open `build/index.html` directly from the file system. No server needed.


### PR DESCRIPTION
In the Installation page, it says that that you can open `index.html`, but doesn't specify where this is. People not familiar with React/webpack might think that this is referencing `src/index.html`, which is a small but confusing deterrent from getting a new project in a new technology started.