### PR TITLE
Fix method for forms in Bucklescript > 6.x

### DIFF
--- a/src/ReactDOMRe.re
+++ b/src/ReactDOMRe.re
@@ -350,7 +350,7 @@ type domProps = {
   media: string, /* a valid media query */
   [@bs.optional]
   mediaGroup: string,
-  [@bs.optional]
+  [@bs.optional] [@bs.as "method"]
   method: string, /* "post" or "get" */
   [@bs.optional]
   min: int,


### PR DESCRIPTION
We encountered a problem in bucklescript 7 where `method` is a reserved word so it would need to be entered as `method_`. This caused ReasonReact to forward it to the dom as `method_` instead of `method` despite the actual prop being named `method`

Therefor this strange fix where we alias the argument as the same thing again.