### PR TITLE
Added `as` property to DOM props

### DIFF
--- a/src/ReactDOM.re
+++ b/src/ReactDOM.re
@@ -1203,6 +1203,8 @@ module Props = {
     [@bs.optional]
     itemType: string, /* uri */
     /* tag-specific html attributes */
+    [@bs.optional] [@bs.as "as"]
+    as_: string,
     [@bs.optional]
     accept: string,
     [@bs.optional]

--- a/src/ReactDOM.re
+++ b/src/ReactDOM.re
@@ -200,6 +200,8 @@ module Props = {
     [@bs.optional]
     itemType: string, /* uri */
     /* tag-specific html attributes */
+    [@bs.optional] [@bs.as "as"]
+    as_: string,
     [@bs.optional]
     accept: string,
     [@bs.optional]


### PR DESCRIPTION
See https://html.spec.whatwg.org/multipage/links.html#link-type-preload for when this can be used. For example:

```html
<link rel="preload" as="style" href="..." />
```