### PR TITLE
Export textContent property on dom element

### DIFF
--- a/src/ReactTestUtils.re
+++ b/src/ReactTestUtils.re
@@ -93,7 +93,6 @@ external querySelectorAll:
   (Dom.element, string) => Js.Array.array_like(Dom.element) =
   "querySelectorAll";
 
-[@bs.get] external textContent: Dom.element => string = "textContent";
 [@bs.get] external body: Dom.document => option(Dom.element) = "body";
 [@bs.send]
 external createElement: (Dom.document, string) => Dom.element =
@@ -112,6 +111,7 @@ module DOM = {
 
   [@bs.return nullable] [@bs.get]
   external value: Dom.element => option(string) = "value";
+  [@bs.get] external textContent: Dom.element => string = "textContent";
 
   let findBySelector = (element, selector) =>
     querySelector(element, selector);

--- a/src/ReactTestUtils.rei
+++ b/src/ReactTestUtils.rei
@@ -46,6 +46,7 @@ module Simulate: {
 module DOM: {
   [@bs.return nullable] [@bs.get]
   external value: Dom.element => option(string) = "value";
+  [@bs.get] external textContent: Dom.element => string = "textContent";
 
   let findBySelector: (Dom.element, string) => option(Dom.element);
   let findByAllSelector: (Dom.element, string) => array(Dom.element);


### PR DESCRIPTION
Export `textContent` property in `ReactTestUtils.rei`

```reason
[@bs.get] external textContent: Dom.element => string = "textContent";
```

Not sure if there was some reason why `textContent` was not being exported. Maybe just an oversight. 