### PR TITLE
 ReasonReactRouter: workaround for bucklescript#3362; check if url has changed

### DIFF
--- a/lib/js/src/ReasonReactRouter.js
+++ b/lib/js/src/ReasonReactRouter.js
@@ -139,7 +139,7 @@ function unwatchUrl(watcherID) {
 
 function useUrl() {
   var match = React.useState((function () {
-          return Curry._1(url(/* () */0), /* () */0);
+          return url(/* () */0);
         }));
   var setUrl = match[1];
   React.useEffect((function () {

--- a/lib/js/src/ReasonReactRouter.js
+++ b/lib/js/src/ReasonReactRouter.js
@@ -142,20 +142,24 @@ function useUrl() {
           return url(/* () */0);
         }));
   var setUrl = match[1];
+  var url$1 = match[0];
   React.useEffect((function () {
           var watcherId = watchUrl((function (url) {
                   return Curry._1(setUrl, (function () {
                                 return url;
                               }));
                 }));
-          Curry._1(setUrl, (function () {
-                  return url(/* () */0);
-                }));
+          var newUrl = url(/* () */0);
+          if (newUrl !== url$1) {
+            Curry._1(setUrl, (function () {
+                    return newUrl;
+                  }));
+          }
           return (function () {
                     return unwatchUrl(watcherId);
                   });
         }), ([]));
-  return match[0];
+  return url$1;
 }
 
 var dangerouslyGetInitialUrl = url;

--- a/src/ReasonReactRouter.re
+++ b/src/ReasonReactRouter.re
@@ -149,7 +149,7 @@ let unwatchUrl = watcherID =>
   };
 
 let useUrl = () => {
-  let (url, setUrl) = React.useState(dangerouslyGetInitialUrl);
+  let (url, setUrl) = React.useState(() => dangerouslyGetInitialUrl());
 
   React.useEffect0(() => {
     let watcherId = watchUrl(url => setUrl(_ => url));

--- a/src/ReasonReactRouter.re
+++ b/src/ReasonReactRouter.re
@@ -153,11 +153,16 @@ let useUrl = () => {
 
   React.useEffect0(() => {
     let watcherId = watchUrl(url => setUrl(_ => url));
+
     /**
       * check for updates that may have occured between
       * the initial state and the subscribe above
       */
-    setUrl(_ => dangerouslyGetInitialUrl());
+    let newUrl = dangerouslyGetInitialUrl();
+    if (newUrl !== url) {
+      setUrl(_ => newUrl);
+    };
+
     Some(() => unwatchUrl(watcherId));
   });
 


### PR DESCRIPTION
@rickyvetter As discussed on Discord, `useUrl` currently crashes because of https://github.com/BuckleScript/bucklescript/issues/3362. This PR fixes that.

Additionally, I added a check in useEffect to see whether the url has actually changed before calling setState.