### PR TITLE
fix make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ format-check: ## Checks if format is correct
 .PHONY: install
 install: ## Update the package dependencies when new deps are added to dune-project
 	@opam pin add -y melange --dev-repo
-	@opam pin add -y dune --dev-repo
+	@opam pin add -y dune.3.9 --dev-repo
 	@opam install . --deps-only --with-test
 	@npm install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "reason-react",
       "version": "0.11.0",
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
In https://github.com/reasonml/reason-react/pull/744, the dune constraint in the opam file was changed 

https://github.com/reasonml/reason-react/blob/32b00573925f4d7c96eaa7bd967f7c4614ecf386/reason-react.opam#L20

This broke `make install` because there's no such version published yet:

```
[ERROR] Package conflict!
  * Missing dependency:
    - dune >= 3.9
    not available because the package is pinned to version 3.8.0
```

This change tells opam that the dev-repo version is 3.9 when pinning it, so it doesn't complain.