### PR TITLE
docs(context-mixins): binding to external Context

### DIFF
--- a/docs/context-mixins.md
+++ b/docs/context-mixins.md
@@ -57,7 +57,7 @@ export const ThemeContext = React.createContext("light");
 ```reason
 /** ComponentToConsumeTheContext.re */
 [@bs.module "ComponentThatDefinesTheContext"]
-external themeContext: React.Context.t('context) = "ThemeContext";
+external themeContext: React.Context.t(string) = "ThemeContext";
 
 [@react.component]
 let make = () => {

--- a/docs/context-mixins.md
+++ b/docs/context-mixins.md
@@ -45,5 +45,29 @@ let make = () => {
 }
 ```
 
+## Binding to an external Context
+
+Binding to a Context defined in a JS file holds no surprises. 
+
+```js
+/** ComponentThatDefinesTheContext.re */
+export const JwtContext = React.createContext("light");
+```
+
+```reason
+/** ComponentToConsumeTheContext.re */
+module JwtContext = {
+  [@bs.module "ComponentThatDefinesTheContext"]
+  external make: React.Context.t('context) = "JwtContext";
+};
+
+[@react.component]
+let make = () => {
+  let theme = React.useContext(ThemeContext.make);
+
+  <h1>theme->React.string</h1>
+}
+```
+
 ## Mixins 
 ReasonReact doesn't support ReactJS mixins. Composing normal functions is a good alternative.

--- a/docs/context-mixins.md
+++ b/docs/context-mixins.md
@@ -51,19 +51,17 @@ Binding to a Context defined in a JS file holds no surprises.
 
 ```js
 /** ComponentThatDefinesTheContext.re */
-export const JwtContext = React.createContext("light");
+export const ThemeContext = React.createContext("light");
 ```
 
 ```reason
 /** ComponentToConsumeTheContext.re */
-module JwtContext = {
-  [@bs.module "ComponentThatDefinesTheContext"]
-  external make: React.Context.t('context) = "JwtContext";
-};
+[@bs.module "ComponentThatDefinesTheContext"]
+external themeContext: React.Context.t('context) = "ThemeContext";
 
 [@react.component]
 let make = () => {
-  let theme = React.useContext(ThemeContext.make);
+  let theme = React.useContext(themeContext);
 
   <h1>theme->React.string</h1>
 }


### PR DESCRIPTION
Adds a section describing how to bind to a Context defined in a JS file.

Please correct my likely incorrect description. That way I, as well as everyone in the future will know how to bind to an external Context :)