### PR TITLE
Move reason-test-framework to devDependency

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -5,6 +5,6 @@
   "package-specs": [{ "module": "commonjs", "in-source": true }],
   "suffix": ".bs.js",
   "refmt": 3,
-  "bs-dependencies": ["reason-test-framework"],
+  "bs-dev-dependencies": ["reason-test-framework"],
   "bsc-flags": ["-bs-no-version-header"]
 }

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,7 +1,7 @@
 {
   "name": "reason-react",
   "reason": { "react-jsx": 3 },
-  "sources": ["src", { "dir": "test", "dev": true }],
+  "sources": ["src", { "dir": "test", "type": "dev" }],
   "package-specs": [{ "module": "commonjs", "in-source": true }],
   "suffix": ".bs.js",
   "refmt": 3,


### PR DESCRIPTION
@anmonteiro made me notice that on another repository. 

I guess this should be merged before the next release. 