### PR TITLE
Update state-actions-reducer.md. Example now works

### DIFF
--- a/docs/state-actions-reducer.md
+++ b/docs/state-actions-reducer.md
@@ -53,7 +53,7 @@ let make = (~greeting, _children) => {
       </button>
       (
         self.state.show
-          ? ReasonReact.string(greeting)
+          ? ReasonReact.string(message)
           : ReasonReact.null
       )
     </div>;


### PR DESCRIPTION
Fixed State, Actions & Reducer code example. `ReasonReact.string(greetings)` should be `ReasonReact.string(message)`.