### PR TITLE
Make props-spread docs friendlier

### DIFF
--- a/docs/props-spread.md
+++ b/docs/props-spread.md
@@ -2,4 +2,10 @@
 title: Props Spread
 ---
 
-You can't. Props spreading is a big source of unpredictability and performance regression (think `shouldComponentUpdate`). Our API prevents this. If you reaaaaally need it for binding to existing ReactJS components, see [this section](clone-element.md).
+There is currently no story around doing this in a type-safe manner.
+
+In some cases, props spreading can a big source of unpredictability and performance regression (think `shouldComponentUpdate`).
+
+You can try either passing props down manually, or restructuring your components in a way that avoids the need for this.
+
+If you need it for binding to existing ReactJS components, see [this section](clone-element.md).


### PR DESCRIPTION
I think there are some legitimate use-cases for spread props, so I wanted to rephrase the issue in a more positive way.

I'm also not sure the link is still relevant with the new API. But I wasn't sure, so kept it in anyway