### PR TITLE
Fix #639: unused variable in website example

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -32,7 +32,7 @@ const codeExampleSmallScreen =`${pre}reason
 [@react.component]
 let make = (~name) =>
   <button>
-    {React.string("Hello!")}
+    {React.string("Hello" ++ name)}
   </button>;
 ${pre}`;
 
@@ -40,7 +40,7 @@ const codeExampleLargeScreen =`${pre}reason
 [@react.component]
 let make = (~name) =>
   <button>
-    {React.string("Hello!")}
+    {React.string("Hello" ++ name)}
   </button>;
 ${pre}`;
 

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -32,7 +32,7 @@ const codeExampleSmallScreen =`${pre}reason
 [@react.component]
 let make = (~name) =>
   <button>
-    {React.string("Hello" ++ name)}
+    {React.string("Hello " ++ name)}
   </button>;
 ${pre}`;
 
@@ -40,7 +40,7 @@ const codeExampleLargeScreen =`${pre}reason
 [@react.component]
 let make = (~name) =>
   <button>
-    {React.string("Hello" ++ name)}
+    {React.string("Hello " ++ name)}
   </button>;
 ${pre}`;
 


### PR DESCRIPTION
Fixes #639 .

I've changed `"Hello!"` to `"Hello " ++ name` and not `"Hello " ++ name ++ "!"` in order to keep the example as minimal as possible.

I'm not entirely sure whether I fixed the example in the right place, (in the source, and not in some generated output), please double check.