### PR TITLE
compare url by value instead of reference since url creates a new record on each invocation

### DIFF
--- a/src/ReasonReactRouter.re
+++ b/src/ReasonReactRouter.re
@@ -168,7 +168,7 @@ let useUrl = (~serverUrl=?, ()) => {
       * the initial state and the subscribe above
       */
     let newUrl = dangerouslyGetInitialUrl();
-    if (newUrl !== url) {
+    if (newUrl != url) {
       setUrl(_ => newUrl);
     };
 


### PR DESCRIPTION
This change prevents the useUrl hook to trigger two renders.