### PR TITLE
Add bindings for useTransition hook

### DIFF
--- a/src/React.re
+++ b/src/React.re
@@ -394,6 +394,6 @@ external setDisplayName: (component('props), string) => unit = "displayName";
 [@bs.deriving abstract]
 type transitionConfig = {timeoutMs: int};
 
-[@bs.module "React"]
+[@bs.module "react"]
 external useTransition: (~config: transitionConfig=?, unit) => (callback(callback(unit, unit), unit), bool) =
   "useTransition";

--- a/src/React.re
+++ b/src/React.re
@@ -390,3 +390,10 @@ external useImperativeHandle7:
 
 [@bs.set]
 external setDisplayName: (component('props), string) => unit = "displayName";
+
+[@bs.deriving abstract]
+type transitionConfig = {timeoutMs: int};
+
+[@bs.module "React"]
+external useTransition: (~config: transitionConfig=?, unit) => (callback(callback(unit, unit), unit), bool) =
+  "useTransition";


### PR DESCRIPTION
This PR adds bindings for the useTransition hook for React (experimental)
- useTransition
- useTransitionWithConfig // calls useTransition with the specified config

@rickyvetter  don't land until it's released in React