### PR TITLE
memoize callbackDomRef

### DIFF
--- a/src/ReactDOMRe.re
+++ b/src/ReactDOMRe.re
@@ -94,7 +94,15 @@ module Ref = {
   type callbackDomRef = Js.nullable(Dom.element) => unit;
 
   external domRef: currentDomRef => domRef = "%identity";
-  external callbackDomRef: callbackDomRef => domRef = "%identity";
+
+  [@bs.module "react"]
+  external callbackDomRef:
+    (
+      [@bs.uncurry] (Js.nullable(Dom.element) => unit),
+      [@bs.as {json|[]|json}] _
+    ) =>
+    domRef =
+    "useCallback";
 };
 
 /* This list isn't exhaustive. We'll add more as we go. */


### PR DESCRIPTION
Callback refs may currently be created with `callbackDomRef` and memoized with `useCallback` as `r->callbackDomRef->useCallback`. This PR, calls `useCallback` instead of using `%identity` for typecasting and achieves the same result with `r->callbackDomRef`, without breaking the API. As callback refs are supposed to be called only when mounting and unmounting, `[]` is the right dependency.

If there are any concerns of unnecessary overheads due to `useCallback`, An alternative may be to add something like `callbackDomRefMemoized`, but perhaps it would be better to add documentation on ref best practices instead.