### PR TITLE
Add createRef

### DIFF
--- a/src/React.re
+++ b/src/React.re
@@ -25,6 +25,8 @@ module Ref = {
   [@bs.set] external setCurrent: (t('value), 'value) => unit = "current";
 };
 
+[@bs.module "react"] external createRef: unit => Ref.t('a) = "";
+
 module Context = {
   type t('props);
 

--- a/src/React.re
+++ b/src/React.re
@@ -25,7 +25,7 @@ module Ref = {
   [@bs.set] external setCurrent: (t('value), 'value) => unit = "current";
 };
 
-[@bs.module "react"] external createRef: unit => Ref.t('a) = "";
+[@bs.module "react"] external createRef: unit => Ref.t(Js.nullable('a)) = "";
 
 module Context = {
   type t('props);


### PR DESCRIPTION
Can be useful when dealing with the old API. 

e.g.

```reason
type state = {
  containerRef: ReactDOMRe.Ref.currentDomRef
};

let state = {
  containerRef: React.createRef()
};

<div ref={state.containerRef->ReactDOMRe.Ref.domRef} />
```