### PR TITLE
Add useTransition Hook

### DIFF
--- a/src/React.re
+++ b/src/React.re
@@ -390,3 +390,15 @@ external useImperativeHandle7:
 
 [@bs.set]
 external setDisplayName: (component('props), string) => unit = "displayName";
+
+[@bs.deriving abstract]
+type transitionConfig = {timeoutMs: int};
+
+[@bs.module "React"]
+external useTransition: unit => ((unit => unit) => unit, bool) =
+  "useTransition";
+
+[@bs.module "React"]
+external useTransitionWithConfig:
+  transitionConfig => ((unit => unit) => unit, bool) =
+  "useTransition";

--- a/src/React.re
+++ b/src/React.re
@@ -394,11 +394,10 @@ external setDisplayName: (component('props), string) => unit = "displayName";
 [@bs.deriving abstract]
 type transitionConfig = {timeoutMs: int};
 
-[@bs.module "React"]
-external useTransition: unit => ((unit => unit) => unit, bool) =
-  "useTransition";
+	
+[@bs.deriving abstract]
+type transitionConfig = {timeoutMs: int};
 
 [@bs.module "React"]
-external useTransitionWithConfig:
-  transitionConfig => ((unit => unit) => unit, bool) =
+external useTransition: (~config: transitionConfig=?, unit) => (callback(callback(unit, unit), unit), bool) =
   "useTransition";


### PR DESCRIPTION
This PR adds bindings for the useTransition hook for React (experimental)

* useTransition
* useTransitionWithConfig // calls useTransition with the specified config

@rickyvetter don't merge until it's actually released in React.