### PR TITLE
RFC: Ease Context.Provider API

### DIFF
--- a/docs/context-mixins.md
+++ b/docs/context-mixins.md
@@ -12,11 +12,7 @@ In order to use React's context, you need to create two things:
 /** ContextProvider.re */
 let themeContext = React.createContext("light");
 
-let makeProps = (~value, ~children, ()) => {
-  "value": value,
-  "children": children,
-};
-
+include React.Context; // Adds the makeProps external
 let make = React.Context.provider(themeContext);
 ```
 

--- a/src/React.re
+++ b/src/React.re
@@ -79,6 +79,15 @@ module Children = {
 module Context = {
   type t('props);
 
+  [@bs.obj]
+  external makeProps:
+    (~value: 'props, ~children: element, unit) =>
+    {
+      .
+      "value": 'props,
+      "children": element,
+    };
+
   [@bs.get]
   external provider:
     t('props) =>

--- a/test/React__test.re
+++ b/test/React__test.re
@@ -130,14 +130,7 @@ module DummyComponentThatMapsChildren = {
 module DummyContext = {
   let context = React.createContext(0);
   module Provider = {
-    [@bs.obj]
-    external makeProps:
-      (~value: int, ~children: React.element, unit) =>
-      {
-        .
-        "value": int,
-        "children": React.element,
-      };
+    include React.Context;
     let make = context->React.Context.provider;
   };
 


### PR DESCRIPTION
The necessity to make the user a the `makeProps` manually is quite cumbersome when creating a context provider.

The idea here would be to provide the default external (no runtime cost).

### Before

```reason
let themeContext = React.createContext("light");
let makeProps = (~value, ~children, ()) => {
  "value": value,
  "children": children,
};
let make = React.Context.provider(themeContext);
```

or

```reason
let themeContext = React.createContext("light");
[@bs.obj]
external makeProps:
  (~value: 'props, ~children: element, unit) =>
  {
    .
    "value": 'props,
    "children": element,
  };
let make = React.Context.provider(themeContext);
```

### After

```reason
let themeContext = React.createContext("light");
include React.Context;
let make = React.Context.provider(themeContext);
```
