### PR TITLE
Update React context example to define makeProps

### DIFF
--- a/docs/context-mixins.md
+++ b/docs/context-mixins.md
@@ -12,8 +12,12 @@ In order to use React's context, you need to create two things:
 /** ContextProvider.re */
 let themeContext = React.createContext("light");
 
-include React.Context; // Adds the makeProps external
 let make = React.Context.provider(themeContext);
+
+let makeProps = (~value, ~children, ()) => {
+  "value": value,
+  "children": children,
+};
 ```
 
 That will give you a `ContextProvider` component you can use in your application later on. You'll do this like you'd normally would in any React application.


### PR DESCRIPTION
This fixes the following issue when compiling: `The value makeProps can't be found in EncounterProvider`. I found this solution in an [external blog post](https://dev.to/margaretkrutikova/reason-react-context-explained-in-action-5eki).

Compilation error summary:

![image](https://user-images.githubusercontent.com/3778552/90323420-13a3d500-df16-11ea-9963-dbb0e169685e.png)

Relevant components and folder structure:

**EncounterContext/EncounterContext.re**
```ocaml
type encounter = {goal: string};

let context = React.createContext({goal: ""});

let useEncounter = () => React.useContext(context);
```

**EncounterProvider/EncounterProvider.re**
```ocaml

include React.Context;
let make = React.Context.provider(EncounterContext.context);
```

**App.re**
```ocaml
type state = EncounterContext.encounter;

type action =
  | Foo;

let reducer = (state, action) => {
  switch (action) {
  | Foo => state
  };
};

let initialState: EncounterContext.encounter = {goal: ""};

[@react.component]
let make = () => {
  let (state, dispatch) = React.useReducer(reducer, initialState);

  <div>
    <EncounterProvider value=state>
      <h1> {React.string("Encounter Builder")} </h1>
      <Goal />
    </EncounterProvider>
  </div>;
};
```

Dependency information:

```
  "dependencies": {
    "react": "^16.8.1",
    "react-dom": "^16.8.1",
    "reason-react": ">=0.7.1"
  },
  "devDependencies": {
    "bs-platform": "^8.2.0",
    "moduleserve": "^0.9.0"
  }
```
