### PR TITLE
add mapWithIndex & forEachWithIndex to Children

### DIFF
--- a/src/React.re
+++ b/src/React.re
@@ -34,12 +34,12 @@ module Children = {
   [@bs.module "react"] [@bs.scope "Children"] [@bs.val]
   external map: (element, element => element) => element = "map";
   [@bs.module "react"] [@bs.scope "Children"] [@bs.val]
-  external mapWithIndex: (element, (element, int) => element) => element =
+  external mapWithIndex: (element, [@bs.uncurry] ((element, int) => element)) => element =
     "map";
   [@bs.module "react"] [@bs.scope "Children"] [@bs.val]
   external forEach: (element, element => unit) => unit = "forEach";
   [@bs.module "react"] [@bs.scope "Children"] [@bs.val]
-  external forEachWithIndex: (element, (element, int) => unit) => unit =
+  external forEachWithIndex: (element, [@bs.uncurry] ((element, int) => unit)) => unit =
     "forEach";
   [@bs.module "react"] [@bs.scope "Children"] [@bs.val]
   external count: element => int = "count";

--- a/src/React.re
+++ b/src/React.re
@@ -34,7 +34,13 @@ module Children = {
   [@bs.module "react"] [@bs.scope "Children"] [@bs.val]
   external map: (element, element => element) => element = "map";
   [@bs.module "react"] [@bs.scope "Children"] [@bs.val]
+  external mapWithIndex: (element, (element, int) => element) => element =
+    "map";
+  [@bs.module "react"] [@bs.scope "Children"] [@bs.val]
   external forEach: (element, element => unit) => unit = "forEach";
+  [@bs.module "react"] [@bs.scope "Children"] [@bs.val]
+  external forEachWithIndex: (element, (element, int) => unit) => unit =
+    "forEach";
   [@bs.module "react"] [@bs.scope "Children"] [@bs.val]
   external count: element => int = "count";
   [@bs.module "react"] [@bs.scope "Children"] [@bs.val]


### PR DESCRIPTION
Needed the array index when iterating through the children prop so I added bindings for `map` & `forEach` that follow the naming convention in Belt (suffixed `WithIndex`).

Example usage:
```reason
let children =
      switch (gap) {
      | Some(spacing) =>
        children->React.Children.mapWithIndex((element, idx) =>
          idx > 0 ? <> <Spacer amount=spacing /> element </> : element
        )
      | None => children
      };
```