### PR TITLE
Fix A Simple Counter Example in Docs

### DIFF
--- a/docs/usestate-hook.md
+++ b/docs/usestate-hook.md
@@ -19,7 +19,7 @@ let make = (~initialCount) => {
   let (count, setCount) = React.useState(_ => initialCount);
 
   <>
-    {React.string("Count: " ++ count)}
+    {React.string("Count: " ++ string_of_int(count))}
     <button onClick={_ => setCount(_ => initialCount)}>
       {React.string("Reset")}
     </button>


### PR DESCRIPTION
Hi,
I got error when trying execute example in useState Hook. I found that error caused by initialCount props is passing `int`, but it tried to render as `string` with `React.string()`.

<img width="500" alt="Screen Shot 2020-08-15 at 18 56 04" src="https://user-images.githubusercontent.com/15377132/90311851-adc14880-df29-11ea-9c9d-50170418b1dc.png">
