### PR TITLE
add unsafeAddStyle, define combine with external binding

### DIFF
--- a/src/ReactDOMRe.re
+++ b/src/ReactDOMRe.re
@@ -2562,12 +2562,10 @@ module Style = {
     style =
     "";
   /* CSS2Properties: https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSS2Properties */
-  let combine: (style, style) => style =
-    (a, b) => {
-      let a: Js.t({..}) = Obj.magic(a);
-      let b: Js.t({..}) = Obj.magic(b);
-      Js.Obj.assign(Js.Obj.assign(Js.Obj.empty(), a), b) |> Obj.magic;
-    };
+  [@bs.val]
+  external combine: ([@bs.as {json|{}|json}] _, style, style) => style =
+    "Object.assign";
+
   let unsafeAddProp: (style, string, string) => style =
     (style, property, value) => {
       let propStyle: style = {
@@ -2577,4 +2575,9 @@ module Style = {
       };
       combine(style, propStyle);
     };
+
+  [@bs.val]
+  external unsafeAddStyle:
+    ([@bs.as {json|{}|json}] _, style, Js.t({..})) => style =
+    "Object.assign";
 };


### PR DESCRIPTION
After a lengthy discussion with @MoOx and @cknitt, we added functions to [bs-react-native](https://github.com/reasonml-community/bs-react-native/commit/69519b2df039784a78bbfa909633c686a928acc7) to handle style props not already included in the binding. I wanted to contribute our result here.

This alternative definition of `combine` is zero-cost. I figured `unsafeAddStyle` would also be useful here, as it allows adding multiple keys at the same time, as below:

```reason
unsafeAddStyle(someStyle, {"key1": value1 , "key2": value2})
```
