### PR TITLE
ReasonReactRouter: expose function to create url type from strings

### DIFF
--- a/lib/js/src/ReasonReactRouter.js
+++ b/lib/js/src/ReasonReactRouter.js
@@ -14,68 +14,77 @@ function safeMakeEvent(eventName) {
   }
 }
 
-function path(param) {
+function pathFromString(pathname) {
+  switch (pathname) {
+    case "" : 
+    case "/" : 
+        return /* [] */0;
+    default:
+      var raw = pathname.slice(1);
+      var match = raw[raw.length - 1 | 0];
+      var raw$1 = match === "/" ? raw.slice(0, -1) : raw;
+      var a = raw$1.split("/");
+      var _i = a.length - 1 | 0;
+      var _res = /* [] */0;
+      while(true) {
+        var res = _res;
+        var i = _i;
+        if (i < 0) {
+          return res;
+        } else {
+          _res = /* :: */[
+            a[i],
+            res
+          ];
+          _i = i - 1 | 0;
+          continue ;
+        }
+      };
+  }
+}
+
+function pathFromWindow(param) {
   var match = typeof window === "undefined" ? undefined : window;
   if (match !== undefined) {
-    var raw = match.location.pathname;
-    switch (raw) {
-      case "" : 
-      case "/" : 
-          return /* [] */0;
-      default:
-        var raw$1 = raw.slice(1);
-        var match$1 = raw$1[raw$1.length - 1 | 0];
-        var raw$2 = match$1 === "/" ? raw$1.slice(0, -1) : raw$1;
-        var a = raw$2.split("/");
-        var _i = a.length - 1 | 0;
-        var _res = /* [] */0;
-        while(true) {
-          var res = _res;
-          var i = _i;
-          if (i < 0) {
-            return res;
-          } else {
-            _res = /* :: */[
-              a[i],
-              res
-            ];
-            _i = i - 1 | 0;
-            continue ;
-          }
-        };
-    }
+    return pathFromString(match.location.pathname);
   } else {
     return /* [] */0;
   }
 }
 
-function hash(param) {
+function hashFromString(hash) {
+  switch (hash) {
+    case "" : 
+    case "#" : 
+        return "";
+    default:
+      return hash.slice(1);
+  }
+}
+
+function hashFromWindow(param) {
   var match = typeof window === "undefined" ? undefined : window;
   if (match !== undefined) {
-    var raw = match.location.hash;
-    switch (raw) {
-      case "" : 
-      case "#" : 
-          return "";
-      default:
-        return raw.slice(1);
-    }
+    return hashFromString(match.location.hash);
   } else {
     return "";
   }
 }
 
-function search(param) {
+function searchFromString(search) {
+  switch (search) {
+    case "" : 
+    case "?" : 
+        return "";
+    default:
+      return search.slice(1);
+  }
+}
+
+function searchFromWindow(param) {
   var match = typeof window === "undefined" ? undefined : window;
   if (match !== undefined) {
-    var raw = match.location.search;
-    switch (raw) {
-      case "" : 
-      case "?" : 
-          return "";
-      default:
-        return raw.slice(1);
-    }
+    return searchFromString(match.location.search);
   } else {
     return "";
   }
@@ -105,11 +114,19 @@ function replace(path) {
   }
 }
 
-function url(param) {
+function urlFromWindow(param) {
   return /* record */[
-          /* path */path(/* () */0),
-          /* hash */hash(/* () */0),
-          /* search */search(/* () */0)
+          /* path */pathFromWindow(/* () */0),
+          /* hash */hashFromWindow(/* () */0),
+          /* search */searchFromWindow(/* () */0)
+        ];
+}
+
+function url(pathname, search, hash, param) {
+  return /* record */[
+          /* path */pathFromString(pathname !== undefined ? pathname : "/"),
+          /* hash */hashFromString(hash !== undefined ? hash : ""),
+          /* search */searchFromString(search !== undefined ? search : "")
         ];
 }
 
@@ -117,7 +134,7 @@ function watchUrl(callback) {
   var match = typeof window === "undefined" ? undefined : window;
   if (match !== undefined) {
     var watcherID = function (param) {
-      return Curry._1(callback, url(/* () */0));
+      return Curry._1(callback, urlFromWindow(/* () */0));
     };
     match.addEventListener("popstate", watcherID);
     return watcherID;
@@ -143,19 +160,19 @@ function useUrl(serverUrl, param) {
           if (serverUrl !== undefined) {
             return serverUrl;
           } else {
-            return url(/* () */0);
+            return urlFromWindow(/* () */0);
           }
         }));
   var setUrl = match[1];
-  var url$1 = match[0];
+  var url = match[0];
   React.useEffect((function () {
           var watcherId = watchUrl((function (url) {
                   return Curry._1(setUrl, (function (param) {
                                 return url;
                               }));
                 }));
-          var newUrl = url(/* () */0);
-          if (Caml_obj.caml_notequal(newUrl, url$1)) {
+          var newUrl = urlFromWindow(/* () */0);
+          if (Caml_obj.caml_notequal(newUrl, url)) {
             Curry._1(setUrl, (function (param) {
                     return newUrl;
                   }));
@@ -164,15 +181,18 @@ function useUrl(serverUrl, param) {
                     return unwatchUrl(watcherId);
                   });
         }), ([]));
-  return url$1;
+  return url;
 }
 
-var dangerouslyGetInitialUrl = url;
+var dangerouslyGetInitialUrl = urlFromWindow;
+
+var getUrl = url;
 
 exports.push = push;
 exports.replace = replace;
 exports.watchUrl = watchUrl;
 exports.unwatchUrl = unwatchUrl;
 exports.dangerouslyGetInitialUrl = dangerouslyGetInitialUrl;
+exports.getUrl = getUrl;
 exports.useUrl = useUrl;
 /* react Not a pure module */

--- a/src/ReasonReactRouter.rei
+++ b/src/ReasonReactRouter.rei
@@ -27,6 +27,9 @@ let unwatchUrl: watcherID => unit;
       for an example.
       */
 let dangerouslyGetInitialUrl: unit => url;
+/** expose url creation functions, usefull for SSR, create an url type from strings to give to serverUrl */
+let getUrl:
+  (~pathname: string=?, ~search: string=?, ~hash: string=?, unit) => url;
 /** hook for watching url changes.
  * serverUrl is used for ssr. it allows you to specify the url without relying on browser apis existing/working as expected
  */


### PR DESCRIPTION
Useful for SSR.

`useUrl` take a `serverUrl` param which is an `url` type. Many SSR examples copy paste functions from ReasonReactRouter because `url` creation logics aren't exposed: [example with razzle](https://github.com/jaredpalmer/razzle/blob/eac1bd787dea392ff29a4f88dba5253e90a5f590/examples/with-reason-react/src/Router.re#L6)