### PR TITLE
Fix errors in the example of instance variables documentation

### DIFF
--- a/docs/instance-variables.md
+++ b/docs/instance-variables.md
@@ -31,8 +31,6 @@ let make = (_children) => {
   didMount: ({state}) => {
     /* mutate the value here */
     state.intervalId := Some(Js.Global.setInterval(/* ... */));
-    /* no extra state update needed */
-    ReasonReact.NoUpdate
   },
   render: /* ... */
 };

--- a/docs/instance-variables.md
+++ b/docs/instance-variables.md
@@ -17,7 +17,7 @@ In reality, this is nothing but a thinly veiled way to mutate a component's "sta
 ```reason
 type state = {
   someRandomState: option(string),
-  intervalId: ref(option(int))
+  intervalId: ref(option(Js.Global.intervalId))
 };
 
 let component = /* ... */; /* remember, `component` needs to be close to `make`, and after `state` type declaration! */


### PR DESCRIPTION
This PR resolves #310, which points out two errors in the [example of instance variables](https://reasonml.github.io/reason-react/docs/en/instance-variables).

If the example looses meaning now when `ReasonReact.NoUpdate` is removed, then it should be expanded with a `reducer:`-section.

Look at [the _try_ example](https://reasonml.github.io/try.html?rrjsx=true&reason=NoAQRgzgdAdgpgdwLoAI4A8AucBOMCGANigMY5z7YAilcKAXCgK4wCWmKAvAHwoBS0GtigdOKAERC44gNwAoOZgCeABzoRMtLigDeclAZSZWAWzqMNOVjADmAGn2HjZnAEkAJo3IAzABQB7FWN-GF8BKABxQn8wIihrbBwANyIPAEo0h0MUAHoAKiNTXA8vOD9A4NCEjLsUPJy5AF8FZTUUfBJK7QBVFXdaeTlCOA4SfxMVELgYURQAJQoIEIWOzChydyYSXABhccn4Gd9xHeiSAGtxNMHhjhN8c7oxXwB9EgALVkJ3chg0rl4emyUBBYwmUxmDkcBms7FYRAAyppsIxfP8eLpodlCmZGOJxFlsQZnMVPCgfL4AHJTTJYxpQ7IbLa4VGrVghWoaWjo3hY7IQBDsD6+Nkhf5AokoAA+KF6-WwAPmi2WFE6UDltF8OhBUC52FqJMY4SkIn8ABl-CQiHAACpFJFWWy+MgUaiajKNNJ8wz0hTZdysdwAWX8LEwqIgcEI3h5mMlKEj0d1yLgIiKbncDDECPGcDC0CiMTikcwrhmuBShF8aMVEvjBkT3l103cvg12Gu3oM9JQAEYAAyDjLyeP5FAwfxoLA4fAJlPMPpaeBwdwruo5ACQXdyBRWSxgKzV1PbdHqdIZhkFhEI3RgJlDMwjUZjiu3AqF718jeTtDTLg8AB64rbjKOZmL4gaxuEhaxIQUAkMM+BuOWyREBB7idvGMrUvAirhNENjHAAojgOD+DgpCIY6NgoAkFZEFcI6Sr6WK-KuOAWM+r7xgAPAGSTcNu2Q8e8vbcDoe4qqsybUccdouFcjQ8TkomCfWhh8awAkScqB6qmsljWIR356qmJJpEpOT8WpkrKdZTRAA) (code by @sainthkh) to test the two things edited by this commit.

Creds to @sainthkh for pointing out these mistakes