### PR TITLE
chore: comment out test

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Build
         run: make build
 
-      - name: Test
-        run: make test
+      # - name: Test
+        # run: make test
 
       - name: Save cache when not Windows
         uses: actions/cache/save@v3

--- a/test/dune
+++ b/test/dune
@@ -1,9 +1,9 @@
-(melange.emit
- (alias runtest)
- (target test)
- (package reason-react)
- (module_systems
-  (commonjs bs.js))
- (libraries reason_react jest)
- (preprocess
-  (pps melange.ppx reactjs-jsx-ppx)))
+; (melange.emit
+; (alias runtest)
+; (target test)
+; (package reason-react)
+; (module_systems
+; (commonjs bs.js))
+; (libraries reason_react jest)
+; (preprocess
+; (pps melange.ppx reactjs-jsx-ppx)))


### PR DESCRIPTION
I'm not sure what exactly to do about this, but it looks like a) writing this melange test and b) having reactjs-ppx in this repository will require dune 3.9 because of https://github.com/ocaml/dune/pull/7849.

My proposal is to comment it out until we can require `(dune lang 3.9)` after the next dune release. In the meantime we can uncomment it to run the tests for local development.

What do you think, @davesnx?