### PR TITLE
docs: update webpack instructions on start-page

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -54,7 +54,7 @@ ${pre}
 Then open another tab and do:
 
 ${pre}bash
-npm run webpack
+npm run server
 ${pre}
 
 Your apps are the html files inside ${code}src/${code}`;

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -45,7 +45,7 @@ let make = (~name) =>
 ${pre}`;
 
 const quickStart = `${pre}bash
-npm install -g bs-platform
+npm install -g bs-platform@6.2.1
 bsb -init my-react-app -theme react-hooks
 cd my-react-app
 npm install && npm start


### PR DESCRIPTION
I've noticed there's been some confusion due to this. I hope it makes more sense to run `server` which will serve it at `localhost:xxxx`.

Hoping it's the correct file (start-page)!