### PR TITLE
Align forwardRef type signature with other Ref functions

### DIFF
--- a/src/React.re
+++ b/src/React.re
@@ -61,7 +61,7 @@ module Context = {
 
 [@bs.module "react"]
 external forwardRef:
-  ([@bs.uncurry] (('props, Js.Nullable.t(Ref.t('a))) => element)) =>
+  ([@bs.uncurry] (('props, Ref.t(Js.Nullable.t('a))) => element)) =>
   component('props) =
   "forwardRef";
 
@@ -311,7 +311,7 @@ external useCallback7:
 [@bs.module "react"]
 external useImperativeHandle0:
   (
-    Js.Nullable.t(Ref.t('value)),
+    Ref.t(Js.Nullable.t('value)),
     [@bs.uncurry] (unit => 'value),
     [@bs.as {json|[]|json}] _
   ) =>
@@ -321,7 +321,7 @@ external useImperativeHandle0:
 [@bs.module "react"]
 external useImperativeHandle1:
   (
-    Js.Nullable.t(Ref.t('value)),
+    Ref.t(Js.Nullable.t('value)),
     [@bs.uncurry] (unit => 'value),
     array('a)
   ) =>
@@ -331,7 +331,7 @@ external useImperativeHandle1:
 [@bs.module "react"]
 external useImperativeHandle2:
   (
-    Js.Nullable.t(Ref.t('value)),
+    Ref.t(Js.Nullable.t('value)),
     [@bs.uncurry] (unit => 'value),
     ('a, 'b)
   ) =>
@@ -341,7 +341,7 @@ external useImperativeHandle2:
 [@bs.module "react"]
 external useImperativeHandle3:
   (
-    Js.Nullable.t(Ref.t('value)),
+    Ref.t(Js.Nullable.t('value)),
     [@bs.uncurry] (unit => 'value),
     ('a, 'b, 'c)
   ) =>
@@ -351,7 +351,7 @@ external useImperativeHandle3:
 [@bs.module "react"]
 external useImperativeHandle4:
   (
-    Js.Nullable.t(Ref.t('value)),
+    Ref.t(Js.Nullable.t('value)),
     [@bs.uncurry] (unit => 'value),
     ('a, 'b, 'c, 'd)
   ) =>
@@ -361,7 +361,7 @@ external useImperativeHandle4:
 [@bs.module "react"]
 external useImperativeHandle5:
   (
-    Js.Nullable.t(Ref.t('value)),
+    Ref.t(Js.Nullable.t('value)),
     [@bs.uncurry] (unit => 'value),
     ('a, 'b, 'c, 'd, 'e)
   ) =>
@@ -371,7 +371,7 @@ external useImperativeHandle5:
 [@bs.module "react"]
 external useImperativeHandle6:
   (
-    Js.Nullable.t(Ref.t('value)),
+    Ref.t(Js.Nullable.t('value)),
     [@bs.uncurry] (unit => 'value),
     ('a, 'b, 'c, 'd, 'e, 'f)
   ) =>
@@ -381,7 +381,7 @@ external useImperativeHandle6:
 [@bs.module "react"]
 external useImperativeHandle7:
   (
-    Js.Nullable.t(Ref.t('value)),
+    Ref.t(Js.Nullable.t('value)),
     [@bs.uncurry] (unit => 'value),
     ('a, 'b, 'c, 'd, 'e, 'f, 'g)
   ) =>


### PR DESCRIPTION
I believe the type signature for `forwardRef` should be changed. Considering the below example from [React.js documentation](https://reactjs.org/docs/forwarding-refs.html)

```
const FancyButton = React.forwardRef((props, ref) => (
  <button ref={ref} className="FancyButton">
    {props.children}
  </button>
));

// You can now get a ref directly to the DOM button:
const ref = React.createRef();
<FancyButton ref={ref}>Click me!</FancyButton>;
```
the argument that relates to `ref` in `forwardRef` should have the same type signature as the return type of `createRef`

Since `forwardRef` may also be used with `useImperativeHandle*`, this PR also updates their type signatures.