### PR TITLE
docs: Clarify the instruction to open the `index.html` file in the build folder.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,7 @@ npm run webpack
 
 BuckleScript's [bsb](https://bucklescript.github.io/docs/en/build-overview.html) build system has an `init` command that generates a project template. The `react` theme offers a lightweight solution optimized for low learning overhead and ease of integration into an existing project.
 
-It compiles to straightforward JS files, so you can open `index.html` directly from the file system. No server needed.
+It compiles to straightforward JS files, so you can open `build/index.html` directly from the file system. No server needed.
 
 ## Adding Reason + Bucklescript to an existing project
 


### PR DESCRIPTION
It could be just me, but I was trying to open the `src/index.html` since it's the folder contains other interesting files.
And it baffled me for a little while until I realised that I should have opened the `build/index.html` file.  

Feel free to close this PR if it's just me being silly. 