### PR TITLE
[@bs.return nullable] to simplify using Ref.t

### DIFF
--- a/src/React.re
+++ b/src/React.re
@@ -22,13 +22,14 @@ external createElementVariadic:
   "createElement";
 
 module Ref = {
-  type t('value);
+  type t('value) = {mutable current: Js.nullable('value)};
 
-  [@bs.get] external current: t('value) => 'value = "current";
+  [@bs.get] [@bs.return nullable] external current: t('value) => option('value) = "current";
   [@bs.set] external setCurrent: (t('value), 'value) => unit = "current";
+  [@bs.set] external setNull: (t('value), [@bs.as {json|null|json}] _) => unit = "current";
 };
 
-[@bs.module "react"] external createRef: unit => Ref.t(Js.nullable('a)) = "createRef";
+[@bs.module "react"] external createRef: unit => Ref.t('a) = "createRef";
 
 module Children = {
   [@bs.module "react"] [@bs.scope "Children"] [@bs.val]

--- a/src/React.re
+++ b/src/React.re
@@ -21,6 +21,8 @@ external createElementVariadic:
   (component('props), 'props, array(element)) => element =
   "createElement";
 
+type ref('value) = {mutable current: 'value};
+
 module Ref = {
   type t('value) = {mutable current: Js.nullable('value)};
 
@@ -307,7 +309,7 @@ external useCallback7:
 
 [@bs.module "react"] external useContext: Context.t('any) => 'any = "useContext";
 
-[@bs.module "react"] external useRef: 'value => Ref.t('value) = "useRef";
+[@bs.module "react"] external useRef: 'value => ref('value) = "useRef";
 
 [@bs.module "react"]
 external useImperativeHandle0:

--- a/src/ReactDOMRe.re
+++ b/src/ReactDOMRe.re
@@ -90,7 +90,7 @@ type domRef;
 
 module Ref = {
   type t = domRef;
-  type currentDomRef = React.Ref.t(Js.nullable(Dom.element));
+  type currentDomRef = React.Ref.t(Dom.element);
   type callbackDomRef = Js.nullable(Dom.element) => unit;
 
   external domRef: currentDomRef => domRef = "%identity";


### PR DESCRIPTION
I meant to prepare something similar to this PR for a while now, but @cknitt's PR #521 allows avoiding another type for `ref` so this would build on that. With #521, we'd have `type t('value) = ref(Js.Nullable.t('value))` in module `Ref`.

In brief, having to deal with both `ref`s for persisted values (i.e. those created with `useRef(someValue)`) and `ref`s to components makes it painful to handle the latter. `someRef->Ref.current->Js.toOption` is hardly pleasant.

If `ref`s are defined as a record, we can repurpose existing functions to allow simpler access to component `ref`s, allowing to use `someRef->Ref.current` instead. I don't suppose setting such a `ref` to `null` is necessary, but that can be handled with a suitable function, as in `setNull`.

With this definition, below statements are both valid for getting a reference to a component:
```reason
someRef->React.Ref.current;
someRef.current->Js.toOption;
```
and likewise for setting a value 
```reason
someRef->React.Ref.setCurrent(someValue);
someRef.current = Js.Nullable.return(someValue);
```
As `useRef` returns `ref(Js.Nullable.t('value))`, this PR introduces some pain in using persisted values (needing to unwrap an `option` and wrapping a value in `Js.nullable`), but `useRef` could (and should) be defined as in #521 to return `ref('value)`.