### PR TITLE
`ReactEvent.relatedTarget` returns option

### DIFF
--- a/src/ReactEvent.re
+++ b/src/ReactEvent.re
@@ -96,7 +96,8 @@ module Focus = {
   include MakeEventWithType({
     type nonrec t = t;
   });
-  [@bs.get] external relatedTarget: t => Js.nullable(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
+  [@bs.get] [@bs.return nullable]
+  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
 };
 
 module Form = {
@@ -124,7 +125,8 @@ module Mouse = {
   [@bs.get] external metaKey: t => bool = "metaKey";
   [@bs.get] external pageX: t => int = "pageX";
   [@bs.get] external pageY: t => int = "pageY";
-  [@bs.get] external relatedTarget: t => Js.nullable(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
+  [@bs.get] [@bs.return nullable]
+  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
   [@bs.get] external screenX: t => int = "screenX";
   [@bs.get] external screenY: t => int = "screenY";
   [@bs.get] external shiftKey: t => bool = "shiftKey";

--- a/src/ReactEvent.rei
+++ b/src/ReactEvent.rei
@@ -162,7 +162,8 @@ module Focus: {
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
-  [@bs.get] external relatedTarget: t => Js.nullable(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
+  [@bs.get] [@bs.return nullable]
+  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
 };
 
 module Form: {
@@ -214,7 +215,8 @@ module Mouse: {
   [@bs.get] external metaKey: t => bool = "metaKey";
   [@bs.get] external pageX: t => int = "pageX";
   [@bs.get] external pageY: t => int = "pageY";
-  [@bs.get] external relatedTarget: t => Js.nullable(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
+  [@bs.get] [@bs.return nullable]
+  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
   [@bs.get] external screenX: t => int = "screenX";
   [@bs.get] external screenY: t => int = "screenY";
   [@bs.get] external shiftKey: t => bool = "shiftKey";


### PR DESCRIPTION
As argued in #525, this PR changes the return types of `Focus.relatedTarget` and `Mouse.relatedTarget` to be wrapped in `option` instead of `nullable`.