### PR TITLE
add React.float and React.int

### DIFF
--- a/src/React.re
+++ b/src/React.re
@@ -2,6 +2,8 @@ type element;
 
 [@bs.val] external null: element = "null";
 
+external float: float => element = "%identity";
+external int: int => element = "%identity";
 external string: string => element = "%identity";
 
 external array: array(element) => element = "%identity";


### PR DESCRIPTION
Plain JS numbers are valid React elements. Without these two functions you have to use either string_of_* or Js.*.toString which generates unnecessary code.