### PR TITLE
Add React.string and React.array.

### DIFF
--- a/src/React.re
+++ b/src/React.re
@@ -1,5 +1,9 @@
 type element;
 
+external string: string => element = "%identity";
+
+external array: array(element) => element = "%identity";
+
 type component('props) = 'props => element;
 
 [@bs.module "react"]


### PR DESCRIPTION
@rickyvetter as discussed on Discord: People using the new hooks API exclusively should not need to depend on the ReasonReact module just for `ReasonReact.string` and `ReasonReact.array`.

So we should provide `React.string` and `React.array`.