### PR TITLE
[RFC] Custom element props

### DIFF
--- a/lib/js/src/ReactDOMRe.js
+++ b/lib/js/src/ReactDOMRe.js
@@ -94,6 +94,8 @@ var Style = {
   unsafeAddProp: unsafeAddProp
 };
 
+var Elements = { };
+
 exports.renderToElementWithClassName = renderToElementWithClassName;
 exports.renderToElementWithId = renderToElementWithId;
 exports.Experimental = Experimental;
@@ -102,4 +104,5 @@ exports.hydrateToElementWithId = hydrateToElementWithId;
 exports.Ref = Ref;
 exports.createElementVariadic = createElementVariadic;
 exports.Style = Style;
+exports.Elements = Elements;
 /* react Not a pure module */

--- a/src/React.re
+++ b/src/React.re
@@ -24,16 +24,16 @@ external createElementVariadic:
   (component('props), 'props, array(element)) => element =
   "createElement";
 
-[@bs.module "React"] [@ocaml.deprecated "Please use JSX syntax directly."]
+[@bs.module "react"] [@ocaml.deprecated "Please use JSX syntax directly."]
 external jsxKeyed: (component('props), 'props, string) => element = "jsx";
 
-[@bs.module "React"] [@ocaml.deprecated "Please use JSX syntax directly."]
+[@bs.module "react"] [@ocaml.deprecated "Please use JSX syntax directly."]
 external jsx: (component('props), 'props) => element = "jsx";
 
-[@bs.module "React"] [@ocaml.deprecated "Please use JSX syntax directly."]
+[@bs.module "react"] [@ocaml.deprecated "Please use JSX syntax directly."]
 external jsxs: (component('props), 'props) => element = "jsxs";
 
-[@bs.module "React"] [@ocaml.deprecated "Please use JSX syntax directly."]
+[@bs.module "react"] [@ocaml.deprecated "Please use JSX syntax directly."]
 external jsxsKeyed: (component('props), 'props, string) => element = "jsxs";
 
 type ref('value) = {mutable current: 'value};

--- a/src/React.re
+++ b/src/React.re
@@ -24,6 +24,18 @@ external createElementVariadic:
   (component('props), 'props, array(element)) => element =
   "createElement";
 
+[@bs.module "React"] [@ocaml.deprecated "Please use JSX syntax directly."]
+external jsxKeyed: (component('props), 'props, string) => element = "jsx";
+
+[@bs.module "React"] [@ocaml.deprecated "Please use JSX syntax directly."]
+external jsx: (component('props), 'props) => element = "jsx";
+
+[@bs.module "React"] [@ocaml.deprecated "Please use JSX syntax directly."]
+external jsxs: (component('props), 'props) => element = "jsxs";
+
+[@bs.module "React"] [@ocaml.deprecated "Please use JSX syntax directly."]
+external jsxsKeyed: (component('props), 'props, string) => element = "jsxs";
+
 type ref('value) = {mutable current: 'value};
 
 module Ref = {

--- a/src/ReactDOMRe.re
+++ b/src/ReactDOMRe.re
@@ -2143,9 +2143,6 @@ external createElement:
   (string, ~props: props=?, array(React.element)) => React.element =
   "createElement";
 
-[@deprecated "Please use JSX syntax directly."];
-external makeDOMComponent: string => React.component(domProps) = "%identity";
-
 /* Only wanna expose createElementVariadic here. Don't wanna write an interface file */
 include (
           /* Use varargs to avoid the ReactJS warning for duplicate keys in children */

--- a/src/ReactDOMRe.re
+++ b/src/ReactDOMRe.re
@@ -1122,7 +1122,9 @@ type domProps = {
   suppressContentEditableWarning: bool,
 };
 
-[@bs.splice] [@bs.module "react"] [@deprecated "Please use React.array or JSX syntax."]
+[@bs.splice]
+[@bs.module "react"]
+[@deprecated "Please use React.array or JSX syntax."]
 external createDOMElementVariadic:
   (string, ~props: domProps=?, array(React.element)) => React.element =
   "createElement";
@@ -2133,7 +2135,10 @@ external objToDOMProps: Js.t({..}) => props = "%identity";
 [@deprecated "Please use ReactDOMRe.props instead"]
 type reactDOMProps = props;
 
-[@bs.splice] [@bs.val] [@bs.module "react"] [@deprecated "Please use React.array or JSX syntax."]
+[@bs.splice]
+[@bs.val]
+[@bs.module "react"]
+[@deprecated "Please use React.array or JSX syntax."]
 external createElement:
   (string, ~props: props=?, array(React.element)) => React.element =
   "createElement";

--- a/src/ReactDOMRe.re
+++ b/src/ReactDOMRe.re
@@ -2617,3 +2617,1635 @@ module Style = {
     ([@bs.as {json|{}|json}] _, style, Js.t({..})) => style =
     "Object.assign";
 };
+
+/* === Beginning of DOM elements and attributes this section is large but do not fear :) === */
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
+
+module Elements: {
+  type domComponent('props);
+  external domComponentToComponent:
+    domComponent('props) => React.component('props) =
+    "%identity";
+  [@bs.inline "div"]
+  let div: domComponent(domProps);
+
+  [@bs.deriving {abstract: light}]
+  type divProps = {
+    [@bs.optional]
+    key: string,
+    [@bs.optional]
+    ref: domRef,
+    /* accessibility */
+    /* https://www.w3.org/TR/wai-aria-1.1/ */
+    /* https://accessibilityresources.org/<aria-tag> is a great resource for these */
+    /* [@bs.optional] [@bs.as "aria-current"] ariaCurrent: page|step|location|date|time|true|false, */
+    [@bs.optional] [@bs.as "aria-details"]
+    ariaDetails: string,
+    [@bs.optional] [@bs.as "aria-disabled"]
+    ariaDisabled: bool,
+    [@bs.optional] [@bs.as "aria-hidden"]
+    ariaHidden: bool,
+    /* [@bs.optional] [@bs.as "aria-invalid"] ariaInvalid: grammar|false|spelling|true, */
+    [@bs.optional] [@bs.as "aria-keyshortcuts"]
+    ariaKeyshortcuts: string,
+    [@bs.optional] [@bs.as "aria-label"]
+    ariaLabel: string,
+    [@bs.optional] [@bs.as "aria-roledescription"]
+    ariaRoledescription: string,
+    /* Widget Attributes */
+    /* [@bs.optional] [@bs.as "aria-autocomplete"] ariaAutocomplete: inline|list|both|none, */
+    /* [@bs.optional] [@bs.as "aria-checked"] ariaChecked: true|false|mixed, /* https://www.w3.org/TR/wai-aria-1.1/#valuetype_tristate */ */
+    [@bs.optional] [@bs.as "aria-expanded"]
+    ariaExpanded: bool,
+    /* [@bs.optional] [@bs.as "aria-haspopup"] ariaHaspopup: false|true|menu|listbox|tree|grid|dialog, */
+    [@bs.optional] [@bs.as "aria-level"]
+    ariaLevel: int,
+    [@bs.optional] [@bs.as "aria-modal"]
+    ariaModal: bool,
+    [@bs.optional] [@bs.as "aria-multiline"]
+    ariaMultiline: bool,
+    [@bs.optional] [@bs.as "aria-multiselectable"]
+    ariaMultiselectable: bool,
+    /* [@bs.optional] [@bs.as "aria-orientation"] ariaOrientation: horizontal|vertical|undefined, */
+    [@bs.optional] [@bs.as "aria-placeholder"]
+    ariaPlaceholder: string,
+    /* [@bs.optional] [@bs.as "aria-pressed"] ariaPressed: true|false|mixed, /* https://www.w3.org/TR/wai-aria-1.1/#valuetype_tristate */ */
+    [@bs.optional] [@bs.as "aria-readonly"]
+    ariaReadonly: bool,
+    [@bs.optional] [@bs.as "aria-required"]
+    ariaRequired: bool,
+    [@bs.optional] [@bs.as "aria-selected"]
+    ariaSelected: bool,
+    [@bs.optional] [@bs.as "aria-sort"]
+    ariaSort: string,
+    [@bs.optional] [@bs.as "aria-valuemax"]
+    ariaValuemax: float,
+    [@bs.optional] [@bs.as "aria-valuemin"]
+    ariaValuemin: float,
+    [@bs.optional] [@bs.as "aria-valuenow"]
+    ariaValuenow: float,
+    [@bs.optional] [@bs.as "aria-valuetext"]
+    ariaValuetext: string,
+    /* Live Region Attributes */
+    [@bs.optional] [@bs.as "aria-atomic"]
+    ariaAtomic: bool,
+    [@bs.optional] [@bs.as "aria-busy"]
+    ariaBusy: bool,
+    /* [@bs.optional] [@bs.as "aria-live"] ariaLive: off|polite|assertive|rude, */
+    [@bs.optional] [@bs.as "aria-relevant"]
+    ariaRelevant: string,
+    /* Drag-and-Drop Attributes */
+    /* [@bs.optional] [@bs.as "aria-dropeffect"] ariaDropeffect: copy|move|link|execute|popup|none, */
+    [@bs.optional] [@bs.as "aria-grabbed"]
+    ariaGrabbed: bool,
+    /* Relationship Attributes */
+    [@bs.optional] [@bs.as "aria-activedescendant"]
+    ariaActivedescendant: string,
+    [@bs.optional] [@bs.as "aria-colcount"]
+    ariaColcount: int,
+    [@bs.optional] [@bs.as "aria-colindex"]
+    ariaColindex: int,
+    [@bs.optional] [@bs.as "aria-colspan"]
+    ariaColspan: int,
+    [@bs.optional] [@bs.as "aria-controls"]
+    ariaControls: string,
+    [@bs.optional] [@bs.as "aria-describedby"]
+    ariaDescribedby: string,
+    [@bs.optional] [@bs.as "aria-errormessage"]
+    ariaErrormessage: string,
+    [@bs.optional] [@bs.as "aria-flowto"]
+    ariaFlowto: string,
+    [@bs.optional] [@bs.as "aria-labelledby"]
+    ariaLabelledby: string,
+    [@bs.optional] [@bs.as "aria-owns"]
+    ariaOwns: string,
+    [@bs.optional] [@bs.as "aria-posinset"]
+    ariaPosinset: int,
+    [@bs.optional] [@bs.as "aria-rowcount"]
+    ariaRowcount: int,
+    [@bs.optional] [@bs.as "aria-rowindex"]
+    ariaRowindex: int,
+    [@bs.optional] [@bs.as "aria-rowspan"]
+    ariaRowspan: int,
+    [@bs.optional] [@bs.as "aria-setsize"]
+    ariaSetsize: int,
+    /* react textarea/input */
+    [@bs.optional]
+    defaultChecked: bool,
+    [@bs.optional]
+    defaultValue: string,
+    /* global html attributes */
+    [@bs.optional]
+    accessKey: string,
+    [@bs.optional]
+    autoCapitalize: string, /* Mobile Safari specific */
+    [@bs.optional]
+    className: string, /* substitute for "class" */
+    [@bs.optional]
+    contentEditable: bool,
+    [@bs.optional]
+    contextMenu: string,
+    [@bs.optional]
+    dir: string, /* "ltr", "rtl" or "auto" */
+    [@bs.optional]
+    draggable: bool,
+    [@bs.optional]
+    hidden: bool,
+    [@bs.optional]
+    id: string,
+    [@bs.optional]
+    lang: string,
+    [@bs.optional]
+    role: string, /* ARIA role */
+    [@bs.optional]
+    style,
+    [@bs.optional]
+    spellCheck: bool,
+    [@bs.optional]
+    tabIndex: int,
+    [@bs.optional]
+    title: string,
+    /* html5 microdata */
+    [@bs.optional]
+    itemID: string,
+    [@bs.optional]
+    itemProp: string,
+    [@bs.optional]
+    itemRef: string,
+    [@bs.optional]
+    itemScope: bool,
+    [@bs.optional]
+    itemType: string, /* uri */
+    /* tag-specific html attributes */
+    /* Clipboard events */
+    [@bs.optional]
+    onCopy: ReactEvent.Clipboard.t => unit,
+    [@bs.optional]
+    onCut: ReactEvent.Clipboard.t => unit,
+    [@bs.optional]
+    onPaste: ReactEvent.Clipboard.t => unit,
+    /* Composition events */
+    [@bs.optional]
+    onCompositionEnd: ReactEvent.Composition.t => unit,
+    [@bs.optional]
+    onCompositionStart: ReactEvent.Composition.t => unit,
+    [@bs.optional]
+    onCompositionUpdate: ReactEvent.Composition.t => unit,
+    /* Keyboard events */
+    [@bs.optional]
+    onKeyDown: ReactEvent.Keyboard.t => unit,
+    [@bs.optional]
+    onKeyPress: ReactEvent.Keyboard.t => unit,
+    [@bs.optional]
+    onKeyUp: ReactEvent.Keyboard.t => unit,
+    /* Focus events */
+    [@bs.optional]
+    onFocus: ReactEvent.Focus.t => unit,
+    [@bs.optional]
+    onBlur: ReactEvent.Focus.t => unit,
+    /* Form events */
+    [@bs.optional]
+    onChange: ReactEvent.Form.t => unit,
+    [@bs.optional]
+    onInput: ReactEvent.Form.t => unit,
+    [@bs.optional]
+    onSubmit: ReactEvent.Form.t => unit,
+    [@bs.optional]
+    onInvalid: ReactEvent.Form.t => unit,
+    /* Mouse events */
+    [@bs.optional]
+    onClick: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onContextMenu: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDoubleClick: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDrag: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragEnd: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragEnter: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragExit: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragLeave: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragOver: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragStart: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDrop: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseDown: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseEnter: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseLeave: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseMove: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseOut: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseOver: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseUp: ReactEvent.Mouse.t => unit,
+    /* Selection events */
+    [@bs.optional]
+    onSelect: ReactEvent.Selection.t => unit,
+    /* Touch events */
+    [@bs.optional]
+    onTouchCancel: ReactEvent.Touch.t => unit,
+    [@bs.optional]
+    onTouchEnd: ReactEvent.Touch.t => unit,
+    [@bs.optional]
+    onTouchMove: ReactEvent.Touch.t => unit,
+    [@bs.optional]
+    onTouchStart: ReactEvent.Touch.t => unit,
+    /* UI events */
+    [@bs.optional]
+    onScroll: ReactEvent.UI.t => unit,
+    /* Wheel events */
+    [@bs.optional]
+    onWheel: ReactEvent.Wheel.t => unit,
+    /* Media events */
+    [@bs.optional]
+    onAbort: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onCanPlay: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onCanPlayThrough: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onDurationChange: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onEmptied: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onEncrypetd: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onEnded: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onError: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onLoadedData: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onLoadedMetadata: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onLoadStart: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onPause: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onPlay: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onPlaying: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onProgress: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onRateChange: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onSeeked: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onSeeking: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onStalled: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onSuspend: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onTimeUpdate: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onVolumeChange: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onWaiting: ReactEvent.Media.t => unit,
+    /* Image events */
+    [@bs.optional]onLoad: ReactEvent.Image.t => unit /* duplicate */, /*~onError: ReactEvent.Image.t => unit=?,*/
+    /* Animation events */
+    [@bs.optional]
+    onAnimationStart: ReactEvent.Animation.t => unit,
+    [@bs.optional]
+    onAnimationEnd: ReactEvent.Animation.t => unit,
+    [@bs.optional]
+    onAnimationIteration: ReactEvent.Animation.t => unit,
+    /* Transition events */
+    [@bs.optional]
+    onTransitionEnd: ReactEvent.Transition.t => unit,
+    /* svg */
+    [@bs.optional]
+    accentHeight: string,
+    [@bs.optional]
+    accumulate: string,
+    [@bs.optional]
+    additive: string,
+    [@bs.optional]
+    alignmentBaseline: string,
+    [@bs.optional]
+    allowReorder: string,
+    [@bs.optional]
+    alphabetic: string,
+    [@bs.optional]
+    amplitude: string,
+    [@bs.optional]
+    arabicForm: string,
+    [@bs.optional]
+    ascent: string,
+    [@bs.optional]
+    attributeName: string,
+    [@bs.optional]
+    attributeType: string,
+    [@bs.optional]
+    autoReverse: string,
+    [@bs.optional]
+    azimuth: string,
+    [@bs.optional]
+    baseFrequency: string,
+    [@bs.optional]
+    baseProfile: string,
+    [@bs.optional]
+    baselineShift: string,
+    [@bs.optional]
+    bbox: string,
+    [@bs.optional] [@bs.as "begin"]
+    begin_: string,
+    [@bs.optional]
+    bias: string,
+    [@bs.optional]
+    by: string,
+    [@bs.optional]
+    calcMode: string,
+    [@bs.optional]
+    capHeight: string,
+    [@bs.optional]
+    clip: string,
+    [@bs.optional]
+    clipPath: string,
+    [@bs.optional]
+    clipPathUnits: string,
+    [@bs.optional]
+    clipRule: string,
+    [@bs.optional]
+    colorInterpolation: string,
+    [@bs.optional]
+    colorInterpolationFilters: string,
+    [@bs.optional]
+    colorProfile: string,
+    [@bs.optional]
+    colorRendering: string,
+    [@bs.optional]
+    contentScriptType: string,
+    [@bs.optional]
+    contentStyleType: string,
+    [@bs.optional]
+    cursor: string,
+    [@bs.optional]
+    cx: string,
+    [@bs.optional]
+    cy: string,
+    [@bs.optional]
+    d: string,
+    [@bs.optional]
+    decelerate: string,
+    [@bs.optional]
+    descent: string,
+    [@bs.optional]
+    diffuseConstant: string,
+    [@bs.optional]
+    direction: string,
+    [@bs.optional]
+    display: string,
+    [@bs.optional]
+    divisor: string,
+    [@bs.optional]
+    dominantBaseline: string,
+    [@bs.optional]
+    dur: string,
+    [@bs.optional]
+    dx: string,
+    [@bs.optional]
+    dy: string,
+    [@bs.optional]
+    edgeMode: string,
+    [@bs.optional]
+    elevation: string,
+    [@bs.optional]
+    enableBackground: string,
+    [@bs.optional] [@bs.as "end"]
+    end_: string,
+    [@bs.optional]
+    exponent: string,
+    [@bs.optional]
+    externalResourcesRequired: string,
+    [@bs.optional]
+    fill: string,
+    [@bs.optional]
+    fillOpacity: string,
+    [@bs.optional]
+    fillRule: string,
+    [@bs.optional]
+    filter: string,
+    [@bs.optional]
+    filterRes: string,
+    [@bs.optional]
+    filterUnits: string,
+    [@bs.optional]
+    floodColor: string,
+    [@bs.optional]
+    floodOpacity: string,
+    [@bs.optional]
+    focusable: string,
+    [@bs.optional]
+    fontFamily: string,
+    [@bs.optional]
+    fontSize: string,
+    [@bs.optional]
+    fontSizeAdjust: string,
+    [@bs.optional]
+    fontStretch: string,
+    [@bs.optional]
+    fontStyle: string,
+    [@bs.optional]
+    fontVariant: string,
+    [@bs.optional]
+    fontWeight: string,
+    [@bs.optional]
+    fomat: string,
+    [@bs.optional]
+    from: string,
+    [@bs.optional]
+    fx: string,
+    [@bs.optional]
+    fy: string,
+    [@bs.optional]
+    g1: string,
+    [@bs.optional]
+    g2: string,
+    [@bs.optional]
+    glyphName: string,
+    [@bs.optional]
+    glyphOrientationHorizontal: string,
+    [@bs.optional]
+    glyphOrientationVertical: string,
+    [@bs.optional]
+    glyphRef: string,
+    [@bs.optional]
+    gradientTransform: string,
+    [@bs.optional]
+    gradientUnits: string,
+    [@bs.optional]
+    hanging: string,
+    [@bs.optional]
+    horizAdvX: string,
+    [@bs.optional]
+    horizOriginX: string,
+    [@bs.optional]
+    ideographic: string,
+    [@bs.optional]
+    imageRendering: string,
+    [@bs.optional] [@bs.as "in"]
+    in_: string,
+    [@bs.optional]
+    intercept: string,
+    [@bs.optional]
+    k: string,
+    [@bs.optional]
+    k1: string,
+    [@bs.optional]
+    k2: string,
+    [@bs.optional]
+    k3: string,
+    [@bs.optional]
+    k4: string,
+    [@bs.optional]
+    kernelMatrix: string,
+    [@bs.optional]
+    kernelUnitLength: string,
+    [@bs.optional]
+    kerning: string,
+    [@bs.optional]
+    keyPoints: string,
+    [@bs.optional]
+    keySplines: string,
+    [@bs.optional]
+    keyTimes: string,
+    [@bs.optional]
+    lengthAdjust: string,
+    [@bs.optional]
+    letterSpacing: string,
+    [@bs.optional]
+    lightingColor: string,
+    [@bs.optional]
+    limitingConeAngle: string,
+    [@bs.optional]
+    local: string,
+    [@bs.optional]
+    markerEnd: string,
+    [@bs.optional]
+    markerHeight: string,
+    [@bs.optional]
+    markerMid: string,
+    [@bs.optional]
+    markerStart: string,
+    [@bs.optional]
+    markerUnits: string,
+    [@bs.optional]
+    markerWidth: string,
+    [@bs.optional]
+    mask: string,
+    [@bs.optional]
+    maskContentUnits: string,
+    [@bs.optional]
+    maskUnits: string,
+    [@bs.optional]
+    mathematical: string,
+    [@bs.optional]
+    mode: string,
+    [@bs.optional]
+    numOctaves: string,
+    [@bs.optional]
+    offset: string,
+    [@bs.optional]
+    opacity: string,
+    [@bs.optional]
+    operator: string,
+    [@bs.optional]
+    order: string,
+    [@bs.optional]
+    orient: string,
+    [@bs.optional]
+    orientation: string,
+    [@bs.optional]
+    origin: string,
+    [@bs.optional]
+    overflow: string,
+    [@bs.optional]
+    overflowX: string,
+    [@bs.optional]
+    overflowY: string,
+    [@bs.optional]
+    overlinePosition: string,
+    [@bs.optional]
+    overlineThickness: string,
+    [@bs.optional]
+    paintOrder: string,
+    [@bs.optional]
+    panose1: string,
+    [@bs.optional]
+    pathLength: string,
+    [@bs.optional]
+    patternContentUnits: string,
+    [@bs.optional]
+    patternTransform: string,
+    [@bs.optional]
+    patternUnits: string,
+    [@bs.optional]
+    pointerEvents: string,
+    [@bs.optional]
+    points: string,
+    [@bs.optional]
+    pointsAtX: string,
+    [@bs.optional]
+    pointsAtY: string,
+    [@bs.optional]
+    pointsAtZ: string,
+    [@bs.optional]
+    preserveAlpha: string,
+    [@bs.optional]
+    preserveAspectRatio: string,
+    [@bs.optional]
+    primitiveUnits: string,
+    [@bs.optional]
+    r: string,
+    [@bs.optional]
+    radius: string,
+    [@bs.optional]
+    refX: string,
+    [@bs.optional]
+    refY: string,
+    [@bs.optional]
+    renderingIntent: string,
+    [@bs.optional]
+    repeatCount: string,
+    [@bs.optional]
+    repeatDur: string,
+    [@bs.optional]
+    requiredExtensions: string,
+    [@bs.optional]
+    requiredFeatures: string,
+    [@bs.optional]
+    restart: string,
+    [@bs.optional]
+    result: string,
+    [@bs.optional]
+    rotate: string,
+    [@bs.optional]
+    rx: string,
+    [@bs.optional]
+    ry: string,
+    [@bs.optional]
+    scale: string,
+    [@bs.optional]
+    seed: string,
+    [@bs.optional]
+    shapeRendering: string,
+    [@bs.optional]
+    slope: string,
+    [@bs.optional]
+    spacing: string,
+    [@bs.optional]
+    specularConstant: string,
+    [@bs.optional]
+    specularExponent: string,
+    [@bs.optional]
+    speed: string,
+    [@bs.optional]
+    spreadMethod: string,
+    [@bs.optional]
+    startOffset: string,
+    [@bs.optional]
+    stdDeviation: string,
+    [@bs.optional]
+    stemh: string,
+    [@bs.optional]
+    stemv: string,
+    [@bs.optional]
+    stitchTiles: string,
+    [@bs.optional]
+    stopColor: string,
+    [@bs.optional]
+    stopOpacity: string,
+    [@bs.optional]
+    strikethroughPosition: string,
+    [@bs.optional]
+    strikethroughThickness: string,
+    [@bs.optional]
+    string,
+    [@bs.optional]
+    stroke: string,
+    [@bs.optional]
+    strokeDasharray: string,
+    [@bs.optional]
+    strokeDashoffset: string,
+    [@bs.optional]
+    strokeLinecap: string,
+    [@bs.optional]
+    strokeLinejoin: string,
+    [@bs.optional]
+    strokeMiterlimit: string,
+    [@bs.optional]
+    strokeOpacity: string,
+    [@bs.optional]
+    strokeWidth: string,
+    [@bs.optional]
+    surfaceScale: string,
+    [@bs.optional]
+    systemLanguage: string,
+    [@bs.optional]
+    tableValues: string,
+    [@bs.optional]
+    targetX: string,
+    [@bs.optional]
+    targetY: string,
+    [@bs.optional]
+    textAnchor: string,
+    [@bs.optional]
+    textDecoration: string,
+    [@bs.optional]
+    textLength: string,
+    [@bs.optional]
+    textRendering: string,
+    [@bs.optional] [@bs.as "to"]
+    to_: string,
+    [@bs.optional]
+    transform: string,
+    [@bs.optional]
+    u1: string,
+    [@bs.optional]
+    u2: string,
+    [@bs.optional]
+    underlinePosition: string,
+    [@bs.optional]
+    underlineThickness: string,
+    [@bs.optional]
+    unicode: string,
+    [@bs.optional]
+    unicodeBidi: string,
+    [@bs.optional]
+    unicodeRange: string,
+    [@bs.optional]
+    unitsPerEm: string,
+    [@bs.optional]
+    vAlphabetic: string,
+    [@bs.optional]
+    vHanging: string,
+    [@bs.optional]
+    vIdeographic: string,
+    [@bs.optional]
+    vMathematical: string,
+    [@bs.optional]
+    values: string,
+    [@bs.optional]
+    vectorEffect: string,
+    [@bs.optional]
+    version: string,
+    [@bs.optional]
+    vertAdvX: string,
+    [@bs.optional]
+    vertAdvY: string,
+    [@bs.optional]
+    vertOriginX: string,
+    [@bs.optional]
+    vertOriginY: string,
+    [@bs.optional]
+    viewBox: string,
+    [@bs.optional]
+    viewTarget: string,
+    [@bs.optional]
+    visibility: string,
+    /*width::string? =>*/
+    [@bs.optional]
+    widths: string,
+    [@bs.optional]
+    wordSpacing: string,
+    [@bs.optional]
+    writingMode: string,
+    [@bs.optional]
+    x: string,
+    [@bs.optional]
+    x1: string,
+    [@bs.optional]
+    x2: string,
+    [@bs.optional]
+    xChannelSelector: string,
+    [@bs.optional]
+    xHeight: string,
+    [@bs.optional]
+    xlinkActuate: string,
+    [@bs.optional]
+    xlinkArcrole: string,
+    [@bs.optional]
+    xlinkHref: string,
+    [@bs.optional]
+    xlinkRole: string,
+    [@bs.optional]
+    xlinkShow: string,
+    [@bs.optional]
+    xlinkTitle: string,
+    [@bs.optional]
+    xlinkType: string,
+    [@bs.optional]
+    xmlns: string,
+    [@bs.optional]
+    xmlnsXlink: string,
+    [@bs.optional]
+    xmlBase: string,
+    [@bs.optional]
+    xmlLang: string,
+    [@bs.optional]
+    xmlSpace: string,
+    [@bs.optional]
+    y: string,
+    [@bs.optional]
+    y1: string,
+    [@bs.optional]
+    y2: string,
+    [@bs.optional]
+    yChannelSelector: string,
+    [@bs.optional]
+    z: string,
+    [@bs.optional]
+    zoomAndPan: string,
+    /* RDFa */
+    [@bs.optional]
+    about: string,
+    [@bs.optional]
+    datatype: string,
+    [@bs.optional]
+    inlist: string,
+    [@bs.optional]
+    prefix: string,
+    [@bs.optional]
+    property: string,
+    [@bs.optional]
+    resource: string,
+    [@bs.optional]
+    typeof: string,
+    [@bs.optional]
+    vocab: string,
+    /* react-specific */
+    [@bs.optional]
+    dangerouslySetInnerHTML: {. "__html": string},
+    [@bs.optional]
+    suppressContentEditableWarning: bool,
+  };
+} = {
+  type domComponent('props) = string;
+  external domComponentToComponent:
+    domComponent('props) => React.component('props) =
+    "%identity";
+
+  [@bs.inline]
+  let div = "div";
+
+  [@bs.deriving {abstract: light}]
+  type divProps = {
+    [@bs.optional]
+    key: string,
+    [@bs.optional]
+    ref: domRef,
+    /* accessibility */
+    /* https://www.w3.org/TR/wai-aria-1.1/ */
+    /* https://accessibilityresources.org/<aria-tag> is a great resource for these */
+    /* [@bs.optional] [@bs.as "aria-current"] ariaCurrent: page|step|location|date|time|true|false, */
+    [@bs.optional] [@bs.as "aria-details"]
+    ariaDetails: string,
+    [@bs.optional] [@bs.as "aria-disabled"]
+    ariaDisabled: bool,
+    [@bs.optional] [@bs.as "aria-hidden"]
+    ariaHidden: bool,
+    /* [@bs.optional] [@bs.as "aria-invalid"] ariaInvalid: grammar|false|spelling|true, */
+    [@bs.optional] [@bs.as "aria-keyshortcuts"]
+    ariaKeyshortcuts: string,
+    [@bs.optional] [@bs.as "aria-label"]
+    ariaLabel: string,
+    [@bs.optional] [@bs.as "aria-roledescription"]
+    ariaRoledescription: string,
+    /* Widget Attributes */
+    /* [@bs.optional] [@bs.as "aria-autocomplete"] ariaAutocomplete: inline|list|both|none, */
+    /* [@bs.optional] [@bs.as "aria-checked"] ariaChecked: true|false|mixed, /* https://www.w3.org/TR/wai-aria-1.1/#valuetype_tristate */ */
+    [@bs.optional] [@bs.as "aria-expanded"]
+    ariaExpanded: bool,
+    /* [@bs.optional] [@bs.as "aria-haspopup"] ariaHaspopup: false|true|menu|listbox|tree|grid|dialog, */
+    [@bs.optional] [@bs.as "aria-level"]
+    ariaLevel: int,
+    [@bs.optional] [@bs.as "aria-modal"]
+    ariaModal: bool,
+    [@bs.optional] [@bs.as "aria-multiline"]
+    ariaMultiline: bool,
+    [@bs.optional] [@bs.as "aria-multiselectable"]
+    ariaMultiselectable: bool,
+    /* [@bs.optional] [@bs.as "aria-orientation"] ariaOrientation: horizontal|vertical|undefined, */
+    [@bs.optional] [@bs.as "aria-placeholder"]
+    ariaPlaceholder: string,
+    /* [@bs.optional] [@bs.as "aria-pressed"] ariaPressed: true|false|mixed, /* https://www.w3.org/TR/wai-aria-1.1/#valuetype_tristate */ */
+    [@bs.optional] [@bs.as "aria-readonly"]
+    ariaReadonly: bool,
+    [@bs.optional] [@bs.as "aria-required"]
+    ariaRequired: bool,
+    [@bs.optional] [@bs.as "aria-selected"]
+    ariaSelected: bool,
+    [@bs.optional] [@bs.as "aria-sort"]
+    ariaSort: string,
+    [@bs.optional] [@bs.as "aria-valuemax"]
+    ariaValuemax: float,
+    [@bs.optional] [@bs.as "aria-valuemin"]
+    ariaValuemin: float,
+    [@bs.optional] [@bs.as "aria-valuenow"]
+    ariaValuenow: float,
+    [@bs.optional] [@bs.as "aria-valuetext"]
+    ariaValuetext: string,
+    /* Live Region Attributes */
+    [@bs.optional] [@bs.as "aria-atomic"]
+    ariaAtomic: bool,
+    [@bs.optional] [@bs.as "aria-busy"]
+    ariaBusy: bool,
+    /* [@bs.optional] [@bs.as "aria-live"] ariaLive: off|polite|assertive|rude, */
+    [@bs.optional] [@bs.as "aria-relevant"]
+    ariaRelevant: string,
+    /* Drag-and-Drop Attributes */
+    /* [@bs.optional] [@bs.as "aria-dropeffect"] ariaDropeffect: copy|move|link|execute|popup|none, */
+    [@bs.optional] [@bs.as "aria-grabbed"]
+    ariaGrabbed: bool,
+    /* Relationship Attributes */
+    [@bs.optional] [@bs.as "aria-activedescendant"]
+    ariaActivedescendant: string,
+    [@bs.optional] [@bs.as "aria-colcount"]
+    ariaColcount: int,
+    [@bs.optional] [@bs.as "aria-colindex"]
+    ariaColindex: int,
+    [@bs.optional] [@bs.as "aria-colspan"]
+    ariaColspan: int,
+    [@bs.optional] [@bs.as "aria-controls"]
+    ariaControls: string,
+    [@bs.optional] [@bs.as "aria-describedby"]
+    ariaDescribedby: string,
+    [@bs.optional] [@bs.as "aria-errormessage"]
+    ariaErrormessage: string,
+    [@bs.optional] [@bs.as "aria-flowto"]
+    ariaFlowto: string,
+    [@bs.optional] [@bs.as "aria-labelledby"]
+    ariaLabelledby: string,
+    [@bs.optional] [@bs.as "aria-owns"]
+    ariaOwns: string,
+    [@bs.optional] [@bs.as "aria-posinset"]
+    ariaPosinset: int,
+    [@bs.optional] [@bs.as "aria-rowcount"]
+    ariaRowcount: int,
+    [@bs.optional] [@bs.as "aria-rowindex"]
+    ariaRowindex: int,
+    [@bs.optional] [@bs.as "aria-rowspan"]
+    ariaRowspan: int,
+    [@bs.optional] [@bs.as "aria-setsize"]
+    ariaSetsize: int,
+    /* react textarea/input */
+    [@bs.optional]
+    defaultChecked: bool,
+    [@bs.optional]
+    defaultValue: string,
+    /* global html attributes */
+    [@bs.optional]
+    accessKey: string,
+    [@bs.optional]
+    autoCapitalize: string, /* Mobile Safari specific */
+    [@bs.optional]
+    className: string, /* substitute for "class" */
+    [@bs.optional]
+    contentEditable: bool,
+    [@bs.optional]
+    contextMenu: string,
+    [@bs.optional]
+    dir: string, /* "ltr", "rtl" or "auto" */
+    [@bs.optional]
+    draggable: bool,
+    [@bs.optional]
+    hidden: bool,
+    [@bs.optional]
+    id: string,
+    [@bs.optional]
+    lang: string,
+    [@bs.optional]
+    role: string, /* ARIA role */
+    [@bs.optional]
+    style,
+    [@bs.optional]
+    spellCheck: bool,
+    [@bs.optional]
+    tabIndex: int,
+    [@bs.optional]
+    title: string,
+    /* html5 microdata */
+    [@bs.optional]
+    itemID: string,
+    [@bs.optional]
+    itemProp: string,
+    [@bs.optional]
+    itemRef: string,
+    [@bs.optional]
+    itemScope: bool,
+    [@bs.optional]
+    itemType: string, /* uri */
+    /* tag-specific html attributes */
+    /* Clipboard events */
+    [@bs.optional]
+    onCopy: ReactEvent.Clipboard.t => unit,
+    [@bs.optional]
+    onCut: ReactEvent.Clipboard.t => unit,
+    [@bs.optional]
+    onPaste: ReactEvent.Clipboard.t => unit,
+    /* Composition events */
+    [@bs.optional]
+    onCompositionEnd: ReactEvent.Composition.t => unit,
+    [@bs.optional]
+    onCompositionStart: ReactEvent.Composition.t => unit,
+    [@bs.optional]
+    onCompositionUpdate: ReactEvent.Composition.t => unit,
+    /* Keyboard events */
+    [@bs.optional]
+    onKeyDown: ReactEvent.Keyboard.t => unit,
+    [@bs.optional]
+    onKeyPress: ReactEvent.Keyboard.t => unit,
+    [@bs.optional]
+    onKeyUp: ReactEvent.Keyboard.t => unit,
+    /* Focus events */
+    [@bs.optional]
+    onFocus: ReactEvent.Focus.t => unit,
+    [@bs.optional]
+    onBlur: ReactEvent.Focus.t => unit,
+    /* Form events */
+    [@bs.optional]
+    onChange: ReactEvent.Form.t => unit,
+    [@bs.optional]
+    onInput: ReactEvent.Form.t => unit,
+    [@bs.optional]
+    onSubmit: ReactEvent.Form.t => unit,
+    [@bs.optional]
+    onInvalid: ReactEvent.Form.t => unit,
+    /* Mouse events */
+    [@bs.optional]
+    onClick: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onContextMenu: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDoubleClick: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDrag: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragEnd: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragEnter: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragExit: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragLeave: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragOver: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragStart: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDrop: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseDown: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseEnter: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseLeave: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseMove: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseOut: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseOver: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseUp: ReactEvent.Mouse.t => unit,
+    /* Selection events */
+    [@bs.optional]
+    onSelect: ReactEvent.Selection.t => unit,
+    /* Touch events */
+    [@bs.optional]
+    onTouchCancel: ReactEvent.Touch.t => unit,
+    [@bs.optional]
+    onTouchEnd: ReactEvent.Touch.t => unit,
+    [@bs.optional]
+    onTouchMove: ReactEvent.Touch.t => unit,
+    [@bs.optional]
+    onTouchStart: ReactEvent.Touch.t => unit,
+    /* UI events */
+    [@bs.optional]
+    onScroll: ReactEvent.UI.t => unit,
+    /* Wheel events */
+    [@bs.optional]
+    onWheel: ReactEvent.Wheel.t => unit,
+    /* Media events */
+    [@bs.optional]
+    onAbort: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onCanPlay: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onCanPlayThrough: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onDurationChange: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onEmptied: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onEncrypetd: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onEnded: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onError: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onLoadedData: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onLoadedMetadata: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onLoadStart: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onPause: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onPlay: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onPlaying: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onProgress: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onRateChange: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onSeeked: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onSeeking: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onStalled: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onSuspend: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onTimeUpdate: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onVolumeChange: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onWaiting: ReactEvent.Media.t => unit,
+    /* Image events */
+    [@bs.optional]onLoad: ReactEvent.Image.t => unit /* duplicate */, /*~onError: ReactEvent.Image.t => unit=?,*/
+    /* Animation events */
+    [@bs.optional]
+    onAnimationStart: ReactEvent.Animation.t => unit,
+    [@bs.optional]
+    onAnimationEnd: ReactEvent.Animation.t => unit,
+    [@bs.optional]
+    onAnimationIteration: ReactEvent.Animation.t => unit,
+    /* Transition events */
+    [@bs.optional]
+    onTransitionEnd: ReactEvent.Transition.t => unit,
+    /* svg */
+    [@bs.optional]
+    accentHeight: string,
+    [@bs.optional]
+    accumulate: string,
+    [@bs.optional]
+    additive: string,
+    [@bs.optional]
+    alignmentBaseline: string,
+    [@bs.optional]
+    allowReorder: string,
+    [@bs.optional]
+    alphabetic: string,
+    [@bs.optional]
+    amplitude: string,
+    [@bs.optional]
+    arabicForm: string,
+    [@bs.optional]
+    ascent: string,
+    [@bs.optional]
+    attributeName: string,
+    [@bs.optional]
+    attributeType: string,
+    [@bs.optional]
+    autoReverse: string,
+    [@bs.optional]
+    azimuth: string,
+    [@bs.optional]
+    baseFrequency: string,
+    [@bs.optional]
+    baseProfile: string,
+    [@bs.optional]
+    baselineShift: string,
+    [@bs.optional]
+    bbox: string,
+    [@bs.optional] [@bs.as "begin"]
+    begin_: string,
+    [@bs.optional]
+    bias: string,
+    [@bs.optional]
+    by: string,
+    [@bs.optional]
+    calcMode: string,
+    [@bs.optional]
+    capHeight: string,
+    [@bs.optional]
+    clip: string,
+    [@bs.optional]
+    clipPath: string,
+    [@bs.optional]
+    clipPathUnits: string,
+    [@bs.optional]
+    clipRule: string,
+    [@bs.optional]
+    colorInterpolation: string,
+    [@bs.optional]
+    colorInterpolationFilters: string,
+    [@bs.optional]
+    colorProfile: string,
+    [@bs.optional]
+    colorRendering: string,
+    [@bs.optional]
+    contentScriptType: string,
+    [@bs.optional]
+    contentStyleType: string,
+    [@bs.optional]
+    cursor: string,
+    [@bs.optional]
+    cx: string,
+    [@bs.optional]
+    cy: string,
+    [@bs.optional]
+    d: string,
+    [@bs.optional]
+    decelerate: string,
+    [@bs.optional]
+    descent: string,
+    [@bs.optional]
+    diffuseConstant: string,
+    [@bs.optional]
+    direction: string,
+    [@bs.optional]
+    display: string,
+    [@bs.optional]
+    divisor: string,
+    [@bs.optional]
+    dominantBaseline: string,
+    [@bs.optional]
+    dur: string,
+    [@bs.optional]
+    dx: string,
+    [@bs.optional]
+    dy: string,
+    [@bs.optional]
+    edgeMode: string,
+    [@bs.optional]
+    elevation: string,
+    [@bs.optional]
+    enableBackground: string,
+    [@bs.optional] [@bs.as "end"]
+    end_: string,
+    [@bs.optional]
+    exponent: string,
+    [@bs.optional]
+    externalResourcesRequired: string,
+    [@bs.optional]
+    fill: string,
+    [@bs.optional]
+    fillOpacity: string,
+    [@bs.optional]
+    fillRule: string,
+    [@bs.optional]
+    filter: string,
+    [@bs.optional]
+    filterRes: string,
+    [@bs.optional]
+    filterUnits: string,
+    [@bs.optional]
+    floodColor: string,
+    [@bs.optional]
+    floodOpacity: string,
+    [@bs.optional]
+    focusable: string,
+    [@bs.optional]
+    fontFamily: string,
+    [@bs.optional]
+    fontSize: string,
+    [@bs.optional]
+    fontSizeAdjust: string,
+    [@bs.optional]
+    fontStretch: string,
+    [@bs.optional]
+    fontStyle: string,
+    [@bs.optional]
+    fontVariant: string,
+    [@bs.optional]
+    fontWeight: string,
+    [@bs.optional]
+    fomat: string,
+    [@bs.optional]
+    from: string,
+    [@bs.optional]
+    fx: string,
+    [@bs.optional]
+    fy: string,
+    [@bs.optional]
+    g1: string,
+    [@bs.optional]
+    g2: string,
+    [@bs.optional]
+    glyphName: string,
+    [@bs.optional]
+    glyphOrientationHorizontal: string,
+    [@bs.optional]
+    glyphOrientationVertical: string,
+    [@bs.optional]
+    glyphRef: string,
+    [@bs.optional]
+    gradientTransform: string,
+    [@bs.optional]
+    gradientUnits: string,
+    [@bs.optional]
+    hanging: string,
+    [@bs.optional]
+    horizAdvX: string,
+    [@bs.optional]
+    horizOriginX: string,
+    [@bs.optional]
+    ideographic: string,
+    [@bs.optional]
+    imageRendering: string,
+    [@bs.optional] [@bs.as "in"]
+    in_: string,
+    [@bs.optional]
+    intercept: string,
+    [@bs.optional]
+    k: string,
+    [@bs.optional]
+    k1: string,
+    [@bs.optional]
+    k2: string,
+    [@bs.optional]
+    k3: string,
+    [@bs.optional]
+    k4: string,
+    [@bs.optional]
+    kernelMatrix: string,
+    [@bs.optional]
+    kernelUnitLength: string,
+    [@bs.optional]
+    kerning: string,
+    [@bs.optional]
+    keyPoints: string,
+    [@bs.optional]
+    keySplines: string,
+    [@bs.optional]
+    keyTimes: string,
+    [@bs.optional]
+    lengthAdjust: string,
+    [@bs.optional]
+    letterSpacing: string,
+    [@bs.optional]
+    lightingColor: string,
+    [@bs.optional]
+    limitingConeAngle: string,
+    [@bs.optional]
+    local: string,
+    [@bs.optional]
+    markerEnd: string,
+    [@bs.optional]
+    markerHeight: string,
+    [@bs.optional]
+    markerMid: string,
+    [@bs.optional]
+    markerStart: string,
+    [@bs.optional]
+    markerUnits: string,
+    [@bs.optional]
+    markerWidth: string,
+    [@bs.optional]
+    mask: string,
+    [@bs.optional]
+    maskContentUnits: string,
+    [@bs.optional]
+    maskUnits: string,
+    [@bs.optional]
+    mathematical: string,
+    [@bs.optional]
+    mode: string,
+    [@bs.optional]
+    numOctaves: string,
+    [@bs.optional]
+    offset: string,
+    [@bs.optional]
+    opacity: string,
+    [@bs.optional]
+    operator: string,
+    [@bs.optional]
+    order: string,
+    [@bs.optional]
+    orient: string,
+    [@bs.optional]
+    orientation: string,
+    [@bs.optional]
+    origin: string,
+    [@bs.optional]
+    overflow: string,
+    [@bs.optional]
+    overflowX: string,
+    [@bs.optional]
+    overflowY: string,
+    [@bs.optional]
+    overlinePosition: string,
+    [@bs.optional]
+    overlineThickness: string,
+    [@bs.optional]
+    paintOrder: string,
+    [@bs.optional]
+    panose1: string,
+    [@bs.optional]
+    pathLength: string,
+    [@bs.optional]
+    patternContentUnits: string,
+    [@bs.optional]
+    patternTransform: string,
+    [@bs.optional]
+    patternUnits: string,
+    [@bs.optional]
+    pointerEvents: string,
+    [@bs.optional]
+    points: string,
+    [@bs.optional]
+    pointsAtX: string,
+    [@bs.optional]
+    pointsAtY: string,
+    [@bs.optional]
+    pointsAtZ: string,
+    [@bs.optional]
+    preserveAlpha: string,
+    [@bs.optional]
+    preserveAspectRatio: string,
+    [@bs.optional]
+    primitiveUnits: string,
+    [@bs.optional]
+    r: string,
+    [@bs.optional]
+    radius: string,
+    [@bs.optional]
+    refX: string,
+    [@bs.optional]
+    refY: string,
+    [@bs.optional]
+    renderingIntent: string,
+    [@bs.optional]
+    repeatCount: string,
+    [@bs.optional]
+    repeatDur: string,
+    [@bs.optional]
+    requiredExtensions: string,
+    [@bs.optional]
+    requiredFeatures: string,
+    [@bs.optional]
+    restart: string,
+    [@bs.optional]
+    result: string,
+    [@bs.optional]
+    rotate: string,
+    [@bs.optional]
+    rx: string,
+    [@bs.optional]
+    ry: string,
+    [@bs.optional]
+    scale: string,
+    [@bs.optional]
+    seed: string,
+    [@bs.optional]
+    shapeRendering: string,
+    [@bs.optional]
+    slope: string,
+    [@bs.optional]
+    spacing: string,
+    [@bs.optional]
+    specularConstant: string,
+    [@bs.optional]
+    specularExponent: string,
+    [@bs.optional]
+    speed: string,
+    [@bs.optional]
+    spreadMethod: string,
+    [@bs.optional]
+    startOffset: string,
+    [@bs.optional]
+    stdDeviation: string,
+    [@bs.optional]
+    stemh: string,
+    [@bs.optional]
+    stemv: string,
+    [@bs.optional]
+    stitchTiles: string,
+    [@bs.optional]
+    stopColor: string,
+    [@bs.optional]
+    stopOpacity: string,
+    [@bs.optional]
+    strikethroughPosition: string,
+    [@bs.optional]
+    strikethroughThickness: string,
+    [@bs.optional]
+    string,
+    [@bs.optional]
+    stroke: string,
+    [@bs.optional]
+    strokeDasharray: string,
+    [@bs.optional]
+    strokeDashoffset: string,
+    [@bs.optional]
+    strokeLinecap: string,
+    [@bs.optional]
+    strokeLinejoin: string,
+    [@bs.optional]
+    strokeMiterlimit: string,
+    [@bs.optional]
+    strokeOpacity: string,
+    [@bs.optional]
+    strokeWidth: string,
+    [@bs.optional]
+    surfaceScale: string,
+    [@bs.optional]
+    systemLanguage: string,
+    [@bs.optional]
+    tableValues: string,
+    [@bs.optional]
+    targetX: string,
+    [@bs.optional]
+    targetY: string,
+    [@bs.optional]
+    textAnchor: string,
+    [@bs.optional]
+    textDecoration: string,
+    [@bs.optional]
+    textLength: string,
+    [@bs.optional]
+    textRendering: string,
+    [@bs.optional] [@bs.as "to"]
+    to_: string,
+    [@bs.optional]
+    transform: string,
+    [@bs.optional]
+    u1: string,
+    [@bs.optional]
+    u2: string,
+    [@bs.optional]
+    underlinePosition: string,
+    [@bs.optional]
+    underlineThickness: string,
+    [@bs.optional]
+    unicode: string,
+    [@bs.optional]
+    unicodeBidi: string,
+    [@bs.optional]
+    unicodeRange: string,
+    [@bs.optional]
+    unitsPerEm: string,
+    [@bs.optional]
+    vAlphabetic: string,
+    [@bs.optional]
+    vHanging: string,
+    [@bs.optional]
+    vIdeographic: string,
+    [@bs.optional]
+    vMathematical: string,
+    [@bs.optional]
+    values: string,
+    [@bs.optional]
+    vectorEffect: string,
+    [@bs.optional]
+    version: string,
+    [@bs.optional]
+    vertAdvX: string,
+    [@bs.optional]
+    vertAdvY: string,
+    [@bs.optional]
+    vertOriginX: string,
+    [@bs.optional]
+    vertOriginY: string,
+    [@bs.optional]
+    viewBox: string,
+    [@bs.optional]
+    viewTarget: string,
+    [@bs.optional]
+    visibility: string,
+    /*width::string? =>*/
+    [@bs.optional]
+    widths: string,
+    [@bs.optional]
+    wordSpacing: string,
+    [@bs.optional]
+    writingMode: string,
+    [@bs.optional]
+    x: string,
+    [@bs.optional]
+    x1: string,
+    [@bs.optional]
+    x2: string,
+    [@bs.optional]
+    xChannelSelector: string,
+    [@bs.optional]
+    xHeight: string,
+    [@bs.optional]
+    xlinkActuate: string,
+    [@bs.optional]
+    xlinkArcrole: string,
+    [@bs.optional]
+    xlinkHref: string,
+    [@bs.optional]
+    xlinkRole: string,
+    [@bs.optional]
+    xlinkShow: string,
+    [@bs.optional]
+    xlinkTitle: string,
+    [@bs.optional]
+    xlinkType: string,
+    [@bs.optional]
+    xmlns: string,
+    [@bs.optional]
+    xmlnsXlink: string,
+    [@bs.optional]
+    xmlBase: string,
+    [@bs.optional]
+    xmlLang: string,
+    [@bs.optional]
+    xmlSpace: string,
+    [@bs.optional]
+    y: string,
+    [@bs.optional]
+    y1: string,
+    [@bs.optional]
+    y2: string,
+    [@bs.optional]
+    yChannelSelector: string,
+    [@bs.optional]
+    z: string,
+    [@bs.optional]
+    zoomAndPan: string,
+    /* RDFa */
+    [@bs.optional]
+    about: string,
+    [@bs.optional]
+    datatype: string,
+    [@bs.optional]
+    inlist: string,
+    [@bs.optional]
+    prefix: string,
+    [@bs.optional]
+    property: string,
+    [@bs.optional]
+    resource: string,
+    [@bs.optional]
+    typeof: string,
+    [@bs.optional]
+    vocab: string,
+    /* react-specific */
+    [@bs.optional]
+    dangerouslySetInnerHTML: {. "__html": string},
+    [@bs.optional]
+    suppressContentEditableWarning: bool,
+  };
+};
+
+include Elements;

--- a/src/ReactDOMRe.re
+++ b/src/ReactDOMRe.re
@@ -2138,17 +2138,8 @@ external createElement:
   (string, ~props: props=?, array(React.element)) => React.element =
   "createElement";
 
-[@bs.module "React"] [@deprecated "Please use JSX syntax directly."]
-external jsxKeyed: (string, domProps, string) => React.element = "jsx";
-
-[@bs.module "React"] [@deprecated "Please use JSX syntax directly."]
-external jsx: (string, domProps) => React.element = "jsx";
-
-[@bs.module "React"] [@deprecated "Please use JSX syntax directly."]
-external jsxs: (string, domProps) => React.element = "jsxs";
-
-[@bs.module "React"] [@deprecated "Please use JSX syntax directly."]
-external jsxsKeyed: (string, domProps, string) => React.element = "jsxs";
+[@deprecated "Please use JSX syntax directly."];
+external makeDOMComponent: string => React.component(domProps) = "%identity";
 
 /* Only wanna expose createElementVariadic here. Don't wanna write an interface file */
 include (

--- a/src/ReactDOMRe.re
+++ b/src/ReactDOMRe.re
@@ -1122,7 +1122,7 @@ type domProps = {
   suppressContentEditableWarning: bool,
 };
 
-[@bs.splice] [@bs.module "react"]
+[@bs.splice] [@bs.module "react"] [@deprecated "Please use React.array or JSX syntax."]
 external createDOMElementVariadic:
   (string, ~props: domProps=?, array(React.element)) => React.element =
   "createElement";
@@ -2133,10 +2133,22 @@ external objToDOMProps: Js.t({..}) => props = "%identity";
 [@deprecated "Please use ReactDOMRe.props instead"]
 type reactDOMProps = props;
 
-[@bs.splice] [@bs.val] [@bs.module "react"]
+[@bs.splice] [@bs.val] [@bs.module "react"] [@deprecated "Please use React.array or JSX syntax."]
 external createElement:
   (string, ~props: props=?, array(React.element)) => React.element =
   "createElement";
+
+[@bs.module "React"] [@deprecated "Please use JSX syntax directly."]
+external jsxKeyed: (string, domProps, string) => React.element = "jsx";
+
+[@bs.module "React"] [@deprecated "Please use JSX syntax directly."]
+external jsx: (string, domProps) => React.element = "jsx";
+
+[@bs.module "React"] [@deprecated "Please use JSX syntax directly."]
+external jsxs: (string, domProps) => React.element = "jsxs";
+
+[@bs.module "React"] [@deprecated "Please use JSX syntax directly."]
+external jsxsKeyed: (string, domProps, string) => React.element = "jsxs";
 
 /* Only wanna expose createElementVariadic here. Don't wanna write an interface file */
 include (
@@ -2150,6 +2162,7 @@ include (
               'returnTypeOfTheFunction =
               "apply";
 
+            [@deprecated "Please use React.array or JSX syntax."]
             let createElementVariadic = (domClassName, ~props=?, children) => {
               let variadicArguments =
                 [|Obj.magic(domClassName), Obj.magic(props)|]
@@ -2162,6 +2175,7 @@ include (
                                          );
             };
           }: {
+            [@deprecated "Please use React.array or JSX syntax."]
             let createElementVariadic:
               (string, ~props: props=?, array(React.element)) => React.element;
           }


### PR DESCRIPTION
This PR starts the process of moving `<div />` from getting compiled to `React.createElement("div", ...)` to forcing `<ReactDOM.div />` which would compile to `React.createElement("div", ...)`. This has a bunch of side-effects but from an API perspective it makes Upper- and lower-cased PPX no longer distinguished. JSX `<x>` just becomes sugar for grabbing a function pair `x` and `xProps` in scope.

This is just a proof of concept and a general idea. I would love to have discussion about the following:

## Is this a good/worthwhile idea?

This is a major change with big consequences.

Pros:
* better type safety and correctness when rendering DOM nodes
* frees up `<lowercase />` JSX syntax to find functions in scope

Cons:
* large breaking change - `<div />` goes to `<ReactDOM.div />`
* use of DOM primitives becomes a bit harder - must add ReactDOM to all calls or encourage `open`, which isn't great to use widely

## The best way to generate and maintain this code
This file will be absolutely massive and incredibly prone to error if I manually create all of these. What ideas do you have for initial generation and maintenance of these?

## Final API
Does `ReactDOM` make sense for this? Should it live somewhere else?