### PR TITLE
Update ReactDOM docs

### DIFF
--- a/docs/adding-data-props.md
+++ b/docs/adding-data-props.md
@@ -7,7 +7,7 @@ Reason doesn't support using props with dashes right now, ie: `data-id` or `data
 ```reason
 /* Spread.re */
 [@react.component]
-let make = (~props, ~children) => ReasonReact.cloneElement(children, ~props, [||]);
+let make = (~props, ~children) => React.cloneElement(children, props);
 ```
 
 Using Spread:

--- a/docs/components.md
+++ b/docs/components.md
@@ -10,7 +10,7 @@ let make = (~name) => {
   let (count, setCount) = React.useState(() => 0);
 
   <div>
-    <p> {React.string(name ++ " clicked " ++ string_of_int(count) ++ " times")} </p>
+    <p> {React.string(name ++ " clicked " ++ Belt.Int.toString(count) ++ " times")} </p>
     <button onClick={_ => setCount(_ => count + 1)}>
       {React.string("Click me")}
     </button>
@@ -31,7 +31,7 @@ let make = (Props) => {
   let (count, setCount) = React.useState(() => 0);
 
   <div>
-    <p> {React.string(name ++ " clicked " ++ string_of_int(count) ++ " times")} </p>
+    <p> {React.string(name ++ " clicked " ++  Belt.Int.toString(count) ++ " times")} </p>
     <button onClick={_evt => setCount(count => count + 1)}>
       {React.string("Click me")}
     </button>
@@ -63,6 +63,20 @@ The component above could be called like this:
 <ComponentTakesChildren name="Imani">
   <div> {React.string("Effectively the child.")} </div>
 </ComponentTakesChildren>
+```
+
+## Rendering text, int, floats, arrays and null
+
+In order for the compiler to understand that rendering a string of text or a number is intentional, you need to explicitely write it:
+
+```reason
+<div>
+  {React.string("Hello")}
+  {React.int(3)}
+  {React.float(1.23)}
+  {React.array([|<div key="0"/>, <span key="1" />|])}
+  {React.null}
+</div>
 ```
 
 ## Hooks

--- a/docs/dom.md
+++ b/docs/dom.md
@@ -4,27 +4,16 @@ title: Working with DOM
 
 ## ReactDOM
 
-ReasonReact's ReactDOM module is called `ReactDOMRe`. The module exposes helpers that work with familiar ReactJS idioms. For example, to access `event.target.value`, you can do `ReactEvent.Form.target(event)##value`.
+ReasonReact's ReactDOM module is called `ReactDOM`. The module exposes helpers that work with familiar ReactJS idioms.
 
-- `render` : `(ReasonReact.reactElement, Dom.element) => unit`
+- `render` : `(React.element, Dom.element) => unit`
 - `unmountComponentAtNode` : `Dom.element => unit`
-- `findDOMNode` : `ReasonReact.reactRef => Dom.element`
-- `hydrate` : `(ReasonReact.reactElement, Dom.element) => unit`
-- `objToDOMProps` : `Js.t({..}) => ReactDOMRe.props` (see use-case in [Invalid Prop Name](invalid-prop-name.md))
-- `createElement` : `(string, ~props: ReactDOMRe.props=?, array(ReasonReact.reactElement)) => ReasonReact.reactElement`: the call that lower-case JSX turns into.
-- `createElementVariadic`: same as above, but a less performant version, used when there's a children spread and not a static array at the call site: `<div>...myChildren</div>`.
-- `domElementToObj` : `Dom.element => Js.t({..})`: turns a DOM element into a Js object whose fields you can dangerously access. Usually not needed.
-
-And 4 convenience utilities:
-
-- `renderToElementWithClassName` : `(ReasonReact.reactElement, string) => unit`: finds the (first) element with the provided class name and `render` to it.
-- `renderToElementWithId` : `(ReasonReact.reactElement, string) => unit`: finds the element with the provided id and `render` to it.
-- `hydrateToElementWithClassName`, `hydrateToElementWithId`: same.
+- `hydrate` : `(React.element, Dom.element) => unit`
+- `createPortal` : `(React.component('props), 'props) => React.element`
 
 ## ReactDOMServer
 
-ReasonReact's equivalent `ReactDOMServerRe` exposes:
+ReasonReact's equivalent `ReactDOMServer` exposes:
 
-- `renderToString` : `ReactRe.reactElement => string`
-
-- `renderToStaticMarkup` : `ReactRe.reactElement => string`
+- `renderToString` : `React.element => string`
+- `renderToStaticMarkup` : `React.element => string`

--- a/docs/event.md
+++ b/docs/event.md
@@ -4,7 +4,7 @@ title: Event
 
 ReasonReact events map cleanly to ReactJS [synthetic events](https://reactjs.org/docs/events.html). More info in the [inline docs](https://github.com/reasonml/reason-react/blob/master/src/ReactEvent.rei#L1).
 
-If you're accessing fields on your event object, like `event.target.value`, you'd use a combination of a `ReactDOMRe` helper and [BuckleScript's `##` object access FFI](https://bucklescript.github.io/docs/en/object.html#accessors):
+If you're accessing fields on your event object, like `event.target.value`, you'd use [BuckleScript's `##` object access FFI](https://bucklescript.github.io/docs/en/object.html#accessors):
 
 ```reason
 ReactEvent.Form.target(event)##value;
@@ -15,5 +15,3 @@ Or, equivalently, using the pipe first operator:
 ```reason
 event->ReactEvent.Form.target##value;
 ```
-
-More info on the `ReactDOMRe` module below in the [Working with DOM](dom.md) section.

--- a/docs/intro-example.md
+++ b/docs/intro-example.md
@@ -20,13 +20,26 @@ If you're writing your entire React app in Reason, you'll probably have a `React
 
 ```reason
 /* file: Index.re */
-ReactDOMRe.renderToElementWithId(<Greeting name="John" />, "root");
+switch (ReactDOM.querySelector("#root")) {
+| Some(root) => ReactDOM.render(<Greeting name="John" />, root)
+| None => ()
+}
 ```
 
 This is how you used to write this in plain Javascript (index.js):
+
 ```js
 /* file: index.js */
-ReactDOM.render(<Greeting name="John">, document.getElementById("root"));
+let root = document.getElementById("root");
+if(root != null) {
+  ReactDOM.render(<Greeting name="John" />, root);
+};
+```
+
+or if you prefer to be surprised with runtime errors:
+
+```js
+ReactDOM.render(<Greeting name="John" />, document.getElementById("root"));
 ```
 
 ### Using Greeting in an existing Javascript/Typescript App
@@ -36,14 +49,14 @@ It's easy to import a Reason component into your existing app. All Reason extens
 ```js
 /* file: App.js */
 
-import { make as Greeting } from './Greeting.bs'
+import { make as Greeting } from "./Greeting.bs";
 
 export default function App() {
-    return (
-        <div>
-            <Greeting name="Peter" />
-        </div>
-    )
+  return (
+    <div>
+      <Greeting name="Peter" />
+    </div>
+  );
 }
 ```
 

--- a/docs/invalid-prop-name.md
+++ b/docs/invalid-prop-name.md
@@ -9,11 +9,10 @@ For `aria-*` use camelCasing, e.g., `ariaLabel`. For DOM components, we'll trans
 For `data-*` this is a bit trickier; words with `-` in them aren't valid in Reason/OCaml. When you do want to write them, e.g., `<div data-name="click me" />`, use the following:
 
 ```reason
-ReactDOMRe.createElementVariadic(
-  "div",
-  ~props=(ReactDOMRe.objToDOMProps({"data-name": "click me"})),
-  [||]
-)
+React.cloneElement(
+  <div />,
+  {"data-name": "click me"}
+);
 ```
 
 For non-DOM components, you need to pick valid prop names.

--- a/docs/refs.md
+++ b/docs/refs.md
@@ -17,7 +17,7 @@ let make = () => {
 };
 ```
 
-DOM elements allow you to pass refs to track specific elements that have been rendered for side-effects outside of React's control. To do this you can use the `ReactDOMRe.Ref` module.
+DOM elements allow you to pass refs to track specific elements that have been rendered for side-effects outside of React's control. To do this you can use the `ReactDOM.Ref` module.
 
 ```reason
 [@react.component]
@@ -28,16 +28,16 @@ let make = () => {
     doSomething(divRef);
   });
 
-  <div ref={ReactDOMRe.Ref.domRef(divRef)} />;
+  <div ref={ReactDOM.Ref.domRef(divRef)} />;
 };
 ```
 
-For some cases it's easier to work with callback refs which get called when the DOM node changes. We support this use-case as well using `ReactDOMRe.Ref.callbackDomRef`.
+For some cases it's easier to work with callback refs which get called when the DOM node changes. We support this use-case as well using `ReactDOM.Ref.callbackDomRef`.
 
 ```reason
 [@react.component]
 let make = () => {
-  <div ref={ReactDOMRe.Ref.callbackDomRef(ref =>
+  <div ref={ReactDOM.Ref.callbackDomRef(ref =>
     doEffectWhenRefChanges(ref)
   )} />;
 };

--- a/docs/style.md
+++ b/docs/style.md
@@ -2,21 +2,21 @@
 title: Style
 ---
 
-Since CSS-in-JS is all the rage right now, we'll recommend our official pick soon. In the meantime, for inline styles, there's the `ReactDOMRe.Style.make` API:
+Since CSS-in-JS is all the rage right now, we'll recommend our official pick soon. In the meantime, for inline styles, there's the `ReactDOM.Style.make` API:
 
 ```reason
 <div style=(
-  ReactDOMRe.Style.make(~color="#444444", ~fontSize="68px", ())
+  ReactDOM.Style.make(~color="#444444", ~fontSize="68px", ())
 )/>
 ```
 
-It's a labeled (typed!) function call that maps to the familiar style object `{color: '#444444', fontSize: '68px'}`. **Note** that `make` returns an opaque `ReactDOMRe.style` type that you can't read into. We also expose a `ReactDOMRe.Style.combine` that takes in two `style`s and combine them.
+It's a labeled (typed!) function call that maps to the familiar style object `{color: '#444444', fontSize: '68px'}`. **Note** that `make` returns an opaque `ReactDOM.style` type that you can't read into. We also expose a `ReactDOM.Style.combine` that takes in two `style`s and combine them.
 
 ## Escape Hatch: `unsafeAddProp`
 
-The above `Style.make` API will safely type check every style field! However, we might have missed some more esoteric fields. If that's the case, the type system will tell you that the field you're trying to add doesn't exist. To remediate this, we're exposing a `ReactDOMRe.Style.unsafeAddProp` to dangerously add a field to a style:
+The above `Style.make` API will safely type check every style field! However, we might have missed some more esoteric fields. If that's the case, the type system will tell you that the field you're trying to add doesn't exist. To remediate this, we're exposing a `ReactDOM.Style.unsafeAddProp` to dangerously add a field to a style:
 
 ```reason
-let myStyle = ReactDOMRe.Style.make(~color="#444444", ~fontSize="68px", ());
-let newStyle = ReactDOMRe.Style.unsafeAddProp(myStyle, "width", "10px");
+let myStyle = ReactDOM.Style.make(~color="#444444", ~fontSize="68px", ());
+let newStyle = ReactDOM.Style.unsafeAddProp(myStyle, "width", "10px");
 ```

--- a/docs/ternary-shortcut.md
+++ b/docs/ternary-shortcut.md
@@ -2,4 +2,4 @@
 title: Ternary Shortcut
 ---
 
-ReactJS allows the pattern `showButton && <Button />`. While in this specific case, it's slightly shorter, in general, try not to do this in JS. In ReasonReact, you need to use `showButton ? <Button /> : ReasonReact.null`.
+ReactJS allows the pattern `showButton && <Button />`. While in this specific case, it's slightly shorter, in general, try not to do this in JS. In ReasonReact, you need to use `showButton ? <Button /> : React.null`.

--- a/src/README.md
+++ b/src/README.md
@@ -2,8 +2,16 @@ Welcome to the source of ReasonReact!
 
 Files overview:
 
-- `ReactDOMRe`: bindings to ReactDOM.
-- `ReactDOMServerRe`: bindings to ReactDOMServer.
+## Bindings
+
+- `React`: bindings to React.
+- `ReactDOM`: bindings to ReactDOM.
+- `ReactDOMServer`: bindings to ReactDOMServer.
 - `ReactEvent`: bindings to React's custom events system.
-- `ReasonReact`: core React bindings.
-- `ReasonReactOptimizedCreateClass`: our reasonReact component initialization uses React's createClass under the hood. This file's a tweaked version of it, with all the dependencies, warnings and invariants commented out (we don't need any of them anymore! Our types obsoleted them =D).
+- `ReactDOMStyle`: bindings to create `style` objects.
+
+## Extra
+
+- `ReactTestUtils`: helpers for testing your components
+- `ReasonReactErrorBoundary`: component to catch errors within your component tree
+- `ReasonReactRouter`: a simple, yet fully featured router with minimal memory allocations

--- a/test/React__test.re
+++ b/test/React__test.re
@@ -171,7 +171,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
     let container = getContainer(container);
 
     act(() => {
-      ReactDOMRe.render(<div> "Hello world!"->React.string </div>, container)
+      ReactDOM.render(<div> "Hello world!"->React.string </div>, container)
     });
 
     expect.bool(
@@ -185,7 +185,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
   test("can render null elements", ({expect}) => {
     let container = getContainer(container);
 
-    act(() => {ReactDOMRe.render(<div> React.null </div>, container)});
+    act(() => {ReactDOM.render(<div> React.null </div>, container)});
 
     expect.bool(
       container
@@ -199,7 +199,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
     let container = getContainer(container);
 
     act(() => {
-      ReactDOMRe.render(<div> "Hello"->React.string </div>, container)
+      ReactDOM.render(<div> "Hello"->React.string </div>, container)
     });
 
     expect.bool(
@@ -213,7 +213,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
   test("can render int elements", ({expect}) => {
     let container = getContainer(container);
 
-    act(() => {ReactDOMRe.render(<div> 12345->React.int </div>, container)});
+    act(() => {ReactDOM.render(<div> 12345->React.int </div>, container)});
 
     expect.bool(
       container
@@ -226,9 +226,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
   test("can render float elements", ({expect}) => {
     let container = getContainer(container);
 
-    act(() => {
-      ReactDOMRe.render(<div> 12.345->React.float </div>, container)
-    });
+    act(() => {ReactDOM.render(<div> 12.345->React.float </div>, container)});
 
     expect.bool(
       container
@@ -244,9 +242,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
       [|1, 2, 3|]
       ->Array.map(item => {<div key={j|$item|j}> item->React.int </div>});
 
-    act(() => {
-      ReactDOMRe.render(<div> array->React.array </div>, container)
-    });
+    act(() => {ReactDOM.render(<div> array->React.array </div>, container)});
 
     expect.bool(
       container
@@ -274,7 +270,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
     let container = getContainer(container);
 
     act(() => {
-      ReactDOMRe.render(
+      ReactDOM.render(
         React.cloneElement(
           <div> "Hello"->React.string </div>,
           {"data-name": "World"},
@@ -297,7 +293,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
   test("can render react components", ({expect}) => {
     let container = getContainer(container);
 
-    act(() => {ReactDOMRe.render(<DummyStatefulComponent />, container)});
+    act(() => {ReactDOM.render(<DummyStatefulComponent />, container)});
 
     expect.bool(
       container
@@ -333,7 +329,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
   test("can render react components with reducers", ({expect}) => {
     let container = getContainer(container);
 
-    act(() => {ReactDOMRe.render(<DummyReducerComponent />, container)});
+    act(() => {ReactDOM.render(<DummyReducerComponent />, container)});
 
     expect.bool(
       container
@@ -401,7 +397,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
     let container = getContainer(container);
 
     act(() => {
-      ReactDOMRe.render(<DummyReducerWithMapStateComponent />, container)
+      ReactDOM.render(<DummyReducerWithMapStateComponent />, container)
     });
 
     expect.bool(
@@ -471,19 +467,19 @@ describe("React", ({test, beforeEach, afterEach}) => {
     let callback = Mock.fn();
 
     act(() => {
-      ReactDOMRe.render(
+      ReactDOM.render(
         <DummyComponentWithEffect value=0 callback />,
         container,
       )
     });
     act(() => {
-      ReactDOMRe.render(
+      ReactDOM.render(
         <DummyComponentWithEffect value=1 callback />,
         container,
       )
     });
     act(() => {
-      ReactDOMRe.render(
+      ReactDOM.render(
         <DummyComponentWithEffect value=1 callback />,
         container,
       )
@@ -500,19 +496,19 @@ describe("React", ({test, beforeEach, afterEach}) => {
     let callback = Mock.fn();
 
     act(() => {
-      ReactDOMRe.render(
+      ReactDOM.render(
         <DummyComponentWithLayoutEffect value=0 callback />,
         container,
       )
     });
     act(() => {
-      ReactDOMRe.render(
+      ReactDOM.render(
         <DummyComponentWithLayoutEffect value=1 callback />,
         container,
       )
     });
     act(() => {
-      ReactDOMRe.render(
+      ReactDOM.render(
         <DummyComponentWithLayoutEffect value=1 callback />,
         container,
       )
@@ -539,10 +535,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
     };
 
     act(() => {
-      ReactDOMRe.render(
-        <DummyComponentWithRefAndEffect callback />,
-        container,
-      )
+      ReactDOM.render(<DummyComponentWithRefAndEffect callback />, container)
     });
 
     expect.value(myRef.contents->Option.map(item => item.current)).toEqual(
@@ -554,7 +547,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
     let container = getContainer(container);
 
     act(() => {
-      ReactDOMRe.render(
+      ReactDOM.render(
         <DummyComponentThatMapsChildren>
           <div> 1->React.int </div>
           <div> 2->React.int </div>
@@ -590,7 +583,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
     let container = getContainer(container);
 
     act(() => {
-      ReactDOMRe.render(
+      ReactDOM.render(
         <DummyContext.Provider value=10>
           <DummyContext.Consumer />
         </DummyContext.Provider>,
@@ -611,7 +604,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
     let value = ref("");
 
     act(() => {
-      ReactDOMRe.render(
+      ReactDOM.render(
         <input
           name="test-input"
           onChange={event => {value :=  event->ReactEvent.Form.target##value}}
@@ -632,7 +625,7 @@ describe("React", ({test, beforeEach, afterEach}) => {
     let container = getContainer(container);
 
     act(() => {
-      ReactDOMRe.render(
+      ReactDOM.render(
         <ReasonReactErrorBoundary
           fallback={({error, info}) => {
             expect.value(error).toEqual(ComponentThatThrows.TestError);

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -41,6 +41,9 @@
       "element-type-is-invalid": {
         "title": "Element Type is Invalid Runtime Error"
       },
+      "error-boundaries": {
+        "title": "Error boundaries"
+      },
       "event": {
         "title": "Event"
       },
@@ -147,7 +150,7 @@
         "title": "Subscriptions Helper"
       },
       "tailwind-css": {
-        "title": "Tailwind CSS"
+        "title": "Styling: Tailwind CSS"
       },
       "ternary-shortcut": {
         "title": "Ternary Shortcut"


### PR DESCRIPTION
Took the opportunity to:

- rename `ReactDOMRe` occurrences to `ReactDOM`
- remove `ReasonReact` bindings calls and replace them with modern `React` ones
- replace OCaml's `*_of_*` with Belt, so that it doesn't seem inconsistent in terms of casing
- added a mention of `React.string/int/float…` in the new docs (only appeared in the deprecated one)
- feature `ReactDOM.querySelector` instead of `renderToElementWith*` in docs