### PR TITLE
Update ps-platform in installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ title: Installation
 [BuckleScript](http://bucklescript.github.io/) compiles ReasonML code to JavaScript. You can get it with:
 
 ```sh
-npm install --global bs-platform@6.2.1
+npm install --global bs-platform
 bsb -init my-react-app -theme react-hooks
 cd my-react-app && npm install && npm start
 # in another tab
@@ -25,7 +25,7 @@ The `.re` files compile to straightforward `.bs.js` files. You can open `index.h
 Install the following dependencies:
 
 ```sh
-yarn add bs-platform@6.2.1 --dev --exact
+yarn add bs-platform --dev --exact
 yarn add reason-react --exact
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ title: Installation
 [BuckleScript](http://bucklescript.github.io/) compiles ReasonML code to JavaScript. You can get it with:
 
 ```sh
-npm install --global bs-platform
+npm install --global bs-platform@^7.0.1
 bsb -init my-react-app -theme react-hooks
 cd my-react-app && npm install && npm start
 # in another tab
@@ -25,7 +25,7 @@ The `.re` files compile to straightforward `.bs.js` files. You can open `index.h
 Install the following dependencies:
 
 ```sh
-yarn add bs-platform --dev --exact
+yarn add bs-platform@^7.0.1 --dev --exact
 yarn add reason-react --exact
 ```
 


### PR DESCRIPTION
`bs-platform@6.2.1` using an older version of `moduleserve` that doesn't support `--spa` option for client-side routing (conflict with ReasonReactRouter functionality in dev environment) 
https://github.com/BuckleScript/bucklescript/pull/3943/