### PR TITLE
Remove unused type definition in example.

### DIFF
--- a/docs/usestate-hook.md
+++ b/docs/usestate-hook.md
@@ -9,9 +9,6 @@ title: useState Hook
 ### A Simple Counter Example
 
 ```reason
-type action =
-  | Tick;
-
 type state = {count: int};
 
 [@react.component]


### PR DESCRIPTION
Remove unused type definition in example.

There is no use of the type definition. Readers would presumably be confused or uncertain what role it plays.

If for some reason this type definition actually is used somehow, then it should be described.