### PR TITLE
Add all aria attributes

### DIFF
--- a/src/ReactDOM.re
+++ b/src/ReactDOM.re
@@ -94,7 +94,7 @@ module Props = {
     [@bs.optional] [@bs.as "aria-errormessage"]
     ariaErrormessage: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage */
     [@bs.optional] [@bs.as "aria-expanded"]
-    ariaExpanded: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded */
+    ariaExpanded: bool, /* string */ /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded */
     [@bs.optional] [@bs.as "aria-flowto"]
     ariaFlowto: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-flowto */
     [@bs.optional] [@bs.as "aria-grabbed"] /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant */
@@ -1122,7 +1122,7 @@ module Props = {
     [@bs.optional] [@bs.as "aria-errormessage"]
     ariaErrormessage: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage */
     [@bs.optional] [@bs.as "aria-expanded"]
-    ariaExpanded: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded */
+    ariaExpanded: bool, /* string */ /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded */
     [@bs.optional] [@bs.as "aria-flowto"]
     ariaFlowto: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-flowto */
     [@bs.optional] [@bs.as "aria-grabbed"] /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant */
@@ -1130,7 +1130,7 @@ module Props = {
     [@bs.optional] [@bs.as "aria-haspopup"]
     ariaHaspopup: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup */
     [@bs.optional] [@bs.as "aria-hidden"]
-    ariaHidden: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden */
+    ariaHidden: bool, /* string */ /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden */
     [@bs.optional] [@bs.as "aria-invalid"]
     ariaInvalid: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid */
     [@bs.optional] [@bs.as "aria-keyshortcuts"]

--- a/src/ReactDOM.re
+++ b/src/ReactDOM.re
@@ -97,6 +97,8 @@ module Props = {
     ariaExpanded: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded */
     [@bs.optional] [@bs.as "aria-flowto"]
     ariaFlowto: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-flowto */
+    [@bs.optional] [@bs.as "aria-grabbed"] /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant */
+    ariaGrabbed: bool,
     [@bs.optional] [@bs.as "aria-haspopup"]
     ariaHaspopup: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup */
     [@bs.optional] [@bs.as "aria-hidden"]
@@ -1123,6 +1125,8 @@ module Props = {
     ariaExpanded: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded */
     [@bs.optional] [@bs.as "aria-flowto"]
     ariaFlowto: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-flowto */
+    [@bs.optional] [@bs.as "aria-grabbed"] /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant */
+    ariaGrabbed: bool,
     [@bs.optional] [@bs.as "aria-haspopup"]
     ariaHaspopup: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup */
     [@bs.optional] [@bs.as "aria-hidden"]

--- a/src/ReactDOM.re
+++ b/src/ReactDOM.re
@@ -66,7 +66,7 @@ module Props = {
     /* accessibility */
     /* https://www.w3.org/TR/wai-aria-1.1/ */
     [@bs.optional] [@bs.as "aria-activedescendant"]
-    ariaActivedescendant: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescenda/t */
+    ariaActivedescendant: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendat */
     [@bs.optional] [@bs.as "aria-atomic"]
     ariaAtomic: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic */
     [@bs.optional] [@bs.as "aria-autocomplete"]
@@ -102,7 +102,7 @@ module Props = {
     [@bs.optional] [@bs.as "aria-haspopup"]
     ariaHaspopup: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup */
     [@bs.optional] [@bs.as "aria-hidden"]
-    ariaHidden: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden */
+    ariaHidden: bool, /* string */ /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden */
     [@bs.optional] [@bs.as "aria-invalid"]
     ariaInvalid: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid */
     [@bs.optional] [@bs.as "aria-keyshortcuts"]
@@ -148,7 +148,7 @@ module Props = {
     [@bs.optional] [@bs.as "aria-rowspan"]
     ariaRowspan: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan */
     [@bs.optional] [@bs.as "aria-selected"]
-    ariaSelected: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected */
+    ariaSelected: bool, /* string */ /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected */
     [@bs.optional] [@bs.as "aria-setsize"]
     ariaSetsize: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize */
     [@bs.optional] [@bs.as "aria-sort"]
@@ -1079,7 +1079,6 @@ module Props = {
     [@bs.optional]
     suppressContentEditableWarning: bool,
   };
-
   /* This list isn't exhaustive. We'll add more as we go. */
   /*
    * Watch out! There are two props types and the only difference is the type of ref.
@@ -1094,7 +1093,7 @@ module Props = {
     /* accessibility */
     /* https://www.w3.org/TR/wai-aria-1.1/ */
     [@bs.optional] [@bs.as "aria-activedescendant"]
-    ariaActivedescendant: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescenda/t */
+    ariaActivedescendant: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendat */
     [@bs.optional] [@bs.as "aria-atomic"]
     ariaAtomic: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic */
     [@bs.optional] [@bs.as "aria-autocomplete"]
@@ -1176,7 +1175,7 @@ module Props = {
     [@bs.optional] [@bs.as "aria-rowspan"]
     ariaRowspan: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan */
     [@bs.optional] [@bs.as "aria-selected"]
-    ariaSelected: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected */
+    ariaSelected: bool, /* string */ /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected */
     [@bs.optional] [@bs.as "aria-setsize"]
     ariaSetsize: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize */
     [@bs.optional] [@bs.as "aria-sort"]

--- a/src/ReactDOM.re
+++ b/src/ReactDOM.re
@@ -65,98 +65,100 @@ module Props = {
     ref: domRef,
     /* accessibility */
     /* https://www.w3.org/TR/wai-aria-1.1/ */
-    /* https://accessibilityresources.org/<aria-tag> is a great resource for these */
-    /* [@bs.optional] [@bs.as "aria-current"] ariaCurrent: page|step|location|date|time|true|false, */
-    [@bs.optional] [@bs.as "aria-details"]
-    ariaDetails: string,
-    [@bs.optional] [@bs.as "aria-disabled"]
-    ariaDisabled: bool,
-    [@bs.optional] [@bs.as "aria-hidden"]
-    ariaHidden: bool,
-    /* [@bs.optional] [@bs.as "aria-invalid"] ariaInvalid: grammar|false|spelling|true, */
-    [@bs.optional] [@bs.as "aria-keyshortcuts"]
-    ariaKeyshortcuts: string,
-    [@bs.optional] [@bs.as "aria-label"]
-    ariaLabel: string,
-    [@bs.optional] [@bs.as "aria-roledescription"]
-    ariaRoledescription: string,
-    /* Widget Attributes */
-    /* [@bs.optional] [@bs.as "aria-autocomplete"] ariaAutocomplete: inline|list|both|none, */
-    /* [@bs.optional] [@bs.as "aria-checked"] ariaChecked: true|false|mixed, /* https://www.w3.org/TR/wai-aria-1.1/#valuetype_tristate */ */
-    [@bs.optional] [@bs.as "aria-expanded"]
-    ariaExpanded: bool,
-    /* [@bs.optional] [@bs.as "aria-haspopup"] ariaHaspopup: false|true|menu|listbox|tree|grid|dialog, */
-    [@bs.optional] [@bs.as "aria-level"]
-    ariaLevel: int,
-    [@bs.optional] [@bs.as "aria-modal"]
-    ariaModal: bool,
-    [@bs.optional] [@bs.as "aria-multiline"]
-    ariaMultiline: bool,
-    [@bs.optional] [@bs.as "aria-multiselectable"]
-    ariaMultiselectable: bool,
-    /* [@bs.optional] [@bs.as "aria-orientation"] ariaOrientation: horizontal|vertical|undefined, */
-    [@bs.optional] [@bs.as "aria-placeholder"]
-    ariaPlaceholder: string,
-    /* [@bs.optional] [@bs.as "aria-pressed"] ariaPressed: true|false|mixed, /* https://www.w3.org/TR/wai-aria-1.1/#valuetype_tristate */ */
-    [@bs.optional] [@bs.as "aria-readonly"]
-    ariaReadonly: bool,
-    [@bs.optional] [@bs.as "aria-required"]
-    ariaRequired: bool,
-    [@bs.optional] [@bs.as "aria-selected"]
-    ariaSelected: bool,
-    [@bs.optional] [@bs.as "aria-sort"]
-    ariaSort: string,
-    [@bs.optional] [@bs.as "aria-valuemax"]
-    ariaValuemax: float,
-    [@bs.optional] [@bs.as "aria-valuemin"]
-    ariaValuemin: float,
-    [@bs.optional] [@bs.as "aria-valuenow"]
-    ariaValuenow: float,
-    [@bs.optional] [@bs.as "aria-valuetext"]
-    ariaValuetext: string,
-    /* Live Region Attributes */
-    [@bs.optional] [@bs.as "aria-atomic"]
-    ariaAtomic: bool,
-    [@bs.optional] [@bs.as "aria-busy"]
-    ariaBusy: bool,
-    /* [@bs.optional] [@bs.as "aria-live"] ariaLive: off|polite|assertive|rude, */
-    [@bs.optional] [@bs.as "aria-relevant"]
-    ariaRelevant: string,
-    /* Drag-and-Drop Attributes */
-    /* [@bs.optional] [@bs.as "aria-dropeffect"] ariaDropeffect: copy|move|link|execute|popup|none, */
-    [@bs.optional] [@bs.as "aria-grabbed"]
-    ariaGrabbed: bool,
-    /* Relationship Attributes */
     [@bs.optional] [@bs.as "aria-activedescendant"]
-    ariaActivedescendant: string,
+    ariaActivedescendant: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescenda/t */
+    [@bs.optional] [@bs.as "aria-atomic"]
+    ariaAtomic: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic */
+    [@bs.optional] [@bs.as "aria-autocomplete"]
+    ariaAutocomplete: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete */
+    [@bs.optional] [@bs.as "aria-busy"]
+    ariaBusy: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy */
+    [@bs.optional] [@bs.as "aria-checked"]
+    ariaChecked: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked */
     [@bs.optional] [@bs.as "aria-colcount"]
-    ariaColcount: int,
+    ariaColcount: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount */
     [@bs.optional] [@bs.as "aria-colindex"]
-    ariaColindex: int,
+    ariaColindex: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex */
     [@bs.optional] [@bs.as "aria-colspan"]
-    ariaColspan: int,
+    ariaColspan: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan */
     [@bs.optional] [@bs.as "aria-controls"]
-    ariaControls: string,
+    ariaControls: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls */
+    [@bs.optional] [@bs.as "aria-current"]
+    ariaCurrent: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current */
     [@bs.optional] [@bs.as "aria-describedby"]
-    ariaDescribedby: string,
+    ariaDescribedby: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby */
+    [@bs.optional] [@bs.as "aria-details"]
+    ariaDetails: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-details */
+    [@bs.optional] [@bs.as "aria-disabled"]
+    ariaDisabled: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled */
     [@bs.optional] [@bs.as "aria-errormessage"]
-    ariaErrormessage: string,
+    ariaErrormessage: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage */
+    [@bs.optional] [@bs.as "aria-expanded"]
+    ariaExpanded: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded */
     [@bs.optional] [@bs.as "aria-flowto"]
-    ariaFlowto: string,
+    ariaFlowto: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-flowto */
+    [@bs.optional] [@bs.as "aria-haspopup"]
+    ariaHaspopup: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup */
+    [@bs.optional] [@bs.as "aria-hidden"]
+    ariaHidden: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden */
+    [@bs.optional] [@bs.as "aria-invalid"]
+    ariaInvalid: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid */
+    [@bs.optional] [@bs.as "aria-keyshortcuts"]
+    ariaKeyshortcuts: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts */
+    [@bs.optional] [@bs.as "aria-label"]
+    ariaLabel: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label */
     [@bs.optional] [@bs.as "aria-labelledby"]
-    ariaLabelledby: string,
+    ariaLabelledby: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby */
+    [@bs.optional] [@bs.as "aria-level"]
+    ariaLevel: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level */
+    [@bs.optional] [@bs.as "aria-live"]
+    ariaLive: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live */
+    [@bs.optional] [@bs.as "aria-modal"]
+    ariaModal: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal */
+    [@bs.optional] [@bs.as "aria-multiline"]
+    ariaMultiline: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline */
+    [@bs.optional] [@bs.as "aria-multiselectable"]
+    ariaMultiselectable: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable */
+    [@bs.optional] [@bs.as "aria-orientation"]
+    ariaOrientation: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation */
     [@bs.optional] [@bs.as "aria-owns"]
-    ariaOwns: string,
+    ariaOwns: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns */
+    [@bs.optional] [@bs.as "aria-placeholder"]
+    ariaPlaceholder: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder */
     [@bs.optional] [@bs.as "aria-posinset"]
-    ariaPosinset: int,
+    ariaPosinset: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset */
+    [@bs.optional] [@bs.as "aria-pressed"]
+    ariaPressed: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed */
+    [@bs.optional] [@bs.as "aria-readonly"]
+    ariaReadonly: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly */
+    [@bs.optional] [@bs.as "aria-relevant"]
+    ariaRelevant: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant */
+    [@bs.optional] [@bs.as "aria-required"]
+    ariaRequired: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required */
+    [@bs.optional] [@bs.as "aria-roledescription"]
+    ariaRoledescription: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription */
     [@bs.optional] [@bs.as "aria-rowcount"]
-    ariaRowcount: int,
+    ariaRowcount: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount */
     [@bs.optional] [@bs.as "aria-rowindex"]
-    ariaRowindex: int,
+    ariaRowindex: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex */
+    [@bs.optional] [@bs.as "aria-rowindextext"]
+    ariaRowindextext: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext */
     [@bs.optional] [@bs.as "aria-rowspan"]
-    ariaRowspan: int,
+    ariaRowspan: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan */
+    [@bs.optional] [@bs.as "aria-selected"]
+    ariaSelected: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected */
     [@bs.optional] [@bs.as "aria-setsize"]
-    ariaSetsize: int,
+    ariaSetsize: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize */
+    [@bs.optional] [@bs.as "aria-sort"]
+    ariaSort: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort */
+    [@bs.optional] [@bs.as "aria-valuemax"]
+    ariaValuemax: float, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax */
+    [@bs.optional] [@bs.as "aria-valuemin"]
+    ariaValuemin: float, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin */
+    [@bs.optional] [@bs.as "aria-valuenow"]
+    ariaValuenow: float, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow */
+    [@bs.optional] [@bs.as "aria-valuetext"]
+    ariaValuetext: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext */
     /* react textarea/input */
     [@bs.optional]
     defaultChecked: bool,
@@ -1089,98 +1091,100 @@ module Props = {
     ref: Js.nullable(Dom.element) => unit,
     /* accessibility */
     /* https://www.w3.org/TR/wai-aria-1.1/ */
-    /* https://accessibilityresources.org/<aria-tag> is a great resource for these */
-    /* [@bs.optional] [@bs.as "aria-current"] ariaCurrent: page|step|location|date|time|true|false, */
-    [@bs.optional] [@bs.as "aria-details"]
-    ariaDetails: string,
-    [@bs.optional] [@bs.as "aria-disabled"]
-    ariaDisabled: bool,
-    [@bs.optional] [@bs.as "aria-hidden"]
-    ariaHidden: bool,
-    /* [@bs.optional] [@bs.as "aria-invalid"] ariaInvalid: grammar|false|spelling|true, */
-    [@bs.optional] [@bs.as "aria-keyshortcuts"]
-    ariaKeyshortcuts: string,
-    [@bs.optional] [@bs.as "aria-label"]
-    ariaLabel: string,
-    [@bs.optional] [@bs.as "aria-roledescription"]
-    ariaRoledescription: string,
-    /* Widget Attributes */
-    /* [@bs.optional] [@bs.as "aria-autocomplete"] ariaAutocomplete: inline|list|both|none, */
-    /* [@bs.optional] [@bs.as "aria-checked"] ariaChecked: true|false|mixed, /* https://www.w3.org/TR/wai-aria-1.1/#valuetype_tristate */ */
-    [@bs.optional] [@bs.as "aria-expanded"]
-    ariaExpanded: bool,
-    /* [@bs.optional] [@bs.as "aria-haspopup"] ariaHaspopup: false|true|menu|listbox|tree|grid|dialog, */
-    [@bs.optional] [@bs.as "aria-level"]
-    ariaLevel: int,
-    [@bs.optional] [@bs.as "aria-modal"]
-    ariaModal: bool,
-    [@bs.optional] [@bs.as "aria-multiline"]
-    ariaMultiline: bool,
-    [@bs.optional] [@bs.as "aria-multiselectable"]
-    ariaMultiselectable: bool,
-    /* [@bs.optional] [@bs.as "aria-orientation"] ariaOrientation: horizontal|vertical|undefined, */
-    [@bs.optional] [@bs.as "aria-placeholder"]
-    ariaPlaceholder: string,
-    /* [@bs.optional] [@bs.as "aria-pressed"] ariaPressed: true|false|mixed, /* https://www.w3.org/TR/wai-aria-1.1/#valuetype_tristate */ */
-    [@bs.optional] [@bs.as "aria-readonly"]
-    ariaReadonly: bool,
-    [@bs.optional] [@bs.as "aria-required"]
-    ariaRequired: bool,
-    [@bs.optional] [@bs.as "aria-selected"]
-    ariaSelected: bool,
-    [@bs.optional] [@bs.as "aria-sort"]
-    ariaSort: string,
-    [@bs.optional] [@bs.as "aria-valuemax"]
-    ariaValuemax: float,
-    [@bs.optional] [@bs.as "aria-valuemin"]
-    ariaValuemin: float,
-    [@bs.optional] [@bs.as "aria-valuenow"]
-    ariaValuenow: float,
-    [@bs.optional] [@bs.as "aria-valuetext"]
-    ariaValuetext: string,
-    /* Live Region Attributes */
-    [@bs.optional] [@bs.as "aria-atomic"]
-    ariaAtomic: bool,
-    [@bs.optional] [@bs.as "aria-busy"]
-    ariaBusy: bool,
-    /* [@bs.optional] [@bs.as "aria-live"] ariaLive: off|polite|assertive|rude, */
-    [@bs.optional] [@bs.as "aria-relevant"]
-    ariaRelevant: string,
-    /* Drag-and-Drop Attributes */
-    /* [@bs.optional] [@bs.as "aria-dropeffect"] ariaDropeffect: copy|move|link|execute|popup|none, */
-    [@bs.optional] [@bs.as "aria-grabbed"]
-    ariaGrabbed: bool,
-    /* Relationship Attributes */
     [@bs.optional] [@bs.as "aria-activedescendant"]
-    ariaActivedescendant: string,
+    ariaActivedescendant: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescenda/t */
+    [@bs.optional] [@bs.as "aria-atomic"]
+    ariaAtomic: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic */
+    [@bs.optional] [@bs.as "aria-autocomplete"]
+    ariaAutocomplete: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete */
+    [@bs.optional] [@bs.as "aria-busy"]
+    ariaBusy: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy */
+    [@bs.optional] [@bs.as "aria-checked"]
+    ariaChecked: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked */
     [@bs.optional] [@bs.as "aria-colcount"]
-    ariaColcount: int,
+    ariaColcount: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount */
     [@bs.optional] [@bs.as "aria-colindex"]
-    ariaColindex: int,
+    ariaColindex: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex */
     [@bs.optional] [@bs.as "aria-colspan"]
-    ariaColspan: int,
+    ariaColspan: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan */
     [@bs.optional] [@bs.as "aria-controls"]
-    ariaControls: string,
+    ariaControls: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls */
+    [@bs.optional] [@bs.as "aria-current"]
+    ariaCurrent: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current */
     [@bs.optional] [@bs.as "aria-describedby"]
-    ariaDescribedby: string,
+    ariaDescribedby: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby */
+    [@bs.optional] [@bs.as "aria-details"]
+    ariaDetails: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-details */
+    [@bs.optional] [@bs.as "aria-disabled"]
+    ariaDisabled: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled */
     [@bs.optional] [@bs.as "aria-errormessage"]
-    ariaErrormessage: string,
+    ariaErrormessage: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage */
+    [@bs.optional] [@bs.as "aria-expanded"]
+    ariaExpanded: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded */
     [@bs.optional] [@bs.as "aria-flowto"]
-    ariaFlowto: string,
+    ariaFlowto: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-flowto */
+    [@bs.optional] [@bs.as "aria-haspopup"]
+    ariaHaspopup: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup */
+    [@bs.optional] [@bs.as "aria-hidden"]
+    ariaHidden: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden */
+    [@bs.optional] [@bs.as "aria-invalid"]
+    ariaInvalid: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid */
+    [@bs.optional] [@bs.as "aria-keyshortcuts"]
+    ariaKeyshortcuts: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts */
+    [@bs.optional] [@bs.as "aria-label"]
+    ariaLabel: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label */
     [@bs.optional] [@bs.as "aria-labelledby"]
-    ariaLabelledby: string,
+    ariaLabelledby: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby */
+    [@bs.optional] [@bs.as "aria-level"]
+    ariaLevel: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level */
+    [@bs.optional] [@bs.as "aria-live"]
+    ariaLive: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live */
+    [@bs.optional] [@bs.as "aria-modal"]
+    ariaModal: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal */
+    [@bs.optional] [@bs.as "aria-multiline"]
+    ariaMultiline: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline */
+    [@bs.optional] [@bs.as "aria-multiselectable"]
+    ariaMultiselectable: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable */
+    [@bs.optional] [@bs.as "aria-orientation"]
+    ariaOrientation: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation */
     [@bs.optional] [@bs.as "aria-owns"]
-    ariaOwns: string,
+    ariaOwns: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns */
+    [@bs.optional] [@bs.as "aria-placeholder"]
+    ariaPlaceholder: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder */
     [@bs.optional] [@bs.as "aria-posinset"]
-    ariaPosinset: int,
+    ariaPosinset: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset */
+    [@bs.optional] [@bs.as "aria-pressed"]
+    ariaPressed: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed */
+    [@bs.optional] [@bs.as "aria-readonly"]
+    ariaReadonly: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly */
+    [@bs.optional] [@bs.as "aria-relevant"]
+    ariaRelevant: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant */
+    [@bs.optional] [@bs.as "aria-required"]
+    ariaRequired: bool, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required */
+    [@bs.optional] [@bs.as "aria-roledescription"]
+    ariaRoledescription: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription */
     [@bs.optional] [@bs.as "aria-rowcount"]
-    ariaRowcount: int,
+    ariaRowcount: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount */
     [@bs.optional] [@bs.as "aria-rowindex"]
-    ariaRowindex: int,
+    ariaRowindex: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex */
+    [@bs.optional] [@bs.as "aria-rowindextext"]
+    ariaRowindextext: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext */
     [@bs.optional] [@bs.as "aria-rowspan"]
-    ariaRowspan: int,
+    ariaRowspan: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan */
+    [@bs.optional] [@bs.as "aria-selected"]
+    ariaSelected: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected */
     [@bs.optional] [@bs.as "aria-setsize"]
-    ariaSetsize: int,
+    ariaSetsize: int, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize */
+    [@bs.optional] [@bs.as "aria-sort"]
+    ariaSort: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort */
+    [@bs.optional] [@bs.as "aria-valuemax"]
+    ariaValuemax: float, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax */
+    [@bs.optional] [@bs.as "aria-valuemin"]
+    ariaValuemin: float, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin */
+    [@bs.optional] [@bs.as "aria-valuenow"]
+    ariaValuenow: float, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow */
+    [@bs.optional] [@bs.as "aria-valuetext"]
+    ariaValuetext: string, /* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext */
     /* react textarea/input */
     [@bs.optional]
     defaultChecked: bool,


### PR DESCRIPTION
Closes https://github.com/reasonml/reason-react/issues/309, https://github.com/reasonml/reason-react/issues/274 and https://github.com/reasonml/reason-react/issues/480.

## Intro

This PR transforms all the data from MDN encoded in https://github.com/ml-in-barcelona/server-reason-react/blob/main/lib/domProps.ml#L232 and https://github.com/ml-in-barcelona/jsoo-react/blob/main/lib/dom_aria_attributes.ml into domProps.

Note: Didn't add `aria-dropeffect` since is deprecated (aria-grabbed is deprecated but it's present in the bindings).

## Solution

The approach of not adding most aria props was due to the weird types from the DOM API, and the impossibility of representing correctly those. For example, some of the attributes are `true | false | undefined` and those are encoded as strings. 

In this PR I treat everything that isn't straightforward an integer, string or number as a string. This way we can enable lower-case components to have aria attributes.

## Future

The plan to bring more type-safety on the lower-case components has always been important for me, currently on jsoo-react we detect which tag is used and rely on a list of valid attributes for each tag, giving an extra level of safety.

Another proposal might be to try to encode all strings that could be variants (or polyvariants), but let's not talk about future (and uncertain) plans.

## Problems

A downside of this PR is the increase of noise on error messages. Currently when there's a lower-case component with a prop that doesn't exist the error message is very ugly, with this PR it's going to be uglier (If I ever implement the same mechanism as jsoo-react, this problem disappears).

There are 3 props that are encoded a booleans while I have them as strings, due to the weirdness of the dom. I left them as bools, to avoid a breaking change.
```
ariaHidden, ariaExpanded, ariaSelected
```