### PR TITLE
Add React.Context.Provider.

### DIFF
--- a/lib/js/src/React.js
+++ b/lib/js/src/React.js
@@ -3,5 +3,13 @@
 
 var Ref = /* module */[];
 
+function Provider(C) {
+  var make = C[/* context */0].Provider;
+  return /* module */[/* make */make];
+}
+
+var Context = /* module */[/* Provider */Provider];
+
 exports.Ref = Ref;
+exports.Context = Context;
 /* No side effect */

--- a/src/React.re
+++ b/src/React.re
@@ -29,6 +29,27 @@ type context('a);
 
 [@bs.module "react"] external createContext: 'a => context('a) = "";
 
+module Context = {
+  module Provider = (C: {
+                       type t;
+                       let context: context(t);
+                     }) => {
+    type props = {
+      .
+      "value": C.t,
+      "children": element,
+    };
+
+    [@bs.get]
+    external provider: context(C.t) => component(props) = "Provider";
+
+    [@bs.obj]
+    external makeProps: (~value: C.t, ~children: element, unit) => props = "";
+
+    let make: props => element = C.context->provider;
+  };
+};
+
 [@bs.module "react"]
 [@deprecated
   "Please use the `[@react.component {forwardRef: ref}]` api. Calling forwardRef by itself can lead to confusing compile and runtime errors."


### PR DESCRIPTION
@rickyvetter Here is a Context.Provider binding as discussed on Discord.

Should we also change

* `React.context` -> `React.Context.t`
* `React.createContext` -> `React.Context.make`

?