### PR TITLE
Attempt an extremely hacky solution for setting a default component instead of using "make"

### DIFF
--- a/jsx_ppx/test.re
+++ b/jsx_ppx/test.re
@@ -26,7 +26,28 @@ module Bar = {
         Js.log("This function should be named `Test$Bar$component`");
         <div />
     };
-}
+
+    module Baz = {
+        [@react.component default]
+        let something = (~a, ~b, _) => {
+            Js.log("This function should be named `Test$Bar$Baz`");
+            <div />
+        };
+
+        module Buzz = {
+            [@react.component default]
+            let something = (~a, ~b, _) => {
+                Js.log("This function should be named `Test$Bar$Baz`");
+                <div />
+            };
+        }
+    };
+};
+
+<Bar a=1 b="1" />;
+<Bar.component a=1 b="1" />;
+<Bar.Baz a=1 b="1" />;
+<Bar.Baz.Buzz a=1 b="1" />;
 
 module type X_int = {
     let x: int;


### PR DESCRIPTION
I had some time today so I wanted to see if I could expand on [my comment](https://github.com/reasonml/reason-react/pull/351#issuecomment-473060066) about flagging a function as the "default" so the `make` name could be available for other things within a module.

I have no delusions that this code will land, but I thought it would be a good thought exercise to see if we could alter the PPX in some way support this feature.

It took me **waaaaay** too long to understand the the `[@react.component]` attribute and the JSX transform were being handled completely independently.  Once that clicked, I figured we'd need some sort of PPX-global state that would store the re-mapped default identifiers. 

Based on the tests I added, this seems to be working but I have no idea what it would do to performance or if this is a massive anti-pattern for PPXs.

cc @rickyvetter 