### PR TITLE
Add more useState flavours

### DIFF
--- a/src/React.re
+++ b/src/React.re
@@ -123,6 +123,11 @@ module Suspense = {
 external useState:
   ([@bs.uncurry] (unit => 'state)) => ('state, ('state => 'state) => unit) =
   "";
+[@bs.module "react"]
+external useStateValue: 'state => ('state, 'state => unit) = "useState";
+[@bs.module "react"]
+external useStatePrevious: 'state => ('state, ('state => 'state) => unit) =
+  "useState";
 
 [@bs.module "react"]
 external useReducer:


### PR DESCRIPTION
This is mostly a discussion / question PR, related to #402.

Something like `useStateValue` below is really useful when one starts prototyping a component, and it feels like ReasonReact should provide an out-of-the-box solution for it.

Maybe there is some typing edge case that I'm missing? I read [this comment](https://github.com/jchavarri/reason-react/blob/6ecf6ee6fdb4412114de9eacba1b3adc517eb387/src/React.re#L116-L121) but I can't figure out in which cases this would not be safe.