### PR TITLE
Clarify initial app entry point in docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,4 +16,4 @@ npm run webpack
 
 BuckleScript's [bsb](https://bucklescript.github.io/docs/en/build-overview.html) build system has an `init` command that generates a project template. The `react` theme offers a lightweight solution optimized for low learning overhead and ease of integration into an existing project.
 
-It compiles to straightforward JS files, so you can open `index.html` directly from the file system. No server needed.
+It compiles to straightforward JS files, so you can open `build/index.html` directly from the file system. No server needed.

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -66,7 +66,7 @@ ${pre}bash
 npm run webpack
 ${pre}
 
-Your apps are the html files inside ${code}src/${code}`;
+Your apps are the html files inside ${code}build/${code}`;
 
 class HomeSplash extends React.Component {
   render() {


### PR DESCRIPTION
This may not be the exact intention of the wording, depending on whether it was specific to the output of bsb, or was indeed about the app's entry point. 

However the combination of reading the homepage stating `src/` and the installation page stating `index.html` lead me to think the index.html was directly openable from `src/`, when it's really `build/`.

I don't mind if this gets addressed in #305. 