### PR TITLE
docs: Update webpack script to server in installation page

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,7 +13,7 @@ npm install --global bs-platform
 bsb -init my-react-app -theme react-hooks
 cd my-react-app && npm install && npm start
 # in another tab
-npm run webpack
+npm run server
 ```
 
 BuckleScript's [bsb](https://bucklescript.github.io/docs/en/build-overview.html) build system has an `init` command that generates a project template. The `react` theme offers a lightweight solution optimized for low learning overhead and ease of integration into an existing project.


### PR DESCRIPTION
Seems that the webpack script is deprecated in development? I try reason-react today, but this makes me a little confused.

This pr is a patch of #481 .