### PR TITLE
Clarifies useEffect API Documentation.

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -69,7 +69,23 @@ The component above could be called like this:
 
 The next thing you might notice looking at this example is the use of hooks (`useState`). ReasonReact binds to [all of the hooks that React provides](https://reactjs.org/docs/hooks-intro.html) with only minor API differences. Please refer to their excellent documentation for more information on how hooks work and for best practices.
 
-The differences that you'll notice are mostly around listing dependencies. In React they are managed by using a tuple of varying length as the final argument to the hook. Reason instead asks you to also list the number of elements you care about. So `useEffect(effect, [dep1, dep2])` becomes `useEffect2(effect, (dep1, dep2))`. Reason also always opts for the safest form of a given hook as well. So `React.useState` in JS can take an initial value or a function that returns an initial value. The former cannot be used safely in all situations, so ReasonReact only supports the second form which takes a function and uses the return.
+The differences that you'll notice are mostly around listing dependencies. In React they are managed by using a tuple of varying length as the final argument to the hook. Reason asks that, in addition, you call `useEffectN` where `N` is the length of your dependencies array. So, for example, the two javascript calls:
+
+```js
+useEffect(effect, [dep1, dep2]) 
+useEffect(effect, []) 
+```
+
+would translate to these two reason calls:
+
+```reason
+useEffect2(effect, (dep1, dep2))
+     /* ^^^ -- Note the number matching the depenedencies' length */
+useEffect0(effect)
+     /* ^^^ --- Compiles to javascript as `useEffect(effect, [])` */
+```   
+
+Reason also always opts for the safest form of a given hook as well. So `React.useState` in JS can take an initial value or a function that returns an initial value. The former cannot be used safely in all situations, so ReasonReact only supports the second form which takes a function and uses the return.
 
 ## Hand-writing components
 


### PR DESCRIPTION
I really only understood this by referencing the react-reason code itself.  I understood that `2` to mean "this is the second version of the thing we're talking about" not "call this specially named function"  (obvious in retrospect, but....).

It still took me a while to realize that I was expected to return a cleanup function from useEffect even if I didn't need to do cleanup (something I'm not used to having to do).  But I guess that begs the question how detailed ya'll want your docs to be here.