### PR TITLE
Update createPortal function signature in DOM docs

### DIFF
--- a/docs/dom.md
+++ b/docs/dom.md
@@ -4,12 +4,12 @@ title: Working with DOM
 
 ## ReactDOM
 
-ReasonReact's ReactDOM module is called `ReactDOM`. The module exposes helpers that work with familiar ReactJS idioms.
+ReasonReact's ReactDOM module is called `ReactDOMRe`. The module exposes helpers that work with familiar ReactJS idioms.
 
 - `render` : `(React.element, Dom.element) => unit`
 - `unmountComponentAtNode` : `Dom.element => unit`
 - `hydrate` : `(React.element, Dom.element) => unit`
-- `createPortal` : `(React.component('props), 'props) => React.element`
+- `createPortal` : `(React.component('props), Dom.element) => React.element`
 
 ## ReactDOMServer
 

--- a/docs/dom.md
+++ b/docs/dom.md
@@ -9,7 +9,7 @@ ReasonReact's ReactDOM module is called `ReactDOMRe`. The module exposes helpers
 - `render` : `(React.element, Dom.element) => unit`
 - `unmountComponentAtNode` : `Dom.element => unit`
 - `hydrate` : `(React.element, Dom.element) => unit`
-- `createPortal` : `(React.component('props), Dom.element) => React.element`
+- `createPortal` : `(React.element, Dom.element) => React.element`
 
 ## ReactDOMServer
 


### PR DESCRIPTION
Hi,

I was going through the documentation and noticed that the function signature for `createPortal` did not match the one given by my editor. Since the `'props` is not needed anymore, we could simplify the signature to `(React.element, Dom.element) => React.element` (which is what is my editor actually says).

I also do no have access to the `ReactDOM` module, I seem to only have `ReactDOMRe`, so I've updated that.

Since I'm just starting in ReasonReact, I am not sure about this change but am proposing it nonetheless.

Cheers ;)