### PR TITLE
Fix typo

### DIFF
--- a/docs/context-mixins.md
+++ b/docs/context-mixins.md
@@ -46,7 +46,7 @@ let make = () => {
 Binding to a Context defined in a JS file holds no surprises. 
 
 ```js
-/** ComponentThatDefinesTheContext.re */
+/** ComponentThatDefinesTheContext.js */
 export const ThemeContext = React.createContext("light");
 ```
 


### PR DESCRIPTION
Since context example includes JavaScript code example, fix typos for correction.