### PR TITLE
Improve useEffect documentation

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -69,21 +69,31 @@ The component above could be called like this:
 
 The next thing you might notice looking at this example is the use of hooks (`useState`). ReasonReact binds to [all of the hooks that React provides](https://reactjs.org/docs/hooks-intro.html) with only minor API differences. Please refer to their excellent documentation for more information on how hooks work and for best practices.
 
-The differences that you'll notice are mostly around listing dependencies. In React they are managed by using a tuple of varying length as the final argument to the hook. Reason asks that, in addition, you call `useEffectN` where `N` is the length of your dependencies array. So, for example, the two javascript calls:
+The differences that you'll notice are mostly around listing dependencies. In React they are passed as an array, however, as Reason does not allow elements of different types in an array, a tuple of varying length is needed as final argument to the hook. For a tuple of length `N` you would need to call `useEffectN`, as otherwise the argument would not type match given the function's type signature which would in turn require a tuple of length `N`.
+
+Accordingly, for example, the two javascript calls:
 
 ```js
 useEffect(effect, [dep1, dep2]) 
 useEffect(effect, []) 
 ```
 
-would translate to these two reason calls:
+would be expressed as the following two reason calls:
 
 ```reason
 useEffect2(effect, (dep1, dep2))
      /* ^^^ -- Note the number matching the dependencies' length */
 useEffect0(effect)
      /* ^^^ --- Compiles to javascript as `useEffect(effect, [])` */
-```   
+```
+
+A notable exception is that when there is only one dependency, the relevant `useEffect1` call takes an array as the final argument to the hook. While tuples are compiled into JS arrays, the singleton would not be. Therefore, it is necessary to explicitly pass the dependency wrapped in an array.
+
+```reason
+useEffect1(effect, [|dep|])
+```
+
+However, as the length of the array is not specified, you could pass an array of arbitrary length, including the empty array, `[||]`.
 
 Reason also always opts for the safest form of a given hook as well. So `React.useState` in JS can take an initial value or a function that returns an initial value. The former cannot be used safely in all situations, so ReasonReact only supports the second form which takes a function and uses the return.
 


### PR DESCRIPTION
`useEffect1` has not been described in the documentation and while adding that I added some of the reasoning behind the irregularity between the arguments for `useEffectN` where `N=1` .