### PR TITLE
Fixed typo at README.md: "truoble" to "trouble"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Note**: ReasonReact now lives at [@rescript/react](https://github.com/rescript-lang/rescript-react), which maintains full compatiblity with the latest ReasonReact, excluding the long-deprecated old modules aliases (such as `ReactDOMRe`, in favor of `ReactDOM`) that we've taken the occasion to finally remove. Migration notes [here](https://rescript-lang.org/docs/react/latest/migrate-from-reason-react).
 
-Tldr: you can just change your `package.json`'s `"reason-react"` dependency to `"@rescript/react"`. For transitive dependencies upgrade truoble, please voice your feedback on our [forum](http://forum.rescript-lang.org) and on the [migration issue](https://github.com/rescript-lang/rescript-react/issues/11). Thanks!
+Tldr: you can just change your `package.json`'s `"reason-react"` dependency to `"@rescript/react"`. For transitive dependencies upgrade trouble, please voice your feedback on our [forum](http://forum.rescript-lang.org) and on the [migration issue](https://github.com/rescript-lang/rescript-react/issues/11). Thanks!
 
 Future updates happens at `rescript-react` as a continuation of ReasonReact, by the same people.
 


### PR DESCRIPTION
Hi maintainers, I think there was a typographical error at the README.md file where "trouble" was misspelled as "truoble". Have fixed it in the PR please review the same.