### PR TITLE
Pointer events.

### DIFF
--- a/src/ReactDOMRe.re
+++ b/src/ReactDOMRe.re
@@ -545,6 +545,27 @@ type domProps = {
   onTouchMove: ReactEvent.Touch.t => unit,
   [@bs.optional]
   onTouchStart: ReactEvent.Touch.t => unit,
+  /* Pointer events */
+  [@bs.optional]
+  onPointerOver: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerEnter: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerDown: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerMove: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerUp: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerCancel: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerOut: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerLeave: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onGotPointerCapture: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onLostPointerCapture: ReactEvent.Pointer.t => unit,
   /* UI events */
   [@bs.optional]
   onScroll: ReactEvent.UI.t => unit,
@@ -1551,6 +1572,27 @@ type props = {
   onTouchMove: ReactEvent.Touch.t => unit,
   [@bs.optional]
   onTouchStart: ReactEvent.Touch.t => unit,
+  /* Pointer events */
+  [@bs.optional]
+  onPointerOver: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerEnter: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerDown: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerMove: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerUp: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerCancel: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerOut: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onPointerLeave: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onGotPointerCapture: ReactEvent.Pointer.t => unit,
+  [@bs.optional]
+  onLostPointerCapture: ReactEvent.Pointer.t => unit,
   /* UI events */
   [@bs.optional]
   onScroll: ReactEvent.UI.t => unit,

--- a/src/ReactEvent.re
+++ b/src/ReactEvent.re
@@ -134,6 +134,53 @@ module Mouse = {
   [@bs.get] external shiftKey: t => bool = "shiftKey";
 };
 
+module Pointer = {
+  type tag;
+  type t = synthetic(tag);
+  include MakeEventWithType({
+    type nonrec t = t;
+  });
+
+  // UIEvent
+  [@bs.get] external detail: t => int = "detail";
+  [@bs.get] external view: t => Dom.window = "view"; /* Should return DOMAbstractView/WindowProxy */
+
+  // MouseEvent
+  [@bs.get] external screenX: t => int = "screenX";
+  [@bs.get] external screenY: t => int = "screenY";
+  [@bs.get] external clientX: t => int = "clientX";
+  [@bs.get] external clientY: t => int = "clientY";
+  [@bs.get] external pageX: t => int = "pageX";
+  [@bs.get] external pageY: t => int = "pageY";
+  [@bs.get] external movementX: t => int = "movementX";
+  [@bs.get] external movementY: t => int = "movementY";
+
+  [@bs.get] external ctrlKey: t => bool = "ctrlKey";
+  [@bs.get] external shiftKey: t => bool = "shiftKey";
+  [@bs.get] external altKey: t => bool = "altKey";
+  [@bs.get] external metaKey: t => bool = "metaKey";
+  [@bs.send]
+  external getModifierState: (t, string) => bool = "getModifierState";
+
+  [@bs.get] external button: t => int = "button";
+  [@bs.get] external buttons: t => int = "buttons";
+
+  [@bs.get] [@bs.return nullable]
+  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
+
+  // PointerEvent
+  [@bs.get] external pointerId: t => float = "pointerId";
+  [@bs.get] external width: t => float = "width";
+  [@bs.get] external height: t => float = "height";
+  [@bs.get] external pressure: t => float = "pressure";
+  [@bs.get] external tangentialPressure: t => float = "tangentialPressure";
+  [@bs.get] external tiltX: t => int = "tiltX";
+  [@bs.get] external tiltY: t => int = "tiltY";
+  [@bs.get] external twist: t => int = "twist";
+  [@bs.get] external pointerType: t => string = "pointerType";
+  [@bs.get] external isPrimary: t => bool = "isPrimary";
+};
+
 module Selection = {
   type tag;
   type t = synthetic(tag);

--- a/src/ReactEvent.re
+++ b/src/ReactEvent.re
@@ -3,7 +3,7 @@ type synthetic('a);
 module MakeEventWithType = (Type: {type t;}) => {
   [@bs.get] external bubbles: Type.t => bool = "bubbles";
   [@bs.get] external cancelable: Type.t => bool = "cancelable";
-  [@bs.get] external currentTarget: Type.t => Js.t({..}) = "currentTarget"; /* Should return Dom.eventTarget */
+  [@bs.get] external currentTarget: Type.t => Dom.eventTarget = "currentTarget";
   [@bs.get] external defaultPrevented: Type.t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: Type.t => int = "eventPhase";
   [@bs.get] external isTrusted: Type.t => bool = "isTrusted";
@@ -14,7 +14,7 @@ module MakeEventWithType = (Type: {type t;}) => {
   [@bs.send] external stopPropagation: Type.t => unit = "stopPropagation";
   [@bs.send]
   external isPropagationStopped: Type.t => bool = "isPropagationStopped";
-  [@bs.get] external target: Type.t => Js.t({..}) = "target"; /* Should return Dom.eventTarget */
+  [@bs.get] external target: Type.t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: Type.t => float = "timeStamp";
   [@bs.get] external type_: Type.t => string = "type";
   [@bs.send] external persist: Type.t => unit = "persist";
@@ -26,7 +26,7 @@ module Synthetic = {
   [@bs.get] external bubbles: synthetic('a) => bool = "bubbles";
   [@bs.get] external cancelable: synthetic('a) => bool = "cancelable";
   [@bs.get]
-  external currentTarget: synthetic('a) => Js.t({..}) = "currentTarget"; /* Should return Dom.eventTarget */
+  external currentTarget: synthetic('a) => Dom.eventTarget = "currentTarget";
   [@bs.get]
   external defaultPrevented: synthetic('a) => bool = "defaultPrevented";
   [@bs.get] external eventPhase: synthetic('a) => int = "eventPhase";
@@ -42,7 +42,7 @@ module Synthetic = {
   [@bs.send]
   external isPropagationStopped: synthetic('a) => bool =
     "isPropagationStopped";
-  [@bs.get] external target: synthetic('a) => Js.t({..}) = "target"; /* Should return Dom.eventTarget */
+  [@bs.get] external target: synthetic('a) => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: synthetic('a) => float = "timeStamp";
   [@bs.get] external type_: synthetic('a) => string = "type";
   [@bs.send] external persist: synthetic('a) => unit = "persist";
@@ -166,10 +166,10 @@ module Pointer = {
   [@bs.get] external buttons: t => int = "buttons";
 
   [@bs.get] [@bs.return nullable]
-  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
+  external relatedTarget: t => option(Dom.eventTarget) = "relatedTarget";
 
   // PointerEvent
-  [@bs.get] external pointerId: t => float = "pointerId";
+  [@bs.get] external pointerId: t => Dom.eventPointerId = "pointerId";
   [@bs.get] external width: t => float = "width";
   [@bs.get] external height: t => float = "height";
   [@bs.get] external pressure: t => float = "pressure";

--- a/src/ReactEvent.re
+++ b/src/ReactEvent.re
@@ -57,7 +57,7 @@ module Clipboard = {
   include MakeEventWithType({
     type nonrec t = t;
   });
-  [@bs.get] external clipboardData: t => Dom.dataTransfer = "clipboardData";
+  [@bs.get] external clipboardData: t => Js.t({..}) = "clipboardData"; /* Should return Dom.dataTransfer */
 };
 
 module Composition = {
@@ -97,7 +97,7 @@ module Focus = {
     type nonrec t = t;
   });
   [@bs.get] [@bs.return nullable]
-  external relatedTarget: t => option(Dom.eventTarget) = "relatedTarget";
+  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
 };
 
 module Form = {
@@ -128,7 +128,7 @@ module Mouse = {
   [@bs.get] external pageX: t => int = "pageX";
   [@bs.get] external pageY: t => int = "pageY";
   [@bs.get] [@bs.return nullable]
-  external relatedTarget: t => option(Dom.eventTarget) = "relatedTarget";
+  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
   [@bs.get] external screenX: t => int = "screenX";
   [@bs.get] external screenY: t => int = "screenY";
   [@bs.get] external shiftKey: t => bool = "shiftKey";

--- a/src/ReactEvent.re
+++ b/src/ReactEvent.re
@@ -169,7 +169,7 @@ module Pointer = {
   external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
 
   // PointerEvent
-  [@bs.get] external pointerId: t => float = "pointerId";
+  [@bs.get] external pointerId: t => Dom.eventPointerId = "pointerId";
   [@bs.get] external width: t => float = "width";
   [@bs.get] external height: t => float = "height";
   [@bs.get] external pressure: t => float = "pressure";

--- a/src/ReactEvent.re
+++ b/src/ReactEvent.re
@@ -57,7 +57,7 @@ module Clipboard = {
   include MakeEventWithType({
     type nonrec t = t;
   });
-  [@bs.get] external clipboardData: t => Js.t({..}) = "clipboardData"; /* Should return Dom.dataTransfer */
+  [@bs.get] external clipboardData: t => Dom.dataTransfer = "clipboardData";
 };
 
 module Composition = {
@@ -97,7 +97,7 @@ module Focus = {
     type nonrec t = t;
   });
   [@bs.get] [@bs.return nullable]
-  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
+  external relatedTarget: t => option(Dom.eventTarget) = "relatedTarget";
 };
 
 module Form = {
@@ -128,7 +128,7 @@ module Mouse = {
   [@bs.get] external pageX: t => int = "pageX";
   [@bs.get] external pageY: t => int = "pageY";
   [@bs.get] [@bs.return nullable]
-  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
+  external relatedTarget: t => option(Dom.eventTarget) = "relatedTarget";
   [@bs.get] external screenX: t => int = "screenX";
   [@bs.get] external screenY: t => int = "screenY";
   [@bs.get] external shiftKey: t => bool = "shiftKey";

--- a/src/ReactEvent.re
+++ b/src/ReactEvent.re
@@ -3,7 +3,7 @@ type synthetic('a);
 module MakeEventWithType = (Type: {type t;}) => {
   [@bs.get] external bubbles: Type.t => bool = "bubbles";
   [@bs.get] external cancelable: Type.t => bool = "cancelable";
-  [@bs.get] external currentTarget: Type.t => Dom.eventTarget = "currentTarget";
+  [@bs.get] external currentTarget: Type.t => Js.t({..}) = "currentTarget"; /* Should return Dom.eventTarget */
   [@bs.get] external defaultPrevented: Type.t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: Type.t => int = "eventPhase";
   [@bs.get] external isTrusted: Type.t => bool = "isTrusted";
@@ -14,7 +14,7 @@ module MakeEventWithType = (Type: {type t;}) => {
   [@bs.send] external stopPropagation: Type.t => unit = "stopPropagation";
   [@bs.send]
   external isPropagationStopped: Type.t => bool = "isPropagationStopped";
-  [@bs.get] external target: Type.t => Dom.eventTarget = "target";
+  [@bs.get] external target: Type.t => Js.t({..}) = "target"; /* Should return Dom.eventTarget */
   [@bs.get] external timeStamp: Type.t => float = "timeStamp";
   [@bs.get] external type_: Type.t => string = "type";
   [@bs.send] external persist: Type.t => unit = "persist";
@@ -26,7 +26,7 @@ module Synthetic = {
   [@bs.get] external bubbles: synthetic('a) => bool = "bubbles";
   [@bs.get] external cancelable: synthetic('a) => bool = "cancelable";
   [@bs.get]
-  external currentTarget: synthetic('a) => Dom.eventTarget = "currentTarget";
+  external currentTarget: synthetic('a) => Js.t({..}) = "currentTarget"; /* Should return Dom.eventTarget */
   [@bs.get]
   external defaultPrevented: synthetic('a) => bool = "defaultPrevented";
   [@bs.get] external eventPhase: synthetic('a) => int = "eventPhase";
@@ -42,7 +42,7 @@ module Synthetic = {
   [@bs.send]
   external isPropagationStopped: synthetic('a) => bool =
     "isPropagationStopped";
-  [@bs.get] external target: synthetic('a) => Dom.eventTarget = "target";
+  [@bs.get] external target: synthetic('a) => Js.t({..}) = "target"; /* Should return Dom.eventTarget */
   [@bs.get] external timeStamp: synthetic('a) => float = "timeStamp";
   [@bs.get] external type_: synthetic('a) => string = "type";
   [@bs.send] external persist: synthetic('a) => unit = "persist";
@@ -166,10 +166,10 @@ module Pointer = {
   [@bs.get] external buttons: t => int = "buttons";
 
   [@bs.get] [@bs.return nullable]
-  external relatedTarget: t => option(Dom.eventTarget) = "relatedTarget";
+  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
 
   // PointerEvent
-  [@bs.get] external pointerId: t => Dom.eventPointerId = "pointerId";
+  [@bs.get] external pointerId: t => float = "pointerId";
   [@bs.get] external width: t => float = "width";
   [@bs.get] external height: t => float = "height";
   [@bs.get] external pressure: t => float = "pressure";

--- a/src/ReactEvent.rei
+++ b/src/ReactEvent.rei
@@ -88,7 +88,7 @@ module Clipboard: {
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
-  [@bs.get] external clipboardData: t => Dom.dataTransfer = "clipboardData";
+  [@bs.get] external clipboardData: t => Js.t({..}) = "clipboardData"; /* Should return Dom.dataTransfer */
 };
 
 module Composition: {
@@ -167,7 +167,7 @@ module Focus: {
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
   [@bs.get] [@bs.return nullable]
-  external relatedTarget: t => option(Dom.eventTarget) = "relatedTarget";
+  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
 };
 
 module Form: {
@@ -224,7 +224,7 @@ module Mouse: {
   [@bs.get] external pageX: t => int = "pageX";
   [@bs.get] external pageY: t => int = "pageY";
   [@bs.get] [@bs.return nullable]
-  external relatedTarget: t => option(Dom.eventTarget) = "relatedTarget";
+  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
   [@bs.get] external screenX: t => int = "screenX";
   [@bs.get] external screenY: t => int = "screenY";
   [@bs.get] external shiftKey: t => bool = "shiftKey";
@@ -236,8 +236,9 @@ module Pointer: {
 
   // Event
   [@bs.get] external type_: t => string = "type";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target"; /* Should return Dom.eventTarget */
   [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+ /* Should return Dom.eventTarget */
 
   [@bs.get] external eventPhase: t => int = "eventPhase";
 

--- a/src/ReactEvent.rei
+++ b/src/ReactEvent.rei
@@ -88,7 +88,7 @@ module Clipboard: {
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
-  [@bs.get] external clipboardData: t => Js.t({..}) = "clipboardData"; /* Should return Dom.dataTransfer */
+  [@bs.get] external clipboardData: t => Dom.dataTransfer = "clipboardData";
 };
 
 module Composition: {
@@ -167,7 +167,7 @@ module Focus: {
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
   [@bs.get] [@bs.return nullable]
-  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
+  external relatedTarget: t => option(Dom.eventTarget) = "relatedTarget";
 };
 
 module Form: {
@@ -224,7 +224,7 @@ module Mouse: {
   [@bs.get] external pageX: t => int = "pageX";
   [@bs.get] external pageY: t => int = "pageY";
   [@bs.get] [@bs.return nullable]
-  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
+  external relatedTarget: t => option(Dom.eventTarget) = "relatedTarget";
   [@bs.get] external screenX: t => int = "screenX";
   [@bs.get] external screenY: t => int = "screenY";
   [@bs.get] external shiftKey: t => bool = "shiftKey";
@@ -236,9 +236,8 @@ module Pointer: {
 
   // Event
   [@bs.get] external type_: t => string = "type";
-  [@bs.get] external target: t => Dom.eventTarget = "target"; /* Should return Dom.eventTarget */
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
- /* Should return Dom.eventTarget */
 
   [@bs.get] external eventPhase: t => int = "eventPhase";
 

--- a/src/ReactEvent.rei
+++ b/src/ReactEvent.rei
@@ -278,7 +278,7 @@ module Pointer: {
   external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
 
   // PointerEvent
-  [@bs.get] external pointerId: t => float = "pointerId";
+  [@bs.get] external pointerId: t => Dom.eventPointerId = "pointerId";
   [@bs.get] external width: t => float = "width";
   [@bs.get] external height: t => float = "height";
   [@bs.get] external pressure: t => float = "pressure";

--- a/src/ReactEvent.rei
+++ b/src/ReactEvent.rei
@@ -224,6 +224,72 @@ module Mouse: {
   [@bs.get] external shiftKey: t => bool = "shiftKey";
 };
 
+module Pointer: {
+  type tag;
+  type t = synthetic(tag);
+
+  // Event
+  [@bs.get] external type_: t => string = "type";
+  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+
+  [@bs.get] external eventPhase: t => int = "eventPhase";
+
+  [@bs.send] external stopPropagation: t => unit = "stopPropagation"; // aka cancelBubble
+  [@bs.get] external bubbles: t => bool = "bubbles";
+  [@bs.get] external cancelable: t => bool = "cancelable";
+  [@bs.send] external preventDefault: t => unit = "preventDefault";
+  [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
+
+  [@bs.get] external isTrusted: t => bool = "isTrusted";
+  [@bs.get] external timeStamp: t => float = "timeStamp";
+
+  // SyntheticEvent
+  [@bs.get] external nativeEvent: t => Js.t({..}) = "nativeEvent";
+  [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
+  [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
+  [@bs.send] external persist: t => unit = "persist";
+
+  // UIEvent
+  [@bs.get] external detail: t => int = "detail";
+  [@bs.get] external view: t => Dom.window = "view"; /* Should return DOMAbstractView/WindowProxy */
+
+  // MouseEvent
+  [@bs.get] external screenX: t => int = "screenX";
+  [@bs.get] external screenY: t => int = "screenY";
+  [@bs.get] external clientX: t => int = "clientX";
+  [@bs.get] external clientY: t => int = "clientY";
+  [@bs.get] external pageX: t => int = "pageX";
+  [@bs.get] external pageY: t => int = "pageY";
+  [@bs.get] external movementX: t => int = "movementX";
+  [@bs.get] external movementY: t => int = "movementY";
+
+  [@bs.get] external ctrlKey: t => bool = "ctrlKey";
+  [@bs.get] external shiftKey: t => bool = "shiftKey";
+  [@bs.get] external altKey: t => bool = "altKey";
+  [@bs.get] external metaKey: t => bool = "metaKey";
+  [@bs.send]
+  external getModifierState: (t, string) => bool = "getModifierState";
+
+  [@bs.get] external button: t => int = "button";
+  [@bs.get] external buttons: t => int = "buttons";
+
+  [@bs.get] [@bs.return nullable]
+  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
+
+  // PointerEvent
+  [@bs.get] external pointerId: t => float = "pointerId";
+  [@bs.get] external width: t => float = "width";
+  [@bs.get] external height: t => float = "height";
+  [@bs.get] external pressure: t => float = "pressure";
+  [@bs.get] external tangentialPressure: t => float = "tangentialPressure";
+  [@bs.get] external tiltX: t => int = "tiltX";
+  [@bs.get] external tiltY: t => int = "tiltY";
+  [@bs.get] external twist: t => int = "twist";
+  [@bs.get] external pointerType: t => string = "pointerType";
+  [@bs.get] external isPrimary: t => bool = "isPrimary";
+};
+
 module Selection: {
   type tag;
   type t = synthetic(tag);

--- a/src/ReactEvent.rei
+++ b/src/ReactEvent.rei
@@ -44,7 +44,7 @@ module Synthetic: {
   [@bs.get] external bubbles: synthetic('a) => bool = "bubbles";
   [@bs.get] external cancelable: synthetic('a) => bool = "cancelable";
   [@bs.get]
-  external currentTarget: synthetic('a) => Js.t({..}) = "currentTarget";
+  external currentTarget: synthetic('a) => Dom.eventTarget = "currentTarget";
   [@bs.get]
   external defaultPrevented: synthetic('a) => bool = "defaultPrevented";
   [@bs.get] external eventPhase: synthetic('a) => int = "eventPhase";
@@ -60,7 +60,7 @@ module Synthetic: {
   [@bs.send]
   external isPropagationStopped: synthetic('a) => bool =
     "isPropagationStopped";
-  [@bs.get] external target: synthetic('a) => Js.t({..}) = "target";
+  [@bs.get] external target: synthetic('a) => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: synthetic('a) => float = "timeStamp";
   [@bs.get] external type_: synthetic('a) => string = "type";
   [@bs.send] external persist: synthetic('a) => unit = "persist";
@@ -74,7 +74,8 @@ module Clipboard: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -83,7 +84,7 @@ module Clipboard: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -95,7 +96,8 @@ module Composition: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -104,7 +106,7 @@ module Composition: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -116,7 +118,8 @@ module Keyboard: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -125,7 +128,7 @@ module Keyboard: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -149,7 +152,8 @@ module Focus: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -158,7 +162,7 @@ module Focus: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -171,7 +175,8 @@ module Form: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -180,7 +185,7 @@ module Form: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -191,7 +196,8 @@ module Mouse: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -200,7 +206,7 @@ module Mouse: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -230,8 +236,9 @@ module Pointer: {
 
   // Event
   [@bs.get] external type_: t => string = "type";
-  [@bs.get] external target: t => Js.t({..}) = "target";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external target: t => Dom.eventTarget = "target"; /* Should return Dom.eventTarget */
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+ /* Should return Dom.eventTarget */
 
   [@bs.get] external eventPhase: t => int = "eventPhase";
 
@@ -275,10 +282,10 @@ module Pointer: {
   [@bs.get] external buttons: t => int = "buttons";
 
   [@bs.get] [@bs.return nullable]
-  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
+  external relatedTarget: t => option(Dom.eventTarget) = "relatedTarget";
 
   // PointerEvent
-  [@bs.get] external pointerId: t => float = "pointerId";
+  [@bs.get] external pointerId: t => Dom.eventPointerId = "pointerId";
   [@bs.get] external width: t => float = "width";
   [@bs.get] external height: t => float = "height";
   [@bs.get] external pressure: t => float = "pressure";
@@ -295,7 +302,8 @@ module Selection: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -304,7 +312,7 @@ module Selection: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -315,7 +323,8 @@ module Touch: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -324,7 +333,7 @@ module Touch: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -344,7 +353,8 @@ module UI: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -353,7 +363,7 @@ module UI: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -366,7 +376,8 @@ module Wheel: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -375,7 +386,7 @@ module Wheel: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -390,7 +401,8 @@ module Media: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -399,7 +411,7 @@ module Media: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -410,7 +422,8 @@ module Image: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -419,7 +432,7 @@ module Image: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -430,7 +443,8 @@ module Animation: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -439,7 +453,7 @@ module Animation: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -453,7 +467,8 @@ module Transition: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
+  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
+
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -462,7 +477,7 @@ module Transition: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external target: t => Dom.eventTarget = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";

--- a/src/ReactEvent.rei
+++ b/src/ReactEvent.rei
@@ -44,7 +44,7 @@ module Synthetic: {
   [@bs.get] external bubbles: synthetic('a) => bool = "bubbles";
   [@bs.get] external cancelable: synthetic('a) => bool = "cancelable";
   [@bs.get]
-  external currentTarget: synthetic('a) => Dom.eventTarget = "currentTarget";
+  external currentTarget: synthetic('a) => Js.t({..}) = "currentTarget";
   [@bs.get]
   external defaultPrevented: synthetic('a) => bool = "defaultPrevented";
   [@bs.get] external eventPhase: synthetic('a) => int = "eventPhase";
@@ -60,7 +60,7 @@ module Synthetic: {
   [@bs.send]
   external isPropagationStopped: synthetic('a) => bool =
     "isPropagationStopped";
-  [@bs.get] external target: synthetic('a) => Dom.eventTarget = "target";
+  [@bs.get] external target: synthetic('a) => Js.t({..}) = "target";
   [@bs.get] external timeStamp: synthetic('a) => float = "timeStamp";
   [@bs.get] external type_: synthetic('a) => string = "type";
   [@bs.send] external persist: synthetic('a) => unit = "persist";
@@ -74,8 +74,7 @@ module Clipboard: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -84,7 +83,7 @@ module Clipboard: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -96,8 +95,7 @@ module Composition: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -106,7 +104,7 @@ module Composition: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -118,8 +116,7 @@ module Keyboard: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -128,7 +125,7 @@ module Keyboard: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -152,8 +149,7 @@ module Focus: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -162,7 +158,7 @@ module Focus: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -175,8 +171,7 @@ module Form: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -185,7 +180,7 @@ module Form: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -196,8 +191,7 @@ module Mouse: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -206,7 +200,7 @@ module Mouse: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -236,9 +230,8 @@ module Pointer: {
 
   // Event
   [@bs.get] external type_: t => string = "type";
-  [@bs.get] external target: t => Dom.eventTarget = "target"; /* Should return Dom.eventTarget */
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
- /* Should return Dom.eventTarget */
+  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
 
   [@bs.get] external eventPhase: t => int = "eventPhase";
 
@@ -282,10 +275,10 @@ module Pointer: {
   [@bs.get] external buttons: t => int = "buttons";
 
   [@bs.get] [@bs.return nullable]
-  external relatedTarget: t => option(Dom.eventTarget) = "relatedTarget";
+  external relatedTarget: t => option(Js.t({..})) = "relatedTarget"; /* Should return Dom.eventTarget */
 
   // PointerEvent
-  [@bs.get] external pointerId: t => Dom.eventPointerId = "pointerId";
+  [@bs.get] external pointerId: t => float = "pointerId";
   [@bs.get] external width: t => float = "width";
   [@bs.get] external height: t => float = "height";
   [@bs.get] external pressure: t => float = "pressure";
@@ -302,8 +295,7 @@ module Selection: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -312,7 +304,7 @@ module Selection: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -323,8 +315,7 @@ module Touch: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -333,7 +324,7 @@ module Touch: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -353,8 +344,7 @@ module UI: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -363,7 +353,7 @@ module UI: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -376,8 +366,7 @@ module Wheel: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -386,7 +375,7 @@ module Wheel: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -401,8 +390,7 @@ module Media: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -411,7 +399,7 @@ module Media: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -422,8 +410,7 @@ module Image: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -432,7 +419,7 @@ module Image: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -443,8 +430,7 @@ module Animation: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -453,7 +439,7 @@ module Animation: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";
@@ -467,8 +453,7 @@ module Transition: {
   type t = synthetic(tag);
   [@bs.get] external bubbles: t => bool = "bubbles";
   [@bs.get] external cancelable: t => bool = "cancelable";
-  [@bs.get] external currentTarget: t => Dom.eventTarget = "currentTarget";
-
+  [@bs.get] external currentTarget: t => Js.t({..}) = "currentTarget";
   [@bs.get] external defaultPrevented: t => bool = "defaultPrevented";
   [@bs.get] external eventPhase: t => int = "eventPhase";
   [@bs.get] external isTrusted: t => bool = "isTrusted";
@@ -477,7 +462,7 @@ module Transition: {
   [@bs.send] external isDefaultPrevented: t => bool = "isDefaultPrevented";
   [@bs.send] external stopPropagation: t => unit = "stopPropagation";
   [@bs.send] external isPropagationStopped: t => bool = "isPropagationStopped";
-  [@bs.get] external target: t => Dom.eventTarget = "target";
+  [@bs.get] external target: t => Js.t({..}) = "target";
   [@bs.get] external timeStamp: t => float = "timeStamp";
   [@bs.get] external type_: t => string = "type";
   [@bs.send] external persist: t => unit = "persist";


### PR DESCRIPTION
I annotated these based on the pointer events spec.  I tested it out and was able to register these event handlers in `reason-react` and log the event fields.  However, I wasn't able to test any advanced features because `reason-react` doesn't implement `Element.setPointerCapture`.  This is implemented in `bs-webapi` though, so I tried importing that package, but it had an [incompatible type for `pointerId`](https://github.com/reasonml-community/bs-webapi-incubator/blob/bc0badfc40420e271f4b1703dd9c43bed7d68b13/src/Webapi/Webapi__Dom/Webapi__Dom__PointerEvent.re#L2).

I don't know how I can make these two packages compatible unless `reason-react` treats `bs-webapi` as a dependency and references its custom type.  @peterpme can we do that?