### PR TITLE
Add playsInline video attribute

### DIFF
--- a/src/ReactDOM.re
+++ b/src/ReactDOM.re
@@ -329,6 +329,8 @@ module Props = {
     [@bs.optional]
     placeholder: string,
     [@bs.optional]
+    playsInline: bool,
+    [@bs.optional]
     poster: string, /* uri */
     [@bs.optional]
     preload: string, /* "none", "metadata" or "auto" (and "" as a synonym for "auto") */


### PR DESCRIPTION
See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Attributes

This is necessary sometimes to display videos properly on mobile browsers.