### PR TITLE
Update jsx.md

### DIFF
--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -100,7 +100,7 @@ React.createElement(MyReasonComponent.make, {});
 
 The `make` above is exactly the same `make` function you've seen in the previous section.
 
-**Note how `ref` and `key` have been lifted out of the JSX call into the `ReasonReact.element` call**. `ref` and `key` are reserved in ReasonReact, just like in ReactJS. **Don't** use them as props in your component!
+`ref` and `key` are reserved in ReasonReact, just like in ReactJS. **Don't** use them as props in your component!
 
 ## Fragment
 


### PR DESCRIPTION
I think the sentence 
**"Note how ref and key have been lifted out of the JSX call into the ReasonReact.element call"** 
was copied from the jsx2 version, but it doesn't make sense here.

relevant section in the jsx2 version:
```
ReasonReact.element(
  ~key=a,
  ~ref=b,
  MyReasonComponent.make(~foo=bar, ~baz=qux, [|child1, child2|])
);
```

compilation of jsx3 version:
```
React.createElement(
  MyReasonComponent.make,
  {
    key: a,
    ref: b,
    foo: bar,
    baz: qux,
    children: null,
  },
  child1,
  child2,
);
```