### PR TITLE
Better editor and merlin integration by improving ppx locations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-tr
 * Add `suppressHydrationWarning` to supported props (@davesnx in
 [#721](https://github.com/reasonml/reason-react/pull/721))
 * Rename `reactjs-jsx-ppx` to `reason-react-ppx` ([@davesnx in #732](https://github.com/reasonml/reason-react/pull/732))
+- Fix locations for lower and uppercase components so that merlin / editor
+  integration can get type defs on hover ([@jchavarri in #748](https://github.com/reasonml/reason-react/pull/748))
 
 # 0.11.0
 

--- a/ppx/src/reactjs_jsx_ppx.ml
+++ b/ppx/src/reactjs_jsx_ppx.ml
@@ -124,12 +124,14 @@ let unerasableIgnore loc =
 
 (* [merlinHide] tells merlin to not look at a node, or at any of its
    descendants. *)
-let merlinHide =
-  {
-    attr_name = { txt = "merlin.hide"; loc = Location.none };
-    attr_payload = PStr [];
-    attr_loc = Location.none;
-  }
+let merlinHideAttrs =
+  [
+    {
+      attr_name = { txt = "merlin.hide"; loc = Location.none };
+      attr_payload = PStr [];
+      attr_loc = Location.none;
+    };
+  ]
 
 let merlinFocus =
   {
@@ -497,7 +499,7 @@ let jsxMapper =
                "JSX name can't be the result of function applications")
     in
     let props =
-      Exp.apply ~attrs:[ merlinHide ] ~loc
+      Exp.apply ~attrs:merlinHideAttrs ~loc
         (Exp.ident ~loc { loc; txt = propsIdent })
         propsArg
     in
@@ -528,7 +530,7 @@ let jsxMapper =
 
       let propsCall =
         Exp.apply ~loc:parentExpLoc
-          (Exp.ident ~loc:parentExpLoc ~attrs:[ merlinHide ]
+          (Exp.ident ~loc:parentExpLoc ~attrs:merlinHideAttrs
              { loc; txt = Ldot (Lident "ReactDOM", "domProps") })
           ((match childrenProp with
            | Some childrenProp ->
@@ -1071,7 +1073,7 @@ let jsxMapper =
               | txt ->
                   Exp.let_ Nonrecursive
                     [
-                      Vb.mk ~loc:gloc ~attrs:[ merlinHide ]
+                      Vb.mk ~loc:gloc ~attrs:merlinHideAttrs
                         (Pat.var ~loc:gloc { loc = gloc; txt })
                         fullExpression;
                     ]

--- a/ppx/src/reactjs_jsx_ppx.ml
+++ b/ppx/src/reactjs_jsx_ppx.ml
@@ -122,6 +122,15 @@ let unerasableIgnore loc =
     attr_loc = loc;
   }
 
+(* [merlinHide] tells merlin to not look at a node, or at any of its
+   descendants. *)
+let merlinHide =
+  {
+    attr_name = { txt = "merlin.hide"; loc = Location.none };
+    attr_payload = PStr [];
+    attr_loc = Location.none;
+  }
+
 let merlinFocus =
   {
     attr_name = { loc = Location.none; txt = "merlin.focus" };
@@ -1067,7 +1076,7 @@ let jsxMapper =
               | txt ->
                   Exp.let_ Nonrecursive
                     [
-                      Vb.mk ~loc:emptyLoc
+                      Vb.mk ~loc:emptyLoc ~attrs:[merlinHide]
                         (Pat.var ~loc:emptyLoc { loc = emptyLoc; txt })
                         fullExpression;
                     ]

--- a/ppx/src/reactjs_jsx_ppx.ml
+++ b/ppx/src/reactjs_jsx_ppx.ml
@@ -499,9 +499,7 @@ let jsxMapper =
                "JSX name can't be the result of function applications")
     in
     let props =
-      Exp.apply ~attrs:merlinHideAttrs ~loc
-        (Exp.ident ~loc { loc; txt = propsIdent })
-        propsArg
+      Exp.apply ~loc (Exp.ident ~loc { loc; txt = propsIdent }) propsArg
     in
     let key_args =
       match key with
@@ -1073,7 +1071,7 @@ let jsxMapper =
               | txt ->
                   Exp.let_ Nonrecursive
                     [
-                      Vb.mk ~loc:gloc ~attrs:merlinHideAttrs
+                      Vb.mk ~loc:gloc
                         (Pat.var ~loc:gloc { loc = gloc; txt })
                         fullExpression;
                     ]
@@ -1225,9 +1223,9 @@ let jsxMapper =
               (Invalid_argument
                  "JSX: `createElement` should be preceeded by a module name.")
         (* Foo.createElement(~prop1=foo, ~prop2=bar, ~children=[], ()) *)
-        | { loc; txt = Ldot (modulePath, ("createElement" | "make")) } ->
-            transformUppercaseCall3 ~ctxt ~caller:"make" modulePath mapper loc
-              attrs callExpression callArguments
+        | { txt = Ldot (modulePath, ("createElement" | "make")) } ->
+            transformUppercaseCall3 ~ctxt ~caller:"make" modulePath mapper
+              parentExpLoc attrs callExpression callArguments
         (* div(~prop1=foo, ~prop2=bar, ~children=[bla], ()) *)
         (* turn that into
            ReactDOMRe.createElement(~props=ReactDOMRe.props(~props1=foo,
@@ -1238,9 +1236,9 @@ let jsxMapper =
         (* Foo.bar(~prop1=foo, ~prop2=bar, ~children=[], ()) *)
         (* Not only "createElement" or "make". See
            https://github.com/reasonml/reason/pull/2541 *)
-        | { loc; txt = Ldot (modulePath, anythingNotCreateElementOrMake) } ->
+        | { txt = Ldot (modulePath, anythingNotCreateElementOrMake) } ->
             transformUppercaseCall3 ~ctxt ~caller:anythingNotCreateElementOrMake
-              modulePath mapper loc attrs callExpression callArguments
+              modulePath mapper parentExpLoc attrs callExpression callArguments
         | { txt = Lapply _ } ->
             (* don't think there's ever a case where this is reached *)
             raise

--- a/ppx/test/dune
+++ b/ppx/test/dune
@@ -21,5 +21,24 @@
  (action
   (diff output.expected result.ml)))
 
+(rule
+ (targets output_locations.ml)
+ (deps generated_locations.ml)
+ (action
+  (run ./standalone.exe -dparsetree --impl %{deps} -o %{targets})))
+
+(rule
+ (targets generated_locations.ml)
+ (deps input_locations.re)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run refmt --parse=re --print=ml %{deps}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff output_locations.expected output_locations.ml)))
+
 (cram
  (package reason-react))

--- a/ppx/test/input_locations.re
+++ b/ppx/test/input_locations.re
@@ -2,3 +2,12 @@
 let make = (~lola) => {
   <div> {React.string(lola)} </div>;
 };
+
+[@react.component]
+let make = (~initialValue=0, ()) => {
+  let (value, setValue) = React.useState(() => initialValue);
+
+  <button onClick={_ => setValue(value => value + 1)}>
+    value->React.int
+  </button>;
+};

--- a/ppx/test/input_locations.re
+++ b/ppx/test/input_locations.re
@@ -1,0 +1,4 @@
+[@react.component]
+let make = (~lola) => {
+  <div> {React.string(lola)} </div>;
+};

--- a/ppx/test/input_locations.re
+++ b/ppx/test/input_locations.re
@@ -11,3 +11,12 @@ let make = (~initialValue=0, ()) => {
     value->React.int
   </button>;
 };
+
+module Uppercase = {
+  [@react.component]
+  let make = (~children as upperCaseChildren) => {
+    <Box>
+      {upperCaseChildren}
+    </Box>;
+  };
+};

--- a/ppx/test/merlin/issue-429.t/run.t
+++ b/ppx/test/merlin/issue-429.t/run.t
@@ -22,55 +22,844 @@ Let's test hovering over parts of the component
 
   $ ocamlmerlin single type-enclosing -position 15:19 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 15,
+        "col": 13
+      },
+      "end": {
+        "line": 15,
+        "col": 21
+      },
+      "type": "string",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 `state` in `let (state, dispatch)`
 
   $ ocamlmerlin single type-enclosing -position 16:11 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 16,
+        "col": 7
+      },
+      "end": {
+        "line": 16,
+        "col": 12
+      },
+      "type": "state",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 16,
+        "col": 6
+      },
+      "end": {
+        "line": 16,
+        "col": 23
+      },
+      "type": "(state, action => unit)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 `dispatch` in `let (state, dispatch)`
 
   $ ocamlmerlin single type-enclosing -position 16:19 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 16,
+        "col": 14
+      },
+      "end": {
+        "line": 16,
+        "col": 22
+      },
+      "type": "action => unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 16,
+        "col": 6
+      },
+      "end": {
+        "line": 16,
+        "col": 23
+      },
+      "type": "(state, action => unit)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 `message` in `let message`
 
   $ ocamlmerlin single type-enclosing -position 26:11 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 26,
+        "col": 6
+      },
+      "end": {
+        "line": 26,
+        "col": 13
+      },
+      "type": "string",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 Wrapping `div`
 
   $ ocamlmerlin single type-enclosing -position 29:5 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 29,
+        "col": 6
+      },
+      "type": "string",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 First child `button`
 
   $ ocamlmerlin single type-enclosing -position 30:9 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 11
+      },
+      "type": "string",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "array(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 First child `onClick` prop
 
   $ ocamlmerlin single type-enclosing -position 30:17 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "array(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 First child `onClick` callback argument (event)
 
   $ ocamlmerlin single type-enclosing -position 30:23 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 30,
+        "col": 20
+      },
+      "end": {
+        "line": 30,
+        "col": 46
+      },
+      "type": "ReactEvent.Mouse.t => unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 20
+      },
+      "end": {
+        "line": 30,
+        "col": 46
+      },
+      "type": "option(ReactEvent.Mouse.t => unit)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "array(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 First child `onClick` prop `dispatch`
 
   $ ocamlmerlin single type-enclosing -position 30:30 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 30,
+        "col": 26
+      },
+      "end": {
+        "line": 30,
+        "col": 34
+      },
+      "type": "action => unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 26
+      },
+      "end": {
+        "line": 30,
+        "col": 45
+      },
+      "type": "unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 20
+      },
+      "end": {
+        "line": 30,
+        "col": 46
+      },
+      "type": "ReactEvent.Mouse.t => unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 20
+      },
+      "end": {
+        "line": 30,
+        "col": 46
+      },
+      "type": "option(ReactEvent.Mouse.t => unit)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "array(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 First child `onClick` prop `Click`
 
@@ -87,6 +876,174 @@ First child `onClick` prop `Click`
         "col": 40
       },
       "type": "((int)) => action",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 35
+      },
+      "end": {
+        "line": 30,
+        "col": 44
+      },
+      "type": "action",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 26
+      },
+      "end": {
+        "line": 30,
+        "col": 45
+      },
+      "type": "unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 20
+      },
+      "end": {
+        "line": 30,
+        "col": 46
+      },
+      "type": "ReactEvent.Mouse.t => unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 20
+      },
+      "end": {
+        "line": 30,
+        "col": 46
+      },
+      "type": "option(ReactEvent.Mouse.t => unit)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "array(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
       "tail": "no"
     }
   ]
@@ -107,6 +1064,150 @@ First child `string`
       },
       "type": "string => element",
       "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 48
+      },
+      "end": {
+        "line": 30,
+        "col": 65
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 48
+      },
+      "end": {
+        "line": 30,
+        "col": 65
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "array(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
     }
   ]
 
@@ -114,19 +1215,442 @@ First child `message`
 
   $ ocamlmerlin single type-enclosing -position 30:62 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 30,
+        "col": 56
+      },
+      "end": {
+        "line": 30,
+        "col": 63
+      },
+      "type": "string",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 48
+      },
+      "end": {
+        "line": 30,
+        "col": 65
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 48
+      },
+      "end": {
+        "line": 30,
+        "col": 65
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 30,
+        "col": 4
+      },
+      "end": {
+        "line": 30,
+        "col": 75
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "array(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 Third child `state`
 
   $ ocamlmerlin single type-enclosing -position 34:9 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 34,
+        "col": 5
+      },
+      "end": {
+        "line": 34,
+        "col": 10
+      },
+      "type": "state",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 34,
+        "col": 5
+      },
+      "end": {
+        "line": 34,
+        "col": 15
+      },
+      "type": "bool",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 34,
+        "col": 4
+      },
+      "end": {
+        "line": 34,
+        "col": 42
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "array(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 Third child `show` in `state.show`
 
   $ ocamlmerlin single type-enclosing -position 34:15 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 34,
+        "col": 11
+      },
+      "end": {
+        "line": 34,
+        "col": 15
+      },
+      "type": "bool",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 34,
+        "col": 5
+      },
+      "end": {
+        "line": 34,
+        "col": 15
+      },
+      "type": "bool",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 34,
+        "col": 4
+      },
+      "end": {
+        "line": 34,
+        "col": 42
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "array(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 Third child `string`
 
@@ -144,6 +1668,126 @@ Third child `string`
       },
       "type": "string => element",
       "tail": "no"
+    },
+    {
+      "start": {
+        "line": 34,
+        "col": 18
+      },
+      "end": {
+        "line": 34,
+        "col": 34
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 34,
+        "col": 4
+      },
+      "end": {
+        "line": 34,
+        "col": 42
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "array(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
     }
   ]
 
@@ -151,7 +1795,140 @@ Third child `greeting`
 
   $ ocamlmerlin single type-enclosing -position 34:30 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
-  []
+  [
+    {
+      "start": {
+        "line": 34,
+        "col": 25
+      },
+      "end": {
+        "line": 34,
+        "col": 33
+      },
+      "type": "string",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 34,
+        "col": 18
+      },
+      "end": {
+        "line": 34,
+        "col": 34
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 34,
+        "col": 4
+      },
+      "end": {
+        "line": 34,
+        "col": 42
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "array(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
+      "tail": "no"
+    }
+  ]
 
 Third child `null`
 
@@ -168,6 +1945,114 @@ Third child `null`
         "col": 41
       },
       "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 34,
+        "col": 4
+      },
+      "end": {
+        "line": 34,
+        "col": 42
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "array(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "option(element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 29,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 26,
+        "col": 2
+      },
+      "end": {
+        "line": 35,
+        "col": 9
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 26
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 11
+      },
+      "end": {
+        "line": 36,
+        "col": 1
+      },
+      "type": "(~greeting: string) => element",
       "tail": "no"
     }
   ]

--- a/ppx/test/merlin/simple.t/run.t
+++ b/ppx/test/merlin/simple.t/run.t
@@ -25,6 +25,78 @@ Let's test hovering over parts of the component
   [
     {
       "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 6,
+        "col": 11
+      },
+      "type": "string",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 38
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 31
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "(~initialValue: int=?, unit) => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
         "line": 1,
         "col": 32
       },
@@ -66,6 +138,78 @@ Let's test hovering over parts of the component
   $ ocamlmerlin single type-enclosing -position 6:17 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   [
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 38
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 31
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "(~initialValue: int=?, unit) => React.element",
+      "tail": "no"
+    },
     {
       "start": {
         "line": 1,
@@ -111,6 +255,102 @@ Let's test hovering over parts of the component
   [
     {
       "start": {
+        "line": 6,
+        "col": 20
+      },
+      "end": {
+        "line": 6,
+        "col": 55
+      },
+      "type": "ReactEvent.Mouse.t => unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 20
+      },
+      "end": {
+        "line": 6,
+        "col": 55
+      },
+      "type": "option(ReactEvent.Mouse.t => unit)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 38
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 31
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "(~initialValue: int=?, unit) => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
         "line": 1,
         "col": 32
       },
@@ -152,6 +392,126 @@ Let's test hovering over parts of the component
   $ ocamlmerlin single type-enclosing -position 6:29 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   [
+    {
+      "start": {
+        "line": 6,
+        "col": 26
+      },
+      "end": {
+        "line": 6,
+        "col": 34
+      },
+      "type": "(int => int) => unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 26
+      },
+      "end": {
+        "line": 6,
+        "col": 54
+      },
+      "type": "unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 20
+      },
+      "end": {
+        "line": 6,
+        "col": 55
+      },
+      "type": "ReactEvent.Mouse.t => unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 20
+      },
+      "end": {
+        "line": 6,
+        "col": 55
+      },
+      "type": "option(ReactEvent.Mouse.t => unit)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 38
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 31
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "(~initialValue: int=?, unit) => React.element",
+      "tail": "no"
+    },
     {
       "start": {
         "line": 1,
@@ -197,6 +557,138 @@ Let's test hovering over parts of the component
   [
     {
       "start": {
+        "line": 6,
+        "col": 35
+      },
+      "end": {
+        "line": 6,
+        "col": 40
+      },
+      "type": "int",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 35
+      },
+      "end": {
+        "line": 6,
+        "col": 53
+      },
+      "type": "int => int",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 26
+      },
+      "end": {
+        "line": 6,
+        "col": 54
+      },
+      "type": "unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 20
+      },
+      "end": {
+        "line": 6,
+        "col": 55
+      },
+      "type": "ReactEvent.Mouse.t => unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 20
+      },
+      "end": {
+        "line": 6,
+        "col": 55
+      },
+      "type": "option(ReactEvent.Mouse.t => unit)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 38
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 31
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "(~initialValue: int=?, unit) => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
         "line": 1,
         "col": 32
       },
@@ -240,6 +732,150 @@ Let's test hovering over parts of the component
   [
     {
       "start": {
+        "line": 6,
+        "col": 44
+      },
+      "end": {
+        "line": 6,
+        "col": 49
+      },
+      "type": "int",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 44
+      },
+      "end": {
+        "line": 6,
+        "col": 53
+      },
+      "type": "int",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 35
+      },
+      "end": {
+        "line": 6,
+        "col": 53
+      },
+      "type": "int => int",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 26
+      },
+      "end": {
+        "line": 6,
+        "col": 54
+      },
+      "type": "unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 20
+      },
+      "end": {
+        "line": 6,
+        "col": 55
+      },
+      "type": "ReactEvent.Mouse.t => unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 20
+      },
+      "end": {
+        "line": 6,
+        "col": 55
+      },
+      "type": "option(ReactEvent.Mouse.t => unit)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 38
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 31
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "(~initialValue: int=?, unit) => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
         "line": 1,
         "col": 32
       },
@@ -281,6 +917,114 @@ Let's test hovering over parts of the component
   $ ocamlmerlin single type-enclosing -position 7:9 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   [
+    {
+      "start": {
+        "line": 7,
+        "col": 6
+      },
+      "end": {
+        "line": 7,
+        "col": 11
+      },
+      "type": "int",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 7,
+        "col": 6
+      },
+      "end": {
+        "line": 7,
+        "col": 22
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 7,
+        "col": 6
+      },
+      "end": {
+        "line": 7,
+        "col": 22
+      },
+      "type": "option(React.element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 38
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 31
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "(~initialValue: int=?, unit) => React.element",
+      "tail": "no"
+    },
     {
       "start": {
         "line": 1,
@@ -338,6 +1082,102 @@ Let's test hovering over parts of the component
     },
     {
       "start": {
+        "line": 7,
+        "col": 6
+      },
+      "end": {
+        "line": 7,
+        "col": 22
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 7,
+        "col": 6
+      },
+      "end": {
+        "line": 7,
+        "col": 22
+      },
+      "type": "option(React.element)",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 38
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 31
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "(~initialValue: int=?, unit) => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
         "line": 1,
         "col": 32
       },
@@ -379,6 +1219,90 @@ Closing `</button>`
   $ ocamlmerlin single type-enclosing -position 8:10 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   [
+    {
+      "start": {
+        "line": 8,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 13
+      },
+      "type": "unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "ReactDOM.domProps",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 4
+      },
+      "end": {
+        "line": 8,
+        "col": 14
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 38
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 31
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "unit => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 13
+      },
+      "end": {
+        "line": 9,
+        "col": 3
+      },
+      "type": "(~initialValue: int=?, unit) => React.element",
+      "tail": "no"
+    },
     {
       "start": {
         "line": 1,

--- a/ppx/test/merlin/uppercase.t/component.re
+++ b/ppx/test/merlin/uppercase.t/component.re
@@ -1,0 +1,17 @@
+module Box = {
+  [@react.component]
+  let make = (~children) => {
+    <div>
+      {children}
+    </div>;
+  };
+};
+
+module Uppercase = {
+  [@react.component]
+  let make = (~children) => {
+    <Box>
+      {children}
+    </Box>;
+  };
+};

--- a/ppx/test/merlin/uppercase.t/run.t
+++ b/ppx/test/merlin/uppercase.t/run.t
@@ -1,0 +1,62 @@
+Test some locations in reason-react components
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (melange.emit
+  >  (alias foo)
+  >  (target foo)
+  >  (libraries reason-react)
+  >  (preprocess
+  >   (pps melange.ppx reason-react-ppx)))
+  > EOF
+
+  $ dune build
+
+Let's test hovering over parts of the component
+
+`children` inside `<Box>` element
+
+  $ ocamlmerlin single type-enclosing -position 14:12 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 10,
+        "col": 19
+      },
+      "end": {
+        "line": 17,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~children: 'children, ~key: string=?, unit) => {. children: 'children}\n    = \"\" \"����\u0000\u0000\u0000\u001c\u0000\u0000\u0000\u000b\u0000\u0000\u0000\u001f\u0000\u0000\u0000\u001e���A�(children��A�#key@��@@@\";\n  let make: (~children: React.element) => React.element;\n  let make: {. children: React.element} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 10,
+        "col": 19
+      },
+      "end": {
+        "line": 17,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~children: 'children, ~key: string=?, unit) => {. children: 'children}\n    = \"\" \"����\u0000\u0000\u0000\u001c\u0000\u0000\u0000\u000b\u0000\u0000\u0000\u001f\u0000\u0000\u0000\u001e���A�(children��A�#key@��@@@\";\n  let make: {. children: React.element} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 10,
+        "col": 0
+      },
+      "end": {
+        "line": 17,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~children: 'children, ~key: string=?, unit) => {. children: 'children}\n    = \"\" \"����\u0000\u0000\u0000\u001c\u0000\u0000\u0000\u000b\u0000\u0000\u0000\u001f\u0000\u0000\u0000\u001e���A�(children��A�#key@��@@@\";\n  let make: {. children: React.element} => React.element;\n}",
+      "tail": "no"
+    }
+  ]

--- a/ppx/test/merlin/uppercase.t/run.t
+++ b/ppx/test/merlin/uppercase.t/run.t
@@ -25,6 +25,66 @@ Let's test hovering over parts of the component
   [
     {
       "start": {
+        "line": 14,
+        "col": 7
+      },
+      "end": {
+        "line": 14,
+        "col": 15
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 14,
+        "col": 6
+      },
+      "end": {
+        "line": 14,
+        "col": 16
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 12,
+        "col": 28
+      },
+      "end": {
+        "line": 16,
+        "col": 3
+      },
+      "type": "{. children: React.element}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 12,
+        "col": 28
+      },
+      "end": {
+        "line": 16,
+        "col": 3
+      },
+      "type": "React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 12,
+        "col": 13
+      },
+      "end": {
+        "line": 16,
+        "col": 3
+      },
+      "type": "(~children: React.element) => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
         "line": 10,
         "col": 19
       },

--- a/ppx/test/output.expected
+++ b/ppx/test/output.expected
@@ -1,47 +1,55 @@
-let lower = ReactDOM.jsx "div" (ReactDOM.domProps ())
+let lower = ReactDOM.jsx "div" (((ReactDOM.domProps)[@merlin.hide ]) ())
 let lower_empty_attr =
   ReactDOM.jsx "div"
-    (ReactDOM.domProps ~className:(("")[@reason.raw_literal ""]) ())
+    (((ReactDOM.domProps)[@merlin.hide ]) ~className:(("")
+       [@reason.raw_literal ""]) ())
 let lower_inline_styles =
   ReactDOM.jsx "div"
-    (ReactDOM.domProps
+    (((ReactDOM.domProps)[@merlin.hide ])
        ~style:((ReactDOM.Style.make ~backgroundColor:(("gainsboro")
                   [@reason.raw_literal "gainsboro"]) ())
        [@reason.preserve_braces ]) ())
 let lower_inner_html =
   ReactDOM.jsx "div"
-    (ReactDOM.domProps ~dangerouslySetInnerHTML:([%bs.obj { __html = text }])
-       ())
-let lower_opt_attr = ReactDOM.jsx "div" (ReactDOM.domProps ?tabIndex ())
+    (((ReactDOM.domProps)[@merlin.hide ])
+       ~dangerouslySetInnerHTML:([%bs.obj { __html = text }]) ())
+let lower_opt_attr =
+  ReactDOM.jsx "div" (((ReactDOM.domProps)[@merlin.hide ]) ?tabIndex ())
 let lowerWithChildAndProps foo =
   ReactDOM.jsx "a"
-    (ReactDOM.domProps ~children:foo ~tabIndex:1
+    (((ReactDOM.domProps)[@merlin.hide ]) ~children:foo ~tabIndex:1
        ~href:(("https://example.com")
        [@reason.raw_literal "https://example.com"]) ())
 let lower_child_static =
   ReactDOM.jsx "div"
-    (ReactDOM.domProps ~children:(ReactDOM.jsx "span" (ReactDOM.domProps ()))
-       ())
+    (((ReactDOM.domProps)[@merlin.hide ])
+       ~children:(ReactDOM.jsx "span"
+                    (((ReactDOM.domProps)[@merlin.hide ]) ())) ())
 let lower_child_ident =
-  ReactDOM.jsx "div" (ReactDOM.domProps ~children:lolaspa ())
+  ReactDOM.jsx "div"
+    (((ReactDOM.domProps)[@merlin.hide ]) ~children:lolaspa ())
 let lower_child_single =
   ReactDOM.jsx "div"
-    (ReactDOM.domProps ~children:(ReactDOM.jsx "div" (ReactDOM.domProps ()))
-       ())
+    (((ReactDOM.domProps)[@merlin.hide ])
+       ~children:(ReactDOM.jsx "div"
+                    (((ReactDOM.domProps)[@merlin.hide ]) ())) ())
 let lower_children_multiple foo bar =
   ReactDOM.jsxs "lower"
-    (ReactDOM.domProps ~children:(React.array [|foo;bar|]) ())
+    (((ReactDOM.domProps)[@merlin.hide ]) ~children:(React.array [|foo;bar|])
+       ())
 let lower_child_with_upper_as_children =
   ReactDOM.jsx "div"
-    (ReactDOM.domProps ~children:(React.jsx App.make (App.makeProps ())) ())
+    (((ReactDOM.domProps)[@merlin.hide ])
+       ~children:(React.jsx App.make ((App.makeProps ())[@merlin.hide ])) ())
 let lower_children_nested =
   ReactDOM.jsx "div"
-    (ReactDOM.domProps
+    (((ReactDOM.domProps)[@merlin.hide ])
        ~children:(ReactDOM.jsxs "div"
-                    (ReactDOM.domProps
+                    (((ReactDOM.domProps)[@merlin.hide ])
                        ~children:(React.array
                                     [|(ReactDOM.jsx "h2"
-                                         (ReactDOM.domProps
+                                         (((ReactDOM.domProps)
+                                            [@merlin.hide ])
                                             ~children:(((("jsoo-react")
                                                           [@reason.raw_literal
                                                             "jsoo-react"])
@@ -50,20 +58,25 @@ let lower_children_nested =
                                             ~className:(("title")
                                             [@reason.raw_literal "title"]) ()));(
                                       ReactDOM.jsx "nav"
-                                        (ReactDOM.domProps
+                                        (((ReactDOM.domProps)[@merlin.hide ])
                                            ~children:(ReactDOM.jsx "ul"
-                                                        (ReactDOM.domProps
+                                                        (((ReactDOM.domProps)
+                                                           [@merlin.hide ])
                                                            ~children:((
                                                            (examples |>
                                                               (List.map
                                                                  (fun e ->
                                                                     ReactDOM.jsxKeyed
                                                                     "li"
-                                                                    (ReactDOM.domProps
+                                                                    (((ReactDOM.domProps)
+                                                                    [@merlin.hide
+                                                                    ])
                                                                     ~children:(
                                                                     ReactDOM.jsx
                                                                     "a"
-                                                                    (ReactDOM.domProps
+                                                                    (((ReactDOM.domProps)
+                                                                    [@merlin.hide
+                                                                    ])
                                                                     ~children:((
                                                                     e.title
                                                                     |> s)
@@ -106,58 +119,67 @@ let nested_fragment foo bar baz =
     [|foo;(ReactDOM.createElement React.jsxFragment [|bar;baz|])|]
 let nested_fragment_with_lower foo =
   ReactDOM.createElement React.jsxFragment
-    [|(ReactDOM.jsx "div" (ReactDOM.domProps ~children:foo ()))|]
-let upper = React.jsx Upper.make (Upper.makeProps ())
-let upper_prop = React.jsx Upper.make (Upper.makeProps ~count ())
+    [|(ReactDOM.jsx "div"
+         (((ReactDOM.domProps)[@merlin.hide ]) ~children:foo ()))|]
+let upper = React.jsx Upper.make ((Upper.makeProps ())[@merlin.hide ])
+let upper_prop =
+  React.jsx Upper.make ((Upper.makeProps ~count ())[@merlin.hide ])
 let upper_children_single foo =
-  React.jsx Upper.make (Upper.makeProps ~children:foo ())
+  React.jsx Upper.make ((Upper.makeProps ~children:foo ())[@merlin.hide ])
 let upper_children_multiple foo bar =
   React.jsxs Upper.make
-    (Upper.makeProps ~children:(React.array [|foo;bar|]) ())
+    ((Upper.makeProps ~children:(React.array [|foo;bar|]) ())[@merlin.hide ])
 let upper_children =
   React.jsx Page.make
-    (Page.makeProps
-       ~children:(ReactDOM.jsx "h1"
-                    (ReactDOM.domProps
-                       ~children:((React.string (("Yep")
-                                     [@reason.raw_literal "Yep"]))
-                       [@reason.preserve_braces ]) ())) ~moreProps:(("hgalo")
-       [@reason.raw_literal "hgalo"]) ())
+    ((Page.makeProps
+        ~children:(ReactDOM.jsx "h1"
+                     (((ReactDOM.domProps)[@merlin.hide ])
+                        ~children:((React.string (("Yep")
+                                      [@reason.raw_literal "Yep"]))
+                        [@reason.preserve_braces ]) ()))
+        ~moreProps:(("hgalo")[@reason.raw_literal "hgalo"]) ())
+    [@merlin.hide ])
 let upper_nested_module =
   React.jsx Foo.Bar.make
-    (Foo.Bar.makeProps ~a:1 ~b:(("1")[@reason.raw_literal "1"]) ())
+    ((Foo.Bar.makeProps ~a:1 ~b:(("1")[@reason.raw_literal "1"]) ())
+    [@merlin.hide ])
 let upper_child_expr =
   React.jsx Div.make
-    (Div.makeProps ~children:((React.int 1)[@reason.preserve_braces ]) ())
-let upper_child_ident = React.jsx Div.make (Div.makeProps ~children:lola ())
+    ((Div.makeProps ~children:((React.int 1)[@reason.preserve_braces ]) ())
+    [@merlin.hide ])
+let upper_child_ident =
+  React.jsx Div.make ((Div.makeProps ~children:lola ())[@merlin.hide ])
 let upper_all_kinds_of_props =
   React.jsx MyComponent.make
-    (MyComponent.makeProps
-       ~children:(ReactDOM.jsx "div"
-                    (ReactDOM.domProps ~children:(("hello")
-                       [@reason.raw_literal "hello"]) ()))
-       ~booleanAttribute:true ~stringAttribute:(("string")
-       [@reason.raw_literal "string"]) ~intAttribute:1
-       ?forcedOptional:((Some (("hello")[@reason.raw_literal "hello"]))
-       [@reason.preserve_braces ][@explicit_arity ])
-       ~onClick:((send handleClick)[@reason.preserve_braces ]) ())
+    ((MyComponent.makeProps
+        ~children:(ReactDOM.jsx "div"
+                     (((ReactDOM.domProps)[@merlin.hide ])
+                        ~children:(("hello")[@reason.raw_literal "hello"]) ()))
+        ~booleanAttribute:true ~stringAttribute:(("string")
+        [@reason.raw_literal "string"]) ~intAttribute:1
+        ?forcedOptional:((Some (("hello")[@reason.raw_literal "hello"]))
+        [@reason.preserve_braces ][@explicit_arity ])
+        ~onClick:((send handleClick)[@reason.preserve_braces ]) ())
+    [@merlin.hide ])
 let upper_ref_with_children =
   React.jsx FancyButton.make
-    (FancyButton.makeProps
-       ~children:(ReactDOM.jsx "div" (ReactDOM.domProps ())) ~ref:buttonRef
-       ())
+    ((FancyButton.makeProps
+        ~children:(ReactDOM.jsx "div"
+                     (((ReactDOM.domProps)[@merlin.hide ]) ()))
+        ~ref:buttonRef ())[@merlin.hide ])
 let lower_ref_with_children =
   ReactDOM.jsx "button"
-    (ReactDOM.domProps ~children ~ref ~className:(("FancyButton")
-       [@reason.raw_literal "FancyButton"]) ())
+    (((ReactDOM.domProps)[@merlin.hide ]) ~children ~ref
+       ~className:(("FancyButton")[@reason.raw_literal "FancyButton"]) ())
 let lower_with_many_props =
   ReactDOM.jsx "div"
-    (ReactDOM.domProps
+    (((ReactDOM.domProps)[@merlin.hide ])
        ~children:(ReactDOM.jsxs "picture"
-                    (ReactDOM.domProps
+                    (((ReactDOM.domProps)[@merlin.hide ])
                        ~children:(React.array
                                     [|(ReactDOM.jsx "img"
-                                         (ReactDOM.domProps
+                                         (((ReactDOM.domProps)
+                                            [@merlin.hide ])
                                             ~src:(("picture/img.png")
                                             [@reason.raw_literal
                                               "picture/img.png"])
@@ -167,14 +189,14 @@ let lower_with_many_props =
                                             ~id:(("idimg")
                                             [@reason.raw_literal "idimg"]) ()));(
                                       ReactDOM.jsx "source"
-                                        (ReactDOM.domProps
+                                        (((ReactDOM.domProps)[@merlin.hide ])
                                            ~type_:(("image/webp")
                                            [@reason.raw_literal "image/webp"])
                                            ~src:(("picture/img1.webp")
                                            [@reason.raw_literal
                                              "picture/img1.webp"]) ()));(
                                       ReactDOM.jsx "source"
-                                        (ReactDOM.domProps
+                                        (((ReactDOM.domProps)[@merlin.hide ])
                                            ~type_:(("image/jpeg")
                                            [@reason.raw_literal "image/jpeg"])
                                            ~src:(("picture/img2.jpg")
@@ -185,8 +207,9 @@ let lower_with_many_props =
        ())
 let some_random_html_element =
   ReactDOM.jsx "text"
-    (ReactDOM.domProps ~dx:(("1 2")[@reason.raw_literal "1 2"]) ~dy:(("3 4")
-       [@reason.raw_literal "3 4"]) ())
+    (((ReactDOM.domProps)[@merlin.hide ]) ~dx:(("1 2")
+       [@reason.raw_literal "1 2"]) ~dy:(("3 4")[@reason.raw_literal "3 4"])
+       ())
 module React_component_with_props =
   struct
     external makeProps :
@@ -195,8 +218,8 @@ module React_component_with_props =
     let make =
       ((fun ~lola ->
           ((ReactDOM.jsx "div"
-              (ReactDOM.domProps ~children:((React.string lola)
-                 [@reason.preserve_braces ]) ()))
+              (((ReactDOM.domProps)[@merlin.hide ])
+                 ~children:((React.string lola)[@reason.preserve_braces ]) ()))
           [@reason.preserve_braces ]))
       [@warning "-16"])
     let make =
@@ -207,8 +230,8 @@ module React_component_with_props =
   end
 let react_component_with_props =
   React.jsx React_component_with_props.make
-    (React_component_with_props.makeProps ~lola:(("flores")
-       [@reason.raw_literal "flores"]) ())
+    ((React_component_with_props.makeProps ~lola:(("flores")
+        [@reason.raw_literal "flores"]) ())[@merlin.hide ])
 module Upper_case_with_fragment_as_root =
   struct
     external makeProps :
@@ -218,16 +241,16 @@ module Upper_case_with_fragment_as_root =
       ((fun ?(name= (("")[@reason.raw_literal ""])) ->
           ReactDOM.createElement React.jsxFragment
             [|(ReactDOM.jsx "div"
-                 (ReactDOM.domProps
+                 (((ReactDOM.domProps)[@merlin.hide ])
                     ~children:((React.string
                                   ((("First ")[@reason.raw_literal "First "])
                                      ^ name))[@reason.preserve_braces ]) ()));(
               React.jsx Hello.make
-                (Hello.makeProps
-                   ~children:((React.string
-                                 ((("2nd ")[@reason.raw_literal "2nd "]) ^
-                                    name))[@reason.preserve_braces ])
-                   ~one:(("1")[@reason.raw_literal "1"]) ()))|])
+                ((Hello.makeProps
+                    ~children:((React.string
+                                  ((("2nd ")[@reason.raw_literal "2nd "]) ^
+                                     name))[@reason.preserve_braces ])
+                    ~one:(("1")[@reason.raw_literal "1"]) ())[@merlin.hide ]))|])
       [@warning "-16"])
     let make =
       let Generated$Upper_case_with_fragment_as_root
@@ -247,8 +270,8 @@ module Forward_Ref =
       ((fun ~children ->
           ((fun ~buttonRef ->
               ((ReactDOM.jsx "button"
-                  (ReactDOM.domProps ~children ~ref:buttonRef
-                     ~className:(("FancyButton")
+                  (((ReactDOM.domProps)[@merlin.hide ]) ~children
+                     ~ref:buttonRef ~className:(("FancyButton")
                      [@reason.raw_literal "FancyButton"]) ()))
               [@reason.preserve_braces ]))
           [@warning "-16"]))
@@ -275,7 +298,8 @@ module Onclick_handler_button =
           ((fun ?isDisabled ->
               ((let onClick event = Js.log event in
                 ReactDOM.jsx "button"
-                  (ReactDOM.domProps ~name ~onClick ~disabled:isDisabled ()))
+                  (((ReactDOM.domProps)[@merlin.hide ]) ~name ~onClick
+                     ~disabled:isDisabled ()))
               [@reason.preserve_braces ]))
           [@warning "-16"]))
       [@warning "-16"])
@@ -294,7 +318,7 @@ module Children_as_string =
     let make =
       ((fun ?(name= (("joe")[@reason.raw_literal "joe"])) ->
           ReactDOM.jsx "div"
-            (ReactDOM.domProps
+            (((ReactDOM.domProps)[@merlin.hide ])
                ~children:(((Printf.sprintf (("`name` is %s")
                               [@reason.raw_literal "`name` is %s"]) name)
                              |> React.string)[@reason.preserve_braces ]) ()))
@@ -319,12 +343,13 @@ module Uppercase_with_SSR_components =
       ((fun ~children ->
           ((fun ~moreProps ->
               ReactDOM.jsxs "html"
-                (ReactDOM.domProps
+                (((ReactDOM.domProps)[@merlin.hide ])
                    ~children:(React.array
                                 [|(ReactDOM.jsx "head"
-                                     (ReactDOM.domProps
+                                     (((ReactDOM.domProps)[@merlin.hide ])
                                         ~children:(ReactDOM.jsx "title"
-                                                     (ReactDOM.domProps
+                                                     (((ReactDOM.domProps)
+                                                        [@merlin.hide ])
                                                         ~children:((React.string
                                                                     ((("SSR React ")
                                                                     [@reason.raw_literal
@@ -334,16 +359,18 @@ module Uppercase_with_SSR_components =
                                                         [@reason.preserve_braces
                                                           ]) ())) ()));(
                                   ReactDOM.jsxs "body"
-                                    (ReactDOM.domProps
+                                    (((ReactDOM.domProps)[@merlin.hide ])
                                        ~children:(React.array
                                                     [|(ReactDOM.jsx "div"
-                                                         (ReactDOM.domProps
+                                                         (((ReactDOM.domProps)
+                                                            [@merlin.hide ])
                                                             ~children
                                                             ~id:(("root")
                                                             [@reason.raw_literal
                                                               "root"]) ()));(
                                                       ReactDOM.jsx "script"
-                                                        (ReactDOM.domProps
+                                                        (((ReactDOM.domProps)
+                                                           [@merlin.hide ])
                                                            ~src:(("/static/client.js")
                                                            [@reason.raw_literal
                                                              "/static/client.js"])
@@ -366,8 +393,8 @@ module Upper_with_aria =
     let make =
       ((fun ~children ->
           ReactDOM.jsx "div"
-            (ReactDOM.domProps ~children ~ariaHidden:(("true")
-               [@reason.raw_literal "true"]) ()))
+            (((ReactDOM.domProps)[@merlin.hide ]) ~children
+               ~ariaHidden:(("true")[@reason.raw_literal "true"]) ()))
       [@warning "-16"])
     let make =
       let Generated$Upper_with_aria (Props : < children: 'children   >  Js.t)
@@ -377,15 +404,18 @@ module Upper_with_aria =
 let data_attributes_should_transform_to_kebabcase =
   ReactDOM.createElement React.jsxFragment
     [|(ReactDOM.jsx "div"
-         (ReactDOM.domProps ~dataAttribute:(("")[@reason.raw_literal ""])
-            ~dataattribute:(("")[@reason.raw_literal ""])
-            ~className:(("md:w-1/3")[@reason.raw_literal "md:w-1/3"]) ()));(
-      ReactDOM.jsx "div"
-        (ReactDOM.domProps ~className:(("md:w-2/3")
-           [@reason.raw_literal "md:w-2/3"]) ()))|]
+         (((ReactDOM.domProps)[@merlin.hide ]) ~dataAttribute:(("")
+            [@reason.raw_literal ""]) ~dataattribute:(("")
+            [@reason.raw_literal ""]) ~className:(("md:w-1/3")
+            [@reason.raw_literal "md:w-1/3"]) ()));(ReactDOM.jsx "div"
+                                                      (((ReactDOM.domProps)
+                                                         [@merlin.hide ])
+                                                         ~className:(("md:w-2/3")
+                                                         [@reason.raw_literal
+                                                           "md:w-2/3"]) ()))|]
 let render_onclickPropsAsString =
   ReactDOM.jsx "div"
-    (ReactDOM.domProps ~_onclick:(("alert('hello')")
+    (((ReactDOM.domProps)[@merlin.hide ]) ~_onclick:(("alert('hello')")
        [@reason.raw_literal "alert('hello')"]) ())
 module External =
   struct
@@ -415,7 +445,8 @@ module Func(M:X_int) =
                     (("This function should be named `Test$Func`")
                     [@reason.raw_literal
                       "This function should be named `Test$Func`"]) M.x;
-                  ReactDOM.jsx "div" (ReactDOM.domProps ()))
+                  ReactDOM.jsx "div"
+                    (((ReactDOM.domProps)[@merlin.hide ]) ()))
                 [@reason.preserve_braces ]))
           [@warning "-16"]))
       [@warning "-16"])

--- a/ppx/test/output.expected
+++ b/ppx/test/output.expected
@@ -1,10 +1,13 @@
 let lower = ReactDOM.jsx "div" (ReactDOM.domProps ())
 let lower_empty_attr =
-  ReactDOM.jsx "div" (ReactDOM.domProps ~className:"" ())
+  ReactDOM.jsx "div"
+    (ReactDOM.domProps ~className:(("")[@reason.raw_literal ""]) ())
 let lower_inline_styles =
   ReactDOM.jsx "div"
     (ReactDOM.domProps
-       ~style:(ReactDOM.Style.make ~backgroundColor:"gainsboro" ()) ())
+       ~style:((ReactDOM.Style.make ~backgroundColor:(("gainsboro")
+                  [@reason.raw_literal "gainsboro"]) ())
+       [@reason.preserve_braces ]) ())
 let lower_inner_html =
   ReactDOM.jsx "div"
     (ReactDOM.domProps ~dangerouslySetInnerHTML:([%bs.obj { __html = text }])
@@ -12,8 +15,9 @@ let lower_inner_html =
 let lower_opt_attr = ReactDOM.jsx "div" (ReactDOM.domProps ?tabIndex ())
 let lowerWithChildAndProps foo =
   ReactDOM.jsx "a"
-    (ReactDOM.domProps ~children:foo ~tabIndex:1 ~href:"https://example.com"
-       ())
+    (ReactDOM.domProps ~children:foo ~tabIndex:1
+       ~href:(("https://example.com")
+       [@reason.raw_literal "https://example.com"]) ())
 let lower_child_static =
   ReactDOM.jsx "div"
     (ReactDOM.domProps ~children:(ReactDOM.jsx "span" (ReactDOM.domProps ()))
@@ -38,13 +42,18 @@ let lower_children_nested =
                        ~children:(React.array
                                     [|(ReactDOM.jsx "h2"
                                          (ReactDOM.domProps
-                                            ~children:("jsoo-react" |> s)
-                                            ~className:"title" ()));(
+                                            ~children:(((("jsoo-react")
+                                                          [@reason.raw_literal
+                                                            "jsoo-react"])
+                                                          |> s)
+                                            [@reason.preserve_braces ])
+                                            ~className:(("title")
+                                            [@reason.raw_literal "title"]) ()));(
                                       ReactDOM.jsx "nav"
                                         (ReactDOM.domProps
                                            ~children:(ReactDOM.jsx "ul"
                                                         (ReactDOM.domProps
-                                                           ~children:(
+                                                           ~children:((
                                                            (examples |>
                                                               (List.map
                                                                  (fun e ->
@@ -55,24 +64,38 @@ let lower_children_nested =
                                                                     ReactDOM.jsx
                                                                     "a"
                                                                     (ReactDOM.domProps
-                                                                    ~children:(
+                                                                    ~children:((
                                                                     e.title
                                                                     |> s)
-                                                                    ~href:(
+                                                                    [@reason.preserve_braces
+                                                                    ])
+                                                                    ~href:((
                                                                     e.path)
-                                                                    ~onClick:(
+                                                                    [@reason.preserve_braces
+                                                                    ])
+                                                                    ~onClick:((
                                                                     fun event
                                                                     ->
-                                                                    ReactEvent.Mouse.preventDefault
+                                                                    ((ReactEvent.Mouse.preventDefault
                                                                     event;
                                                                     ReactRouter.push
                                                                     e.path)
-                                                                    ())) ())
-                                                                    e.path)))
+                                                                    [@reason.preserve_braces
+                                                                    ]))
+                                                                    [@reason.preserve_braces
+                                                                    ]) ()))
+                                                                    ())
+                                                                    ((e.path)
+                                                                    [@reason.preserve_braces
+                                                                    ]))))
                                                              |> React.list)
-                                                           ()))
-                                           ~className:"menu" ()))|])
-                       ~className:"sidebar" ())) ~className:"flex-container"
+                                                           [@reason.preserve_braces
+                                                             ]) ()))
+                                           ~className:(("menu")
+                                           [@reason.raw_literal "menu"]) ()))|])
+                       ~className:(("sidebar")
+                       [@reason.raw_literal "sidebar"]) ()))
+       ~className:(("flex-container")[@reason.raw_literal "flex-container"])
        ())
 let fragment foo = ((ReactDOM.createElement React.jsxFragment [|foo|])
   [@bla ])
@@ -95,20 +118,29 @@ let upper_children =
   React.jsx Page.make
     (Page.makeProps
        ~children:(ReactDOM.jsx "h1"
-                    (ReactDOM.domProps ~children:(React.string "Yep") ()))
-       ~moreProps:"hgalo" ())
+                    (ReactDOM.domProps
+                       ~children:((React.string (("Yep")
+                                     [@reason.raw_literal "Yep"]))
+                       [@reason.preserve_braces ]) ())) ~moreProps:(("hgalo")
+       [@reason.raw_literal "hgalo"]) ())
 let upper_nested_module =
-  React.jsx Foo.Bar.make (Foo.Bar.makeProps ~a:1 ~b:"1" ())
+  React.jsx Foo.Bar.make
+    (Foo.Bar.makeProps ~a:1 ~b:(("1")[@reason.raw_literal "1"]) ())
 let upper_child_expr =
-  React.jsx Div.make (Div.makeProps ~children:(React.int 1) ())
+  React.jsx Div.make
+    (Div.makeProps ~children:((React.int 1)[@reason.preserve_braces ]) ())
 let upper_child_ident = React.jsx Div.make (Div.makeProps ~children:lola ())
 let upper_all_kinds_of_props =
   React.jsx MyComponent.make
     (MyComponent.makeProps
-       ~children:(ReactDOM.jsx "div" (ReactDOM.domProps ~children:"hello" ()))
-       ~booleanAttribute:true ~stringAttribute:"string" ~intAttribute:1
-       ?forcedOptional:((Some "hello")[@explicit_arity ])
-       ~onClick:(send handleClick) ())
+       ~children:(ReactDOM.jsx "div"
+                    (ReactDOM.domProps ~children:(("hello")
+                       [@reason.raw_literal "hello"]) ()))
+       ~booleanAttribute:true ~stringAttribute:(("string")
+       [@reason.raw_literal "string"]) ~intAttribute:1
+       ?forcedOptional:((Some (("hello")[@reason.raw_literal "hello"]))
+       [@reason.preserve_braces ][@explicit_arity ])
+       ~onClick:((send handleClick)[@reason.preserve_braces ]) ())
 let upper_ref_with_children =
   React.jsx FancyButton.make
     (FancyButton.makeProps
@@ -116,7 +148,8 @@ let upper_ref_with_children =
        ())
 let lower_ref_with_children =
   ReactDOM.jsx "button"
-    (ReactDOM.domProps ~children ~ref ~className:"FancyButton" ())
+    (ReactDOM.domProps ~children ~ref ~className:(("FancyButton")
+       [@reason.raw_literal "FancyButton"]) ())
 let lower_with_many_props =
   ReactDOM.jsx "div"
     (ReactDOM.domProps
@@ -125,21 +158,35 @@ let lower_with_many_props =
                        ~children:(React.array
                                     [|(ReactDOM.jsx "img"
                                          (ReactDOM.domProps
-                                            ~src:"picture/img.png"
-                                            ~alt:"test picture/img.png"
-                                            ~id:"idimg" ()));(ReactDOM.jsx
-                                                                "source"
-                                                                (ReactDOM.domProps
-                                                                   ~type_:"image/webp"
-                                                                   ~src:"picture/img1.webp"
-                                                                   ()));(
+                                            ~src:(("picture/img.png")
+                                            [@reason.raw_literal
+                                              "picture/img.png"])
+                                            ~alt:(("test picture/img.png")
+                                            [@reason.raw_literal
+                                              "test picture/img.png"])
+                                            ~id:(("idimg")
+                                            [@reason.raw_literal "idimg"]) ()));(
                                       ReactDOM.jsx "source"
                                         (ReactDOM.domProps
-                                           ~type_:"image/jpeg"
-                                           ~src:"picture/img2.jpg" ()))|])
-                       ~id:"idpicture" ())) ~translate:"yes" ())
+                                           ~type_:(("image/webp")
+                                           [@reason.raw_literal "image/webp"])
+                                           ~src:(("picture/img1.webp")
+                                           [@reason.raw_literal
+                                             "picture/img1.webp"]) ()));(
+                                      ReactDOM.jsx "source"
+                                        (ReactDOM.domProps
+                                           ~type_:(("image/jpeg")
+                                           [@reason.raw_literal "image/jpeg"])
+                                           ~src:(("picture/img2.jpg")
+                                           [@reason.raw_literal
+                                             "picture/img2.jpg"]) ()))|])
+                       ~id:(("idpicture")[@reason.raw_literal "idpicture"])
+                       ())) ~translate:(("yes")[@reason.raw_literal "yes"])
+       ())
 let some_random_html_element =
-  ReactDOM.jsx "text" (ReactDOM.domProps ~dx:"1 2" ~dy:"3 4" ())
+  ReactDOM.jsx "text"
+    (ReactDOM.domProps ~dx:(("1 2")[@reason.raw_literal "1 2"]) ~dy:(("3 4")
+       [@reason.raw_literal "3 4"]) ())
 module React_component_with_props =
   struct
     external makeProps :
@@ -147,8 +194,10 @@ module React_component_with_props =
     [@@bs.obj ]
     let make =
       ((fun ~lola ->
-          ReactDOM.jsx "div"
-            (ReactDOM.domProps ~children:(React.string lola) ()))
+          ((ReactDOM.jsx "div"
+              (ReactDOM.domProps ~children:((React.string lola)
+                 [@reason.preserve_braces ]) ()))
+          [@reason.preserve_braces ]))
       [@warning "-16"])
     let make =
       let Generated$React_component_with_props
@@ -157,21 +206,27 @@ module React_component_with_props =
   end
 let react_component_with_props =
   React.jsx React_component_with_props.make
-    (React_component_with_props.makeProps ~lola:"flores" ())
+    (React_component_with_props.makeProps ~lola:(("flores")
+       [@reason.raw_literal "flores"]) ())
 module Upper_case_with_fragment_as_root =
   struct
     external makeProps :
       ?name:'name -> ?key:string -> unit -> < name: 'name option   >  Js.t =
         ""[@@bs.obj ]
     let make =
-      ((fun ?(name= "") ->
+      ((fun ?(name= (("")[@reason.raw_literal ""])) ->
           ReactDOM.createElement React.jsxFragment
             [|(ReactDOM.jsx "div"
                  (ReactDOM.domProps
-                    ~children:(React.string ("First " ^ name)) ()));(
+                    ~children:((React.string
+                                  ((("First ")[@reason.raw_literal "First "])
+                                     ^ name))[@reason.preserve_braces ]) ()));(
               React.jsx Hello.make
-                (Hello.makeProps ~children:(React.string ("2nd " ^ name))
-                   ~one:"1" ()))|])
+                (Hello.makeProps
+                   ~children:((React.string
+                                 ((("2nd ")[@reason.raw_literal "2nd "]) ^
+                                    name))[@reason.preserve_braces ])
+                   ~one:(("1")[@reason.raw_literal "1"]) ()))|])
       [@warning "-16"])
     let make =
       let Generated$Upper_case_with_fragment_as_root
@@ -189,9 +244,11 @@ module Forward_Ref =
     let make =
       ((fun ~children ->
           ((fun ~buttonRef ->
-              ReactDOM.jsx "button"
-                (ReactDOM.domProps ~children ~ref:buttonRef
-                   ~className:"FancyButton" ()))
+              ((ReactDOM.jsx "button"
+                  (ReactDOM.domProps ~children ~ref:buttonRef
+                     ~className:(("FancyButton")
+                     [@reason.raw_literal "FancyButton"]) ()))
+              [@reason.preserve_braces ]))
           [@warning "-16"]))
       [@warning "-16"])
     let make =
@@ -213,9 +270,10 @@ module Onclick_handler_button =
     let make =
       ((fun ~name ->
           ((fun ?isDisabled ->
-              let onClick event = Js.log event in
-              ReactDOM.jsx "button"
-                (ReactDOM.domProps ~name ~onClick ~disabled:isDisabled ()))
+              ((let onClick event = Js.log event in
+                ReactDOM.jsx "button"
+                  (ReactDOM.domProps ~name ~onClick ~disabled:isDisabled ()))
+              [@reason.preserve_braces ]))
           [@warning "-16"]))
       [@warning "-16"])
     let make =
@@ -230,11 +288,12 @@ module Children_as_string =
       ?name:'name -> ?key:string -> unit -> < name: 'name option   >  Js.t =
         ""[@@bs.obj ]
     let make =
-      ((fun ?(name= "joe") ->
+      ((fun ?(name= (("joe")[@reason.raw_literal "joe"])) ->
           ReactDOM.jsx "div"
             (ReactDOM.domProps
-               ~children:((Printf.sprintf "`name` is %s" name) |>
-                            React.string) ()))
+               ~children:(((Printf.sprintf (("`name` is %s")
+                              [@reason.raw_literal "`name` is %s"]) name)
+                             |> React.string)[@reason.preserve_braces ]) ()))
       [@warning "-16"])
     let make =
       let Generated$Children_as_string
@@ -261,29 +320,29 @@ module Uppercase_with_SSR_components =
                                      (ReactDOM.domProps
                                         ~children:(ReactDOM.jsx "title"
                                                      (ReactDOM.domProps
-                                                        ~children:(React.string
-                                                                    ("SSR React "
+                                                        ~children:((React.string
+                                                                    ((("SSR React ")
+                                                                    [@reason.raw_literal
+                                                                    "SSR React "])
                                                                     ^
                                                                     moreProps))
-                                                        ())) ()));(ReactDOM.jsxs
-                                                                    "body"
-                                                                    (ReactDOM.domProps
-                                                                    ~children:(
-                                                                    React.array
-                                                                    [|(
-                                                                    ReactDOM.jsx
-                                                                    "div"
-                                                                    (ReactDOM.domProps
-                                                                    ~children
-                                                                    ~id:"root"
-                                                                    ()));(
-                                                                    ReactDOM.jsx
-                                                                    "script"
-                                                                    (ReactDOM.domProps
-                                                                    ~src:"/static/client.js"
-                                                                    ()))|])
-                                                                    ()))|])
-                   ()))
+                                                        [@reason.preserve_braces
+                                                          ]) ())) ()));(
+                                  ReactDOM.jsxs "body"
+                                    (ReactDOM.domProps
+                                       ~children:(React.array
+                                                    [|(ReactDOM.jsx "div"
+                                                         (ReactDOM.domProps
+                                                            ~children
+                                                            ~id:(("root")
+                                                            [@reason.raw_literal
+                                                              "root"]) ()));(
+                                                      ReactDOM.jsx "script"
+                                                        (ReactDOM.domProps
+                                                           ~src:(("/static/client.js")
+                                                           [@reason.raw_literal
+                                                             "/static/client.js"])
+                                                           ()))|]) ()))|]) ()))
           [@warning "-16"]))
       [@warning "-16"])
     let make =
@@ -301,7 +360,8 @@ module Upper_with_aria =
     let make =
       ((fun ~children ->
           ReactDOM.jsx "div"
-            (ReactDOM.domProps ~children ~ariaHidden:"true" ()))
+            (ReactDOM.domProps ~children ~ariaHidden:(("true")
+               [@reason.raw_literal "true"]) ()))
       [@warning "-16"])
     let make =
       let Generated$Upper_with_aria (Props : < children: 'children   >  Js.t)
@@ -311,12 +371,16 @@ module Upper_with_aria =
 let data_attributes_should_transform_to_kebabcase =
   ReactDOM.createElement React.jsxFragment
     [|(ReactDOM.jsx "div"
-         (ReactDOM.domProps ~dataAttribute:"" ~dataattribute:""
-            ~className:"md:w-1/3" ()));(ReactDOM.jsx "div"
-                                          (ReactDOM.domProps
-                                             ~className:"md:w-2/3" ()))|]
+         (ReactDOM.domProps ~dataAttribute:(("")[@reason.raw_literal ""])
+            ~dataattribute:(("")[@reason.raw_literal ""])
+            ~className:(("md:w-1/3")[@reason.raw_literal "md:w-1/3"]) ()));(
+      ReactDOM.jsx "div"
+        (ReactDOM.domProps ~className:(("md:w-2/3")
+           [@reason.raw_literal "md:w-2/3"]) ()))|]
 let render_onclickPropsAsString =
-  ReactDOM.jsx "div" (ReactDOM.domProps ~_onclick:"alert('hello')" ())
+  ReactDOM.jsx "div"
+    (ReactDOM.domProps ~_onclick:(("alert('hello')")
+       [@reason.raw_literal "alert('hello')"]) ())
 module External =
   struct
     external componentProps :
@@ -326,7 +390,9 @@ module External =
     external component :
       (< a: int  ;b: string   >  Js.t, React.element) React.componentLike =
         "require(\"my-react-library\").MyReactComponent"[@@otherAttribute
-                                                          "bla"]
+                                                          (("bla")
+                                                            [@reason.raw_literal
+                                                              "bla"])]
   end
 module type X_int  = sig val x : int end
 module Func(M:X_int) =
@@ -339,8 +405,12 @@ module Func(M:X_int) =
       ((fun ~a ->
           ((fun ~b ->
               fun _ ->
-                print_endline "This function should be named `Test$Func`" M.x;
-                ReactDOM.jsx "div" (ReactDOM.domProps ()))
+                ((print_endline
+                    (("This function should be named `Test$Func`")
+                    [@reason.raw_literal
+                      "This function should be named `Test$Func`"]) M.x;
+                  ReactDOM.jsx "div" (ReactDOM.domProps ()))
+                [@reason.preserve_braces ]))
           [@warning "-16"]))
       [@warning "-16"])
     let make =

--- a/ppx/test/output.expected
+++ b/ppx/test/output.expected
@@ -35,7 +35,7 @@ let lower_children_multiple foo bar =
 let lower_child_with_upper_as_children =
   ReactDOM.jsx "div"
     (((ReactDOM.domProps)[@merlin.hide ])
-       ~children:(React.jsx App.make ((App.makeProps ())[@merlin.hide ])) ())
+       ~children:(React.jsx App.make (App.makeProps ())) ())
 let lower_children_nested =
   ReactDOM.jsx "div"
     (((ReactDOM.domProps)[@merlin.hide ])
@@ -97,42 +97,39 @@ let nested_fragment_with_lower foo =
   ReactDOM.createElement React.jsxFragment
     [|(ReactDOM.jsx "div"
          (((ReactDOM.domProps)[@merlin.hide ]) ~children:foo ()))|]
-let upper = React.jsx Upper.make ((Upper.makeProps ())[@merlin.hide ])
-let upper_prop =
-  React.jsx Upper.make ((Upper.makeProps ~count ())[@merlin.hide ])
+let upper = React.jsx Upper.make (Upper.makeProps ())
+let upper_prop = React.jsx Upper.make (Upper.makeProps ~count ())
 let upper_children_single foo =
-  React.jsx Upper.make ((Upper.makeProps ~children:foo ())[@merlin.hide ])
+  React.jsx Upper.make (Upper.makeProps ~children:foo ())
 let upper_children_multiple foo bar =
   React.jsxs Upper.make
-    ((Upper.makeProps ~children:(React.array [|foo;bar|]) ())[@merlin.hide ])
+    (Upper.makeProps ~children:(React.array [|foo;bar|]) ())
 let upper_children =
   React.jsx Page.make
-    ((Page.makeProps
-        ~children:(ReactDOM.jsx "h1"
-                     (((ReactDOM.domProps)[@merlin.hide ])
-                        ~children:(React.string "Yep") ()))
-        ~moreProps:"hgalo" ())[@merlin.hide ])
+    (Page.makeProps
+       ~children:(ReactDOM.jsx "h1"
+                    (((ReactDOM.domProps)[@merlin.hide ])
+                       ~children:(React.string "Yep") ())) ~moreProps:"hgalo"
+       ())
 let upper_nested_module =
-  React.jsx Foo.Bar.make ((Foo.Bar.makeProps ~a:1 ~b:"1" ())[@merlin.hide ])
+  React.jsx Foo.Bar.make (Foo.Bar.makeProps ~a:1 ~b:"1" ())
 let upper_child_expr =
-  React.jsx Div.make ((Div.makeProps ~children:(React.int 1) ())
-    [@merlin.hide ])
-let upper_child_ident =
-  React.jsx Div.make ((Div.makeProps ~children:lola ())[@merlin.hide ])
+  React.jsx Div.make (Div.makeProps ~children:(React.int 1) ())
+let upper_child_ident = React.jsx Div.make (Div.makeProps ~children:lola ())
 let upper_all_kinds_of_props =
   React.jsx MyComponent.make
-    ((MyComponent.makeProps
-        ~children:(ReactDOM.jsx "div"
-                     (((ReactDOM.domProps)[@merlin.hide ]) ~children:"hello"
-                        ())) ~booleanAttribute:true ~stringAttribute:"string"
-        ~intAttribute:1 ?forcedOptional:((Some "hello")[@explicit_arity ])
-        ~onClick:(send handleClick) ())[@merlin.hide ])
+    (MyComponent.makeProps
+       ~children:(ReactDOM.jsx "div"
+                    (((ReactDOM.domProps)[@merlin.hide ]) ~children:"hello"
+                       ())) ~booleanAttribute:true ~stringAttribute:"string"
+       ~intAttribute:1 ?forcedOptional:((Some "hello")[@explicit_arity ])
+       ~onClick:(send handleClick) ())
 let upper_ref_with_children =
   React.jsx FancyButton.make
-    ((FancyButton.makeProps
-        ~children:(ReactDOM.jsx "div"
-                     (((ReactDOM.domProps)[@merlin.hide ]) ()))
-        ~ref:buttonRef ())[@merlin.hide ])
+    (FancyButton.makeProps
+       ~children:(ReactDOM.jsx "div"
+                    (((ReactDOM.domProps)[@merlin.hide ]) ())) ~ref:buttonRef
+       ())
 let lower_ref_with_children =
   ReactDOM.jsx "button"
     (((ReactDOM.domProps)[@merlin.hide ]) ~children ~ref
@@ -177,13 +174,12 @@ module React_component_with_props =
       [@warning "-16"])
     let make =
       let Generated$React_component_with_props
-        (Props : < lola: 'lola   >  Js.t) = make ~lola:(Props ## lola)
-        [@@merlin.hide ] in
+        (Props : < lola: 'lola   >  Js.t) = make ~lola:(Props ## lola) in
       Generated$React_component_with_props
   end
 let react_component_with_props =
   React.jsx React_component_with_props.make
-    ((React_component_with_props.makeProps ~lola:"flores" ())[@merlin.hide ])
+    (React_component_with_props.makeProps ~lola:"flores" ())
 module Upper_case_with_fragment_as_root =
   struct
     external makeProps :
@@ -196,13 +192,12 @@ module Upper_case_with_fragment_as_root =
                  (((ReactDOM.domProps)[@merlin.hide ])
                     ~children:(React.string ("First " ^ name)) ()));(
               React.jsx Hello.make
-                ((Hello.makeProps ~children:(React.string ("2nd " ^ name))
-                    ~one:"1" ())[@merlin.hide ]))|])
+                (Hello.makeProps ~children:(React.string ("2nd " ^ name))
+                   ~one:"1" ()))|])
       [@warning "-16"])
     let make =
       let Generated$Upper_case_with_fragment_as_root
-        (Props : < name: 'name option   >  Js.t) = make ?name:(Props ## name)
-        [@@merlin.hide ] in
+        (Props : < name: 'name option   >  Js.t) = make ?name:(Props ## name) in
       Generated$Upper_case_with_fragment_as_root
   end
 module Forward_Ref =
@@ -226,8 +221,7 @@ module Forward_Ref =
         (let Generated$Forward_Ref
            (Props : < children: 'children  ;buttonRef: 'buttonRef   >  Js.t)
            =
-           make ~buttonRef:(Props ## buttonRef) ~children:(Props ## children)
-           [@@merlin.hide ] in
+           make ~buttonRef:(Props ## buttonRef) ~children:(Props ## children) in
          Generated$Forward_Ref)
   end
 module Onclick_handler_button =
@@ -250,8 +244,7 @@ module Onclick_handler_button =
     let make =
       let Generated$Onclick_handler_button
         (Props : < name: 'name  ;isDisabled: 'isDisabled option   >  Js.t) =
-        make ?isDisabled:(Props ## isDisabled) ~name:(Props ## name)[@@merlin.hide
-                                                                    ] in
+        make ?isDisabled:(Props ## isDisabled) ~name:(Props ## name) in
       Generated$Onclick_handler_button
   end
 module Children_as_string =
@@ -268,8 +261,7 @@ module Children_as_string =
       [@warning "-16"])
     let make =
       let Generated$Children_as_string
-        (Props : < name: 'name option   >  Js.t) = make ?name:(Props ## name)
-        [@@merlin.hide ] in
+        (Props : < name: 'name option   >  Js.t) = make ?name:(Props ## name) in
       Generated$Children_as_string
   end
 let () = Dream.run ()
@@ -327,8 +319,7 @@ module Uppercase_with_SSR_components =
     let make =
       let Generated$Uppercase_with_SSR_components
         (Props : < children: 'children  ;moreProps: 'moreProps   >  Js.t) =
-        make ~moreProps:(Props ## moreProps) ~children:(Props ## children)
-        [@@merlin.hide ] in
+        make ~moreProps:(Props ## moreProps) ~children:(Props ## children) in
       Generated$Uppercase_with_SSR_components
   end
 module Upper_with_aria =
@@ -345,7 +336,7 @@ module Upper_with_aria =
       [@warning "-16"])
     let make =
       let Generated$Upper_with_aria (Props : < children: 'children   >  Js.t)
-        = make ~children:(Props ## children)[@@merlin.hide ] in
+        = make ~children:(Props ## children) in
       Generated$Upper_with_aria
   end
 let data_attributes_should_transform_to_kebabcase =
@@ -389,6 +380,6 @@ module Func(M:X_int) =
       [@warning "-16"])
     let make =
       let Generated$Func (Props : < a: 'a  ;b: 'b   >  Js.t) =
-        make ~b:(Props ## b) ~a:(Props ## a) ()[@@merlin.hide ] in
+        make ~b:(Props ## b) ~a:(Props ## a) () in
       Generated$Func
   end

--- a/ppx/test/output.expected
+++ b/ppx/test/output.expected
@@ -201,7 +201,8 @@ module React_component_with_props =
       [@warning "-16"])
     let make =
       let Generated$React_component_with_props
-        (Props : < lola: 'lola   >  Js.t) = make ~lola:(Props ## lola) in
+        (Props : < lola: 'lola   >  Js.t) = make ~lola:(Props ## lola)
+        [@@merlin.hide ] in
       Generated$React_component_with_props
   end
 let react_component_with_props =
@@ -230,7 +231,8 @@ module Upper_case_with_fragment_as_root =
       [@warning "-16"])
     let make =
       let Generated$Upper_case_with_fragment_as_root
-        (Props : < name: 'name option   >  Js.t) = make ?name:(Props ## name) in
+        (Props : < name: 'name option   >  Js.t) = make ?name:(Props ## name)
+        [@@merlin.hide ] in
       Generated$Upper_case_with_fragment_as_root
   end
 module Forward_Ref =
@@ -256,7 +258,8 @@ module Forward_Ref =
         (let Generated$Forward_Ref
            (Props : < children: 'children  ;buttonRef: 'buttonRef   >  Js.t)
            =
-           make ~buttonRef:(Props ## buttonRef) ~children:(Props ## children) in
+           make ~buttonRef:(Props ## buttonRef) ~children:(Props ## children)
+           [@@merlin.hide ] in
          Generated$Forward_Ref)
   end
 module Onclick_handler_button =
@@ -279,7 +282,8 @@ module Onclick_handler_button =
     let make =
       let Generated$Onclick_handler_button
         (Props : < name: 'name  ;isDisabled: 'isDisabled option   >  Js.t) =
-        make ?isDisabled:(Props ## isDisabled) ~name:(Props ## name) in
+        make ?isDisabled:(Props ## isDisabled) ~name:(Props ## name)[@@merlin.hide
+                                                                    ] in
       Generated$Onclick_handler_button
   end
 module Children_as_string =
@@ -297,7 +301,8 @@ module Children_as_string =
       [@warning "-16"])
     let make =
       let Generated$Children_as_string
-        (Props : < name: 'name option   >  Js.t) = make ?name:(Props ## name) in
+        (Props : < name: 'name option   >  Js.t) = make ?name:(Props ## name)
+        [@@merlin.hide ] in
       Generated$Children_as_string
   end
 let () = Dream.run ()
@@ -348,7 +353,8 @@ module Uppercase_with_SSR_components =
     let make =
       let Generated$Uppercase_with_SSR_components
         (Props : < children: 'children  ;moreProps: 'moreProps   >  Js.t) =
-        make ~moreProps:(Props ## moreProps) ~children:(Props ## children) in
+        make ~moreProps:(Props ## moreProps) ~children:(Props ## children)
+        [@@merlin.hide ] in
       Generated$Uppercase_with_SSR_components
   end
 module Upper_with_aria =
@@ -365,7 +371,7 @@ module Upper_with_aria =
       [@warning "-16"])
     let make =
       let Generated$Upper_with_aria (Props : < children: 'children   >  Js.t)
-        = make ~children:(Props ## children) in
+        = make ~children:(Props ## children)[@@merlin.hide ] in
       Generated$Upper_with_aria
   end
 let data_attributes_should_transform_to_kebabcase =
@@ -415,6 +421,6 @@ module Func(M:X_int) =
       [@warning "-16"])
     let make =
       let Generated$Func (Props : < a: 'a  ;b: 'b   >  Js.t) =
-        make ~b:(Props ## b) ~a:(Props ## a) () in
+        make ~b:(Props ## b) ~a:(Props ## a) ()[@@merlin.hide ] in
       Generated$Func
   end

--- a/ppx/test/output.expected
+++ b/ppx/test/output.expected
@@ -1,14 +1,10 @@
 let lower = ReactDOM.jsx "div" (((ReactDOM.domProps)[@merlin.hide ]) ())
 let lower_empty_attr =
-  ReactDOM.jsx "div"
-    (((ReactDOM.domProps)[@merlin.hide ]) ~className:(("")
-       [@reason.raw_literal ""]) ())
+  ReactDOM.jsx "div" (((ReactDOM.domProps)[@merlin.hide ]) ~className:"" ())
 let lower_inline_styles =
   ReactDOM.jsx "div"
     (((ReactDOM.domProps)[@merlin.hide ])
-       ~style:((ReactDOM.Style.make ~backgroundColor:(("gainsboro")
-                  [@reason.raw_literal "gainsboro"]) ())
-       [@reason.preserve_braces ]) ())
+       ~style:(ReactDOM.Style.make ~backgroundColor:"gainsboro" ()) ())
 let lower_inner_html =
   ReactDOM.jsx "div"
     (((ReactDOM.domProps)[@merlin.hide ])
@@ -18,8 +14,7 @@ let lower_opt_attr =
 let lowerWithChildAndProps foo =
   ReactDOM.jsx "a"
     (((ReactDOM.domProps)[@merlin.hide ]) ~children:foo ~tabIndex:1
-       ~href:(("https://example.com")
-       [@reason.raw_literal "https://example.com"]) ())
+       ~href:"https://example.com" ())
 let lower_child_static =
   ReactDOM.jsx "div"
     (((ReactDOM.domProps)[@merlin.hide ])
@@ -50,19 +45,14 @@ let lower_children_nested =
                                     [|(ReactDOM.jsx "h2"
                                          (((ReactDOM.domProps)
                                             [@merlin.hide ])
-                                            ~children:(((("jsoo-react")
-                                                          [@reason.raw_literal
-                                                            "jsoo-react"])
-                                                          |> s)
-                                            [@reason.preserve_braces ])
-                                            ~className:(("title")
-                                            [@reason.raw_literal "title"]) ()));(
+                                            ~children:("jsoo-react" |> s)
+                                            ~className:"title" ()));(
                                       ReactDOM.jsx "nav"
                                         (((ReactDOM.domProps)[@merlin.hide ])
                                            ~children:(ReactDOM.jsx "ul"
                                                         (((ReactDOM.domProps)
                                                            [@merlin.hide ])
-                                                           ~children:((
+                                                           ~children:(
                                                            (examples |>
                                                               (List.map
                                                                  (fun e ->
@@ -77,38 +67,24 @@ let lower_children_nested =
                                                                     (((ReactDOM.domProps)
                                                                     [@merlin.hide
                                                                     ])
-                                                                    ~children:((
+                                                                    ~children:(
                                                                     e.title
                                                                     |> s)
-                                                                    [@reason.preserve_braces
-                                                                    ])
-                                                                    ~href:((
+                                                                    ~href:(
                                                                     e.path)
-                                                                    [@reason.preserve_braces
-                                                                    ])
-                                                                    ~onClick:((
+                                                                    ~onClick:(
                                                                     fun event
                                                                     ->
-                                                                    ((ReactEvent.Mouse.preventDefault
+                                                                    ReactEvent.Mouse.preventDefault
                                                                     event;
                                                                     ReactRouter.push
                                                                     e.path)
-                                                                    [@reason.preserve_braces
-                                                                    ]))
-                                                                    [@reason.preserve_braces
-                                                                    ]) ()))
-                                                                    ())
-                                                                    ((e.path)
-                                                                    [@reason.preserve_braces
-                                                                    ]))))
+                                                                    ())) ())
+                                                                    e.path)))
                                                              |> React.list)
-                                                           [@reason.preserve_braces
-                                                             ]) ()))
-                                           ~className:(("menu")
-                                           [@reason.raw_literal "menu"]) ()))|])
-                       ~className:(("sidebar")
-                       [@reason.raw_literal "sidebar"]) ()))
-       ~className:(("flex-container")[@reason.raw_literal "flex-container"])
+                                                           ()))
+                                           ~className:"menu" ()))|])
+                       ~className:"sidebar" ())) ~className:"flex-container"
        ())
 let fragment foo = ((ReactDOM.createElement React.jsxFragment [|foo|])
   [@bla ])
@@ -134,18 +110,12 @@ let upper_children =
     ((Page.makeProps
         ~children:(ReactDOM.jsx "h1"
                      (((ReactDOM.domProps)[@merlin.hide ])
-                        ~children:((React.string (("Yep")
-                                      [@reason.raw_literal "Yep"]))
-                        [@reason.preserve_braces ]) ()))
-        ~moreProps:(("hgalo")[@reason.raw_literal "hgalo"]) ())
-    [@merlin.hide ])
+                        ~children:(React.string "Yep") ()))
+        ~moreProps:"hgalo" ())[@merlin.hide ])
 let upper_nested_module =
-  React.jsx Foo.Bar.make
-    ((Foo.Bar.makeProps ~a:1 ~b:(("1")[@reason.raw_literal "1"]) ())
-    [@merlin.hide ])
+  React.jsx Foo.Bar.make ((Foo.Bar.makeProps ~a:1 ~b:"1" ())[@merlin.hide ])
 let upper_child_expr =
-  React.jsx Div.make
-    ((Div.makeProps ~children:((React.int 1)[@reason.preserve_braces ]) ())
+  React.jsx Div.make ((Div.makeProps ~children:(React.int 1) ())
     [@merlin.hide ])
 let upper_child_ident =
   React.jsx Div.make ((Div.makeProps ~children:lola ())[@merlin.hide ])
@@ -153,14 +123,10 @@ let upper_all_kinds_of_props =
   React.jsx MyComponent.make
     ((MyComponent.makeProps
         ~children:(ReactDOM.jsx "div"
-                     (((ReactDOM.domProps)[@merlin.hide ])
-                        ~children:(("hello")[@reason.raw_literal "hello"]) ()))
-        ~booleanAttribute:true ~stringAttribute:(("string")
-        [@reason.raw_literal "string"]) ~intAttribute:1
-        ?forcedOptional:((Some (("hello")[@reason.raw_literal "hello"]))
-        [@reason.preserve_braces ][@explicit_arity ])
-        ~onClick:((send handleClick)[@reason.preserve_braces ]) ())
-    [@merlin.hide ])
+                     (((ReactDOM.domProps)[@merlin.hide ]) ~children:"hello"
+                        ())) ~booleanAttribute:true ~stringAttribute:"string"
+        ~intAttribute:1 ?forcedOptional:((Some "hello")[@explicit_arity ])
+        ~onClick:(send handleClick) ())[@merlin.hide ])
 let upper_ref_with_children =
   React.jsx FancyButton.make
     ((FancyButton.makeProps
@@ -170,7 +136,7 @@ let upper_ref_with_children =
 let lower_ref_with_children =
   ReactDOM.jsx "button"
     (((ReactDOM.domProps)[@merlin.hide ]) ~children ~ref
-       ~className:(("FancyButton")[@reason.raw_literal "FancyButton"]) ())
+       ~className:"FancyButton" ())
 let lower_with_many_props =
   ReactDOM.jsx "div"
     (((ReactDOM.domProps)[@merlin.hide ])
@@ -180,36 +146,24 @@ let lower_with_many_props =
                                     [|(ReactDOM.jsx "img"
                                          (((ReactDOM.domProps)
                                             [@merlin.hide ])
-                                            ~src:(("picture/img.png")
-                                            [@reason.raw_literal
-                                              "picture/img.png"])
-                                            ~alt:(("test picture/img.png")
-                                            [@reason.raw_literal
-                                              "test picture/img.png"])
-                                            ~id:(("idimg")
-                                            [@reason.raw_literal "idimg"]) ()));(
+                                            ~src:"picture/img.png"
+                                            ~alt:"test picture/img.png"
+                                            ~id:"idimg" ()));(ReactDOM.jsx
+                                                                "source"
+                                                                (((ReactDOM.domProps)
+                                                                   [@merlin.hide
+                                                                    ])
+                                                                   ~type_:"image/webp"
+                                                                   ~src:"picture/img1.webp"
+                                                                   ()));(
                                       ReactDOM.jsx "source"
                                         (((ReactDOM.domProps)[@merlin.hide ])
-                                           ~type_:(("image/webp")
-                                           [@reason.raw_literal "image/webp"])
-                                           ~src:(("picture/img1.webp")
-                                           [@reason.raw_literal
-                                             "picture/img1.webp"]) ()));(
-                                      ReactDOM.jsx "source"
-                                        (((ReactDOM.domProps)[@merlin.hide ])
-                                           ~type_:(("image/jpeg")
-                                           [@reason.raw_literal "image/jpeg"])
-                                           ~src:(("picture/img2.jpg")
-                                           [@reason.raw_literal
-                                             "picture/img2.jpg"]) ()))|])
-                       ~id:(("idpicture")[@reason.raw_literal "idpicture"])
-                       ())) ~translate:(("yes")[@reason.raw_literal "yes"])
-       ())
+                                           ~type_:"image/jpeg"
+                                           ~src:"picture/img2.jpg" ()))|])
+                       ~id:"idpicture" ())) ~translate:"yes" ())
 let some_random_html_element =
   ReactDOM.jsx "text"
-    (((ReactDOM.domProps)[@merlin.hide ]) ~dx:(("1 2")
-       [@reason.raw_literal "1 2"]) ~dy:(("3 4")[@reason.raw_literal "3 4"])
-       ())
+    (((ReactDOM.domProps)[@merlin.hide ]) ~dx:"1 2" ~dy:"3 4" ())
 module React_component_with_props =
   struct
     external makeProps :
@@ -217,10 +171,9 @@ module React_component_with_props =
     [@@bs.obj ]
     let make =
       ((fun ~lola ->
-          ((ReactDOM.jsx "div"
-              (((ReactDOM.domProps)[@merlin.hide ])
-                 ~children:((React.string lola)[@reason.preserve_braces ]) ()))
-          [@reason.preserve_braces ]))
+          ReactDOM.jsx "div"
+            (((ReactDOM.domProps)[@merlin.hide ])
+               ~children:(React.string lola) ()))
       [@warning "-16"])
     let make =
       let Generated$React_component_with_props
@@ -230,27 +183,21 @@ module React_component_with_props =
   end
 let react_component_with_props =
   React.jsx React_component_with_props.make
-    ((React_component_with_props.makeProps ~lola:(("flores")
-        [@reason.raw_literal "flores"]) ())[@merlin.hide ])
+    ((React_component_with_props.makeProps ~lola:"flores" ())[@merlin.hide ])
 module Upper_case_with_fragment_as_root =
   struct
     external makeProps :
       ?name:'name -> ?key:string -> unit -> < name: 'name option   >  Js.t =
         ""[@@bs.obj ]
     let make =
-      ((fun ?(name= (("")[@reason.raw_literal ""])) ->
+      ((fun ?(name= "") ->
           ReactDOM.createElement React.jsxFragment
             [|(ReactDOM.jsx "div"
                  (((ReactDOM.domProps)[@merlin.hide ])
-                    ~children:((React.string
-                                  ((("First ")[@reason.raw_literal "First "])
-                                     ^ name))[@reason.preserve_braces ]) ()));(
+                    ~children:(React.string ("First " ^ name)) ()));(
               React.jsx Hello.make
-                ((Hello.makeProps
-                    ~children:((React.string
-                                  ((("2nd ")[@reason.raw_literal "2nd "]) ^
-                                     name))[@reason.preserve_braces ])
-                    ~one:(("1")[@reason.raw_literal "1"]) ())[@merlin.hide ]))|])
+                ((Hello.makeProps ~children:(React.string ("2nd " ^ name))
+                    ~one:"1" ())[@merlin.hide ]))|])
       [@warning "-16"])
     let make =
       let Generated$Upper_case_with_fragment_as_root
@@ -269,11 +216,9 @@ module Forward_Ref =
     let make =
       ((fun ~children ->
           ((fun ~buttonRef ->
-              ((ReactDOM.jsx "button"
-                  (((ReactDOM.domProps)[@merlin.hide ]) ~children
-                     ~ref:buttonRef ~className:(("FancyButton")
-                     [@reason.raw_literal "FancyButton"]) ()))
-              [@reason.preserve_braces ]))
+              ReactDOM.jsx "button"
+                (((ReactDOM.domProps)[@merlin.hide ]) ~children
+                   ~ref:buttonRef ~className:"FancyButton" ()))
           [@warning "-16"]))
       [@warning "-16"])
     let make =
@@ -296,11 +241,10 @@ module Onclick_handler_button =
     let make =
       ((fun ~name ->
           ((fun ?isDisabled ->
-              ((let onClick event = Js.log event in
-                ReactDOM.jsx "button"
-                  (((ReactDOM.domProps)[@merlin.hide ]) ~name ~onClick
-                     ~disabled:isDisabled ()))
-              [@reason.preserve_braces ]))
+              let onClick event = Js.log event in
+              ReactDOM.jsx "button"
+                (((ReactDOM.domProps)[@merlin.hide ]) ~name ~onClick
+                   ~disabled:isDisabled ()))
           [@warning "-16"]))
       [@warning "-16"])
     let make =
@@ -316,12 +260,11 @@ module Children_as_string =
       ?name:'name -> ?key:string -> unit -> < name: 'name option   >  Js.t =
         ""[@@bs.obj ]
     let make =
-      ((fun ?(name= (("joe")[@reason.raw_literal "joe"])) ->
+      ((fun ?(name= "joe") ->
           ReactDOM.jsx "div"
             (((ReactDOM.domProps)[@merlin.hide ])
-               ~children:(((Printf.sprintf (("`name` is %s")
-                              [@reason.raw_literal "`name` is %s"]) name)
-                             |> React.string)[@reason.preserve_braces ]) ()))
+               ~children:((Printf.sprintf "`name` is %s" name) |>
+                            React.string) ()))
       [@warning "-16"])
     let make =
       let Generated$Children_as_string
@@ -350,31 +293,35 @@ module Uppercase_with_SSR_components =
                                         ~children:(ReactDOM.jsx "title"
                                                      (((ReactDOM.domProps)
                                                         [@merlin.hide ])
-                                                        ~children:((React.string
-                                                                    ((("SSR React ")
-                                                                    [@reason.raw_literal
-                                                                    "SSR React "])
+                                                        ~children:(React.string
+                                                                    ("SSR React "
                                                                     ^
                                                                     moreProps))
-                                                        [@reason.preserve_braces
-                                                          ]) ())) ()));(
-                                  ReactDOM.jsxs "body"
-                                    (((ReactDOM.domProps)[@merlin.hide ])
-                                       ~children:(React.array
-                                                    [|(ReactDOM.jsx "div"
-                                                         (((ReactDOM.domProps)
-                                                            [@merlin.hide ])
-                                                            ~children
-                                                            ~id:(("root")
-                                                            [@reason.raw_literal
-                                                              "root"]) ()));(
-                                                      ReactDOM.jsx "script"
-                                                        (((ReactDOM.domProps)
-                                                           [@merlin.hide ])
-                                                           ~src:(("/static/client.js")
-                                                           [@reason.raw_literal
-                                                             "/static/client.js"])
-                                                           ()))|]) ()))|]) ()))
+                                                        ())) ()));(ReactDOM.jsxs
+                                                                    "body"
+                                                                    (((ReactDOM.domProps)
+                                                                    [@merlin.hide
+                                                                    ])
+                                                                    ~children:(
+                                                                    React.array
+                                                                    [|(
+                                                                    ReactDOM.jsx
+                                                                    "div"
+                                                                    (((ReactDOM.domProps)
+                                                                    [@merlin.hide
+                                                                    ])
+                                                                    ~children
+                                                                    ~id:"root"
+                                                                    ()));(
+                                                                    ReactDOM.jsx
+                                                                    "script"
+                                                                    (((ReactDOM.domProps)
+                                                                    [@merlin.hide
+                                                                    ])
+                                                                    ~src:"/static/client.js"
+                                                                    ()))|])
+                                                                    ()))|])
+                   ()))
           [@warning "-16"]))
       [@warning "-16"])
     let make =
@@ -394,7 +341,7 @@ module Upper_with_aria =
       ((fun ~children ->
           ReactDOM.jsx "div"
             (((ReactDOM.domProps)[@merlin.hide ]) ~children
-               ~ariaHidden:(("true")[@reason.raw_literal "true"]) ()))
+               ~ariaHidden:"true" ()))
       [@warning "-16"])
     let make =
       let Generated$Upper_with_aria (Props : < children: 'children   >  Js.t)
@@ -404,19 +351,16 @@ module Upper_with_aria =
 let data_attributes_should_transform_to_kebabcase =
   ReactDOM.createElement React.jsxFragment
     [|(ReactDOM.jsx "div"
-         (((ReactDOM.domProps)[@merlin.hide ]) ~dataAttribute:(("")
-            [@reason.raw_literal ""]) ~dataattribute:(("")
-            [@reason.raw_literal ""]) ~className:(("md:w-1/3")
-            [@reason.raw_literal "md:w-1/3"]) ()));(ReactDOM.jsx "div"
-                                                      (((ReactDOM.domProps)
-                                                         [@merlin.hide ])
-                                                         ~className:(("md:w-2/3")
-                                                         [@reason.raw_literal
-                                                           "md:w-2/3"]) ()))|]
+         (((ReactDOM.domProps)[@merlin.hide ]) ~dataAttribute:""
+            ~dataattribute:"" ~className:"md:w-1/3" ()));(ReactDOM.jsx "div"
+                                                            (((ReactDOM.domProps)
+                                                               [@merlin.hide
+                                                                 ])
+                                                               ~className:"md:w-2/3"
+                                                               ()))|]
 let render_onclickPropsAsString =
   ReactDOM.jsx "div"
-    (((ReactDOM.domProps)[@merlin.hide ]) ~_onclick:(("alert('hello')")
-       [@reason.raw_literal "alert('hello')"]) ())
+    (((ReactDOM.domProps)[@merlin.hide ]) ~_onclick:"alert('hello')" ())
 module External =
   struct
     external componentProps :
@@ -426,9 +370,7 @@ module External =
     external component :
       (< a: int  ;b: string   >  Js.t, React.element) React.componentLike =
         "require(\"my-react-library\").MyReactComponent"[@@otherAttribute
-                                                          (("bla")
-                                                            [@reason.raw_literal
-                                                              "bla"])]
+                                                          "bla"]
   end
 module type X_int  = sig val x : int end
 module Func(M:X_int) =
@@ -441,13 +383,8 @@ module Func(M:X_int) =
       ((fun ~a ->
           ((fun ~b ->
               fun _ ->
-                ((print_endline
-                    (("This function should be named `Test$Func`")
-                    [@reason.raw_literal
-                      "This function should be named `Test$Func`"]) M.x;
-                  ReactDOM.jsx "div"
-                    (((ReactDOM.domProps)[@merlin.hide ]) ()))
-                [@reason.preserve_braces ]))
+                print_endline "This function should be named `Test$Func`" M.x;
+                ReactDOM.jsx "div" (((ReactDOM.domProps)[@merlin.hide ]) ()))
           [@warning "-16"]))
       [@warning "-16"])
     let make =

--- a/ppx/test/output_locations.expected
+++ b/ppx/test/output_locations.expected
@@ -2617,4 +2617,889 @@
     (loc_end
      ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
       (pos_cnum 394)))
-    (loc_ghost true)))))
+    (loc_ghost true))))
+ ((pstr_desc
+   (Pstr_module
+    ((pmb_name
+      ((txt (Uppercase))
+       (loc
+        ((loc_start
+          ((pos_fname generated_locations.ml) (pos_lnum 8) (pos_bol 395)
+           (pos_cnum 402)))
+         (loc_end
+          ((pos_fname generated_locations.ml) (pos_lnum 8) (pos_bol 395)
+           (pos_cnum 411)))
+         (loc_ghost false)))))
+     (pmb_expr
+      ((pmod_desc
+        (Pmod_structure
+         (((pstr_desc
+            (Pstr_primitive
+             ((pval_name
+               ((txt makeProps)
+                (loc
+                 ((loc_start
+                   ((pos_fname generated_locations.ml) (pos_lnum 10)
+                    (pos_bol 423) (pos_cnum 427)))
+                  (loc_end
+                   ((pos_fname generated_locations.ml) (pos_lnum 12)
+                    (pos_bol 553) (pos_cnum 622)))
+                  (loc_ghost true)))))
+              (pval_type
+               ((ptyp_desc
+                 (Ptyp_arrow (Labelled children)
+                  ((ptyp_desc (Ptyp_var children))
+                   (ptyp_loc
+                    ((loc_start
+                      ((pos_fname generated_locations.ml) (pos_lnum 10)
+                       (pos_bol 423) (pos_cnum 446)))
+                     (loc_end
+                      ((pos_fname generated_locations.ml) (pos_lnum 10)
+                       (pos_bol 423) (pos_cnum 463)))
+                     (loc_ghost false)))
+                   (ptyp_loc_stack ()) (ptyp_attributes ()))
+                  ((ptyp_desc
+                    (Ptyp_arrow (Optional key)
+                     ((ptyp_desc
+                       (Ptyp_constr
+                        ((txt (Lident string))
+                         (loc
+                          ((loc_start
+                            ((pos_fname generated_locations.ml) (pos_lnum 10)
+                             (pos_bol 423) (pos_cnum 427)))
+                           (loc_end
+                            ((pos_fname generated_locations.ml) (pos_lnum 12)
+                             (pos_bol 553) (pos_cnum 622)))
+                           (loc_ghost true))))
+                        ()))
+                      (ptyp_loc
+                       ((loc_start
+                         ((pos_fname generated_locations.ml) (pos_lnum 10)
+                          (pos_bol 423) (pos_cnum 427)))
+                        (loc_end
+                         ((pos_fname generated_locations.ml) (pos_lnum 12)
+                          (pos_bol 553) (pos_cnum 622)))
+                        (loc_ghost true)))
+                      (ptyp_loc_stack ()) (ptyp_attributes ()))
+                     ((ptyp_desc
+                       (Ptyp_arrow Nolabel
+                        ((ptyp_desc
+                          (Ptyp_constr
+                           ((txt (Lident unit))
+                            (loc
+                             ((loc_start
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 10) (pos_bol 423) (pos_cnum 427)))
+                              (loc_end
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 12) (pos_bol 553) (pos_cnum 622)))
+                              (loc_ghost true))))
+                           ()))
+                         (ptyp_loc
+                          ((loc_start
+                            ((pos_fname generated_locations.ml) (pos_lnum 10)
+                             (pos_bol 423) (pos_cnum 427)))
+                           (loc_end
+                            ((pos_fname generated_locations.ml) (pos_lnum 12)
+                             (pos_bol 553) (pos_cnum 622)))
+                           (loc_ghost true)))
+                         (ptyp_loc_stack ()) (ptyp_attributes ()))
+                        ((ptyp_desc
+                          (Ptyp_constr
+                           ((txt (Ldot (Lident Js) t))
+                            (loc
+                             ((loc_start
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 10) (pos_bol 423) (pos_cnum 427)))
+                              (loc_end
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 12) (pos_bol 553) (pos_cnum 622)))
+                              (loc_ghost true))))
+                           (((ptyp_desc
+                              (Ptyp_object
+                               (((pof_desc
+                                  (Otag
+                                   ((txt children)
+                                    (loc
+                                     ((loc_start
+                                       ((pos_fname generated_locations.ml)
+                                        (pos_lnum 10) (pos_bol 423)
+                                        (pos_cnum 427)))
+                                      (loc_end
+                                       ((pos_fname generated_locations.ml)
+                                        (pos_lnum 12) (pos_bol 553)
+                                        (pos_cnum 622)))
+                                      (loc_ghost true))))
+                                   ((ptyp_desc (Ptyp_var children))
+                                    (ptyp_loc
+                                     ((loc_start
+                                       ((pos_fname generated_locations.ml)
+                                        (pos_lnum 10) (pos_bol 423)
+                                        (pos_cnum 446)))
+                                      (loc_end
+                                       ((pos_fname generated_locations.ml)
+                                        (pos_lnum 10) (pos_bol 423)
+                                        (pos_cnum 463)))
+                                      (loc_ghost false)))
+                                    (ptyp_loc_stack ()) (ptyp_attributes ()))))
+                                 (pof_loc
+                                  ((loc_start
+                                    ((pos_fname generated_locations.ml)
+                                     (pos_lnum 10) (pos_bol 423)
+                                     (pos_cnum 427)))
+                                   (loc_end
+                                    ((pos_fname generated_locations.ml)
+                                     (pos_lnum 12) (pos_bol 553)
+                                     (pos_cnum 622)))
+                                   (loc_ghost true)))
+                                 (pof_attributes ())))
+                               Closed))
+                             (ptyp_loc
+                              ((loc_start
+                                ((pos_fname generated_locations.ml)
+                                 (pos_lnum 10) (pos_bol 423) (pos_cnum 427)))
+                               (loc_end
+                                ((pos_fname generated_locations.ml)
+                                 (pos_lnum 12) (pos_bol 553) (pos_cnum 622)))
+                               (loc_ghost true)))
+                             (ptyp_loc_stack ()) (ptyp_attributes ())))))
+                         (ptyp_loc
+                          ((loc_start
+                            ((pos_fname generated_locations.ml) (pos_lnum 10)
+                             (pos_bol 423) (pos_cnum 427)))
+                           (loc_end
+                            ((pos_fname generated_locations.ml) (pos_lnum 12)
+                             (pos_bol 553) (pos_cnum 622)))
+                           (loc_ghost true)))
+                         (ptyp_loc_stack ()) (ptyp_attributes ()))))
+                      (ptyp_loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true)))
+                      (ptyp_loc_stack ()) (ptyp_attributes ()))))
+                   (ptyp_loc
+                    ((loc_start
+                      ((pos_fname generated_locations.ml) (pos_lnum 10)
+                       (pos_bol 423) (pos_cnum 427)))
+                     (loc_end
+                      ((pos_fname generated_locations.ml) (pos_lnum 12)
+                       (pos_bol 553) (pos_cnum 622)))
+                     (loc_ghost true)))
+                   (ptyp_loc_stack ()) (ptyp_attributes ()))))
+                (ptyp_loc
+                 ((loc_start
+                   ((pos_fname generated_locations.ml) (pos_lnum 10)
+                    (pos_bol 423) (pos_cnum 446)))
+                  (loc_end
+                   ((pos_fname generated_locations.ml) (pos_lnum 10)
+                    (pos_bol 423) (pos_cnum 463)))
+                  (loc_ghost false)))
+                (ptyp_loc_stack ()) (ptyp_attributes ())))
+              (pval_prim (""))
+              (pval_attributes
+               (((attr_name
+                  ((txt bs.obj)
+                   (loc
+                    ((loc_start
+                      ((pos_fname generated_locations.ml) (pos_lnum 10)
+                       (pos_bol 423) (pos_cnum 427)))
+                     (loc_end
+                      ((pos_fname generated_locations.ml) (pos_lnum 12)
+                       (pos_bol 553) (pos_cnum 622)))
+                     (loc_ghost true)))))
+                 (attr_payload (PStr ()))
+                 (attr_loc
+                  ((loc_start
+                    ((pos_fname generated_locations.ml) (pos_lnum 10)
+                     (pos_bol 423) (pos_cnum 427)))
+                   (loc_end
+                    ((pos_fname generated_locations.ml) (pos_lnum 12)
+                     (pos_bol 553) (pos_cnum 622)))
+                   (loc_ghost true))))))
+              (pval_loc
+               ((loc_start
+                 ((pos_fname generated_locations.ml) (pos_lnum 10)
+                  (pos_bol 423) (pos_cnum 427)))
+                (loc_end
+                 ((pos_fname generated_locations.ml) (pos_lnum 12)
+                  (pos_bol 553) (pos_cnum 622)))
+                (loc_ghost true))))))
+           (pstr_loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 10) (pos_bol 423)
+               (pos_cnum 427)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 12) (pos_bol 553)
+               (pos_cnum 622)))
+             (loc_ghost true))))
+          ((pstr_desc
+            (Pstr_value Nonrecursive
+             (((pvb_pat
+                ((ppat_desc
+                  (Ppat_var
+                   ((txt make)
+                    (loc
+                     ((loc_start
+                       ((pos_fname generated_locations.ml) (pos_lnum 10)
+                        (pos_bol 423) (pos_cnum 431)))
+                      (loc_end
+                       ((pos_fname generated_locations.ml) (pos_lnum 10)
+                        (pos_bol 423) (pos_cnum 435)))
+                      (loc_ghost false))))))
+                 (ppat_loc
+                  ((loc_start
+                    ((pos_fname generated_locations.ml) (pos_lnum 10)
+                     (pos_bol 423) (pos_cnum 431)))
+                   (loc_end
+                    ((pos_fname generated_locations.ml) (pos_lnum 10)
+                     (pos_bol 423) (pos_cnum 435)))
+                   (loc_ghost false)))
+                 (ppat_loc_stack ()) (ppat_attributes ())))
+               (pvb_expr
+                ((pexp_desc
+                  (Pexp_fun (Labelled children) ()
+                   ((ppat_desc
+                     (Ppat_var
+                      ((txt upperCaseChildren)
+                       (loc
+                        ((loc_start
+                          ((pos_fname generated_locations.ml) (pos_lnum 10)
+                           (pos_bol 423) (pos_cnum 446)))
+                         (loc_end
+                          ((pos_fname generated_locations.ml) (pos_lnum 10)
+                           (pos_bol 423) (pos_cnum 463)))
+                         (loc_ghost false))))))
+                    (ppat_loc
+                     ((loc_start
+                       ((pos_fname generated_locations.ml) (pos_lnum 10)
+                        (pos_bol 423) (pos_cnum 446)))
+                      (loc_end
+                       ((pos_fname generated_locations.ml) (pos_lnum 10)
+                        (pos_bol 423) (pos_cnum 463)))
+                      (loc_ghost false)))
+                    (ppat_loc_stack ()) (ppat_attributes ()))
+                   ((pexp_desc
+                     (Pexp_apply
+                      ((pexp_desc
+                        (Pexp_ident
+                         ((txt (Ldot (Lident React) jsx))
+                          (loc
+                           ((loc_start
+                             ((pos_fname generated_locations.ml)
+                              (pos_lnum 11) (pos_bol 467) (pos_cnum 475)))
+                            (loc_end
+                             ((pos_fname generated_locations.ml)
+                              (pos_lnum 11) (pos_bol 467) (pos_cnum 492)))
+                            (loc_ghost false))))))
+                       (pexp_loc
+                        ((loc_start
+                          ((pos_fname generated_locations.ml) (pos_lnum 11)
+                           (pos_bol 467) (pos_cnum 475)))
+                         (loc_end
+                          ((pos_fname generated_locations.ml) (pos_lnum 11)
+                           (pos_bol 467) (pos_cnum 492)))
+                         (loc_ghost false)))
+                       (pexp_loc_stack ()) (pexp_attributes ()))
+                      ((Nolabel
+                        ((pexp_desc
+                          (Pexp_ident
+                           ((txt (Ldot (Lident Box) make))
+                            (loc
+                             ((loc_start
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 11) (pos_bol 467) (pos_cnum 475)))
+                              (loc_end
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 11) (pos_bol 467) (pos_cnum 492)))
+                              (loc_ghost false))))))
+                         (pexp_loc
+                          ((loc_start
+                            ((pos_fname generated_locations.ml) (pos_lnum 11)
+                             (pos_bol 467) (pos_cnum 475)))
+                           (loc_end
+                            ((pos_fname generated_locations.ml) (pos_lnum 11)
+                             (pos_bol 467) (pos_cnum 492)))
+                           (loc_ghost false)))
+                         (pexp_loc_stack ()) (pexp_attributes ())))
+                       (Nolabel
+                        ((pexp_desc
+                          (Pexp_apply
+                           ((pexp_desc
+                             (Pexp_ident
+                              ((txt (Ldot (Lident Box) makeProps))
+                               (loc
+                                ((loc_start
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 11) (pos_bol 467)
+                                   (pos_cnum 475)))
+                                 (loc_end
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 11) (pos_bol 467)
+                                   (pos_cnum 492)))
+                                 (loc_ghost false))))))
+                            (pexp_loc
+                             ((loc_start
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 11) (pos_bol 467) (pos_cnum 475)))
+                              (loc_end
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 11) (pos_bol 467) (pos_cnum 492)))
+                              (loc_ghost false)))
+                            (pexp_loc_stack ()) (pexp_attributes ()))
+                           (((Labelled children)
+                             ((pexp_desc
+                               (Pexp_ident
+                                ((txt (Lident upperCaseChildren))
+                                 (loc
+                                  ((loc_start
+                                    ((pos_fname generated_locations.ml)
+                                     (pos_lnum 11) (pos_bol 467)
+                                     (pos_cnum 504)))
+                                   (loc_end
+                                    ((pos_fname generated_locations.ml)
+                                     (pos_lnum 11) (pos_bol 467)
+                                     (pos_cnum 521)))
+                                   (loc_ghost false))))))
+                              (pexp_loc
+                               ((loc_start
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 11) (pos_bol 467) (pos_cnum 504)))
+                                (loc_end
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 11) (pos_bol 467) (pos_cnum 521)))
+                                (loc_ghost false)))
+                              (pexp_loc_stack ()) (pexp_attributes ())))
+                            (Nolabel
+                             ((pexp_desc
+                               (Pexp_construct
+                                ((txt (Lident "()"))
+                                 (loc
+                                  ((loc_start
+                                    ((pos_fname generated_locations.ml)
+                                     (pos_lnum 11) (pos_bol 467)
+                                     (pos_cnum 523)))
+                                   (loc_end
+                                    ((pos_fname generated_locations.ml)
+                                     (pos_lnum 11) (pos_bol 467)
+                                     (pos_cnum 525)))
+                                   (loc_ghost false))))
+                                ()))
+                              (pexp_loc
+                               ((loc_start
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 11) (pos_bol 467) (pos_cnum 523)))
+                                (loc_end
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 11) (pos_bol 467) (pos_cnum 525)))
+                                (loc_ghost false)))
+                              (pexp_loc_stack ()) (pexp_attributes ()))))))
+                         (pexp_loc
+                          ((loc_start
+                            ((pos_fname generated_locations.ml) (pos_lnum 11)
+                             (pos_bol 467) (pos_cnum 475)))
+                           (loc_end
+                            ((pos_fname generated_locations.ml) (pos_lnum 11)
+                             (pos_bol 467) (pos_cnum 492)))
+                           (loc_ghost false)))
+                         (pexp_loc_stack ())
+                         (pexp_attributes
+                          (((attr_name
+                             ((txt merlin.hide)
+                              (loc
+                               ((loc_start
+                                 ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                                  (pos_cnum -1)))
+                                (loc_end
+                                 ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                                  (pos_cnum -1)))
+                                (loc_ghost true)))))
+                            (attr_payload (PStr ()))
+                            (attr_loc
+                             ((loc_start
+                               ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                                (pos_cnum -1)))
+                              (loc_end
+                               ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                                (pos_cnum -1)))
+                              (loc_ghost true)))))))))))
+                    (pexp_loc
+                     ((loc_start
+                       ((pos_fname generated_locations.ml) (pos_lnum 11)
+                        (pos_bol 467) (pos_cnum 475)))
+                      (loc_end
+                       ((pos_fname generated_locations.ml) (pos_lnum 11)
+                        (pos_bol 467) (pos_cnum 492)))
+                      (loc_ghost false)))
+                    (pexp_loc_stack ()) (pexp_attributes ()))))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname generated_locations.ml) (pos_lnum 10)
+                     (pos_bol 423) (pos_cnum 436)))
+                   (loc_end
+                    ((pos_fname generated_locations.ml) (pos_lnum 11)
+                     (pos_bol 467) (pos_cnum 534)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ())
+                 (pexp_attributes
+                  (((attr_name
+                     ((txt warning)
+                      (loc
+                       ((loc_start
+                         ((pos_fname generated_locations.ml) (pos_lnum 10)
+                          (pos_bol 423) (pos_cnum 427)))
+                        (loc_end
+                         ((pos_fname generated_locations.ml) (pos_lnum 12)
+                          (pos_bol 553) (pos_cnum 622)))
+                        (loc_ghost true)))))
+                    (attr_payload
+                     (PStr
+                      (((pstr_desc
+                         (Pstr_eval
+                          ((pexp_desc
+                            (Pexp_constant
+                             (Pconst_string -16
+                              ((loc_start
+                                ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                                 (pos_cnum -1)))
+                               (loc_end
+                                ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                                 (pos_cnum -1)))
+                               (loc_ghost true))
+                              ())))
+                           (pexp_loc
+                            ((loc_start
+                              ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                               (pos_cnum -1)))
+                             (loc_end
+                              ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                               (pos_cnum -1)))
+                             (loc_ghost true)))
+                           (pexp_loc_stack ()) (pexp_attributes ()))
+                          ()))
+                        (pstr_loc
+                         ((loc_start
+                           ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                            (pos_cnum -1)))
+                          (loc_end
+                           ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                            (pos_cnum -1)))
+                          (loc_ghost true)))))))
+                    (attr_loc
+                     ((loc_start
+                       ((pos_fname generated_locations.ml) (pos_lnum 10)
+                        (pos_bol 423) (pos_cnum 427)))
+                      (loc_end
+                       ((pos_fname generated_locations.ml) (pos_lnum 12)
+                        (pos_bol 553) (pos_cnum 622)))
+                      (loc_ghost true))))))))
+               (pvb_attributes ())
+               (pvb_loc
+                ((loc_start
+                  ((pos_fname generated_locations.ml) (pos_lnum 10)
+                   (pos_bol 423) (pos_cnum 427)))
+                 (loc_end
+                  ((pos_fname generated_locations.ml) (pos_lnum 12)
+                   (pos_bol 553) (pos_cnum 622)))
+                 (loc_ghost false)))))))
+           (pstr_loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 10) (pos_bol 423)
+               (pos_cnum 427)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 12) (pos_bol 553)
+               (pos_cnum 622)))
+             (loc_ghost false))))
+          ((pstr_desc
+            (Pstr_value Nonrecursive
+             (((pvb_pat
+                ((ppat_desc
+                  (Ppat_var
+                   ((txt make)
+                    (loc
+                     ((loc_start
+                       ((pos_fname generated_locations.ml) (pos_lnum 10)
+                        (pos_bol 423) (pos_cnum 431)))
+                      (loc_end
+                       ((pos_fname generated_locations.ml) (pos_lnum 10)
+                        (pos_bol 423) (pos_cnum 435)))
+                      (loc_ghost false))))))
+                 (ppat_loc
+                  ((loc_start
+                    ((pos_fname generated_locations.ml) (pos_lnum 10)
+                     (pos_bol 423) (pos_cnum 431)))
+                   (loc_end
+                    ((pos_fname generated_locations.ml) (pos_lnum 10)
+                     (pos_bol 423) (pos_cnum 435)))
+                   (loc_ghost false)))
+                 (ppat_loc_stack ()) (ppat_attributes ())))
+               (pvb_expr
+                ((pexp_desc
+                  (Pexp_let Nonrecursive
+                   (((pvb_pat
+                      ((ppat_desc
+                        (Ppat_var
+                         ((txt Generated_locations$Uppercase)
+                          (loc
+                           ((loc_start
+                             ((pos_fname generated_locations.ml)
+                              (pos_lnum 10) (pos_bol 423) (pos_cnum 427)))
+                            (loc_end
+                             ((pos_fname generated_locations.ml)
+                              (pos_lnum 12) (pos_bol 553) (pos_cnum 622)))
+                            (loc_ghost true))))))
+                       (ppat_loc
+                        ((loc_start
+                          ((pos_fname generated_locations.ml) (pos_lnum 10)
+                           (pos_bol 423) (pos_cnum 427)))
+                         (loc_end
+                          ((pos_fname generated_locations.ml) (pos_lnum 12)
+                           (pos_bol 553) (pos_cnum 622)))
+                         (loc_ghost true)))
+                       (ppat_loc_stack ()) (ppat_attributes ())))
+                     (pvb_expr
+                      ((pexp_desc
+                        (Pexp_fun Nolabel ()
+                         ((ppat_desc
+                           (Ppat_constraint
+                            ((ppat_desc
+                              (Ppat_var
+                               ((txt Props)
+                                (loc
+                                 ((loc_start
+                                   ((pos_fname generated_locations.ml)
+                                    (pos_lnum 10) (pos_bol 423)
+                                    (pos_cnum 427)))
+                                  (loc_end
+                                   ((pos_fname generated_locations.ml)
+                                    (pos_lnum 12) (pos_bol 553)
+                                    (pos_cnum 622)))
+                                  (loc_ghost true))))))
+                             (ppat_loc
+                              ((loc_start
+                                ((pos_fname generated_locations.ml)
+                                 (pos_lnum 10) (pos_bol 423) (pos_cnum 427)))
+                               (loc_end
+                                ((pos_fname generated_locations.ml)
+                                 (pos_lnum 12) (pos_bol 553) (pos_cnum 622)))
+                               (loc_ghost true)))
+                             (ppat_loc_stack ()) (ppat_attributes ()))
+                            ((ptyp_desc
+                              (Ptyp_constr
+                               ((txt (Ldot (Lident Js) t))
+                                (loc
+                                 ((loc_start
+                                   ((pos_fname generated_locations.ml)
+                                    (pos_lnum 10) (pos_bol 423)
+                                    (pos_cnum 427)))
+                                  (loc_end
+                                   ((pos_fname generated_locations.ml)
+                                    (pos_lnum 12) (pos_bol 553)
+                                    (pos_cnum 622)))
+                                  (loc_ghost true))))
+                               (((ptyp_desc
+                                  (Ptyp_object
+                                   (((pof_desc
+                                      (Otag
+                                       ((txt children)
+                                        (loc
+                                         ((loc_start
+                                           ((pos_fname
+                                             generated_locations.ml)
+                                            (pos_lnum 10) (pos_bol 423)
+                                            (pos_cnum 427)))
+                                          (loc_end
+                                           ((pos_fname
+                                             generated_locations.ml)
+                                            (pos_lnum 12) (pos_bol 553)
+                                            (pos_cnum 622)))
+                                          (loc_ghost true))))
+                                       ((ptyp_desc (Ptyp_var children))
+                                        (ptyp_loc
+                                         ((loc_start
+                                           ((pos_fname
+                                             generated_locations.ml)
+                                            (pos_lnum 10) (pos_bol 423)
+                                            (pos_cnum 446)))
+                                          (loc_end
+                                           ((pos_fname
+                                             generated_locations.ml)
+                                            (pos_lnum 10) (pos_bol 423)
+                                            (pos_cnum 463)))
+                                          (loc_ghost false)))
+                                        (ptyp_loc_stack ())
+                                        (ptyp_attributes ()))))
+                                     (pof_loc
+                                      ((loc_start
+                                        ((pos_fname generated_locations.ml)
+                                         (pos_lnum 10) (pos_bol 423)
+                                         (pos_cnum 427)))
+                                       (loc_end
+                                        ((pos_fname generated_locations.ml)
+                                         (pos_lnum 12) (pos_bol 553)
+                                         (pos_cnum 622)))
+                                       (loc_ghost true)))
+                                     (pof_attributes ())))
+                                   Closed))
+                                 (ptyp_loc
+                                  ((loc_start
+                                    ((pos_fname generated_locations.ml)
+                                     (pos_lnum 10) (pos_bol 423)
+                                     (pos_cnum 427)))
+                                   (loc_end
+                                    ((pos_fname generated_locations.ml)
+                                     (pos_lnum 12) (pos_bol 553)
+                                     (pos_cnum 622)))
+                                   (loc_ghost true)))
+                                 (ptyp_loc_stack ()) (ptyp_attributes ())))))
+                             (ptyp_loc
+                              ((loc_start
+                                ((pos_fname generated_locations.ml)
+                                 (pos_lnum 10) (pos_bol 423) (pos_cnum 427)))
+                               (loc_end
+                                ((pos_fname generated_locations.ml)
+                                 (pos_lnum 12) (pos_bol 553) (pos_cnum 622)))
+                               (loc_ghost true)))
+                             (ptyp_loc_stack ()) (ptyp_attributes ()))))
+                          (ppat_loc
+                           ((loc_start
+                             ((pos_fname generated_locations.ml)
+                              (pos_lnum 10) (pos_bol 423) (pos_cnum 427)))
+                            (loc_end
+                             ((pos_fname generated_locations.ml)
+                              (pos_lnum 12) (pos_bol 553) (pos_cnum 622)))
+                            (loc_ghost true)))
+                          (ppat_loc_stack ()) (ppat_attributes ()))
+                         ((pexp_desc
+                           (Pexp_apply
+                            ((pexp_desc
+                              (Pexp_ident
+                               ((txt (Lident make))
+                                (loc
+                                 ((loc_start
+                                   ((pos_fname generated_locations.ml)
+                                    (pos_lnum 10) (pos_bol 423)
+                                    (pos_cnum 427)))
+                                  (loc_end
+                                   ((pos_fname generated_locations.ml)
+                                    (pos_lnum 12) (pos_bol 553)
+                                    (pos_cnum 622)))
+                                  (loc_ghost true))))))
+                             (pexp_loc
+                              ((loc_start
+                                ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                                 (pos_cnum -1)))
+                               (loc_end
+                                ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                                 (pos_cnum -1)))
+                               (loc_ghost true)))
+                             (pexp_loc_stack ()) (pexp_attributes ()))
+                            (((Labelled children)
+                              ((pexp_desc
+                                (Pexp_apply
+                                 ((pexp_desc
+                                   (Pexp_ident
+                                    ((txt (Lident ##))
+                                     (loc
+                                      ((loc_start
+                                        ((pos_fname generated_locations.ml)
+                                         (pos_lnum 10) (pos_bol 423)
+                                         (pos_cnum 446)))
+                                       (loc_end
+                                        ((pos_fname generated_locations.ml)
+                                         (pos_lnum 10) (pos_bol 423)
+                                         (pos_cnum 463)))
+                                       (loc_ghost false))))))
+                                  (pexp_loc
+                                   ((loc_start
+                                     ((pos_fname generated_locations.ml)
+                                      (pos_lnum 10) (pos_bol 423)
+                                      (pos_cnum 446)))
+                                    (loc_end
+                                     ((pos_fname generated_locations.ml)
+                                      (pos_lnum 10) (pos_bol 423)
+                                      (pos_cnum 463)))
+                                    (loc_ghost false)))
+                                  (pexp_loc_stack ()) (pexp_attributes ()))
+                                 ((Nolabel
+                                   ((pexp_desc
+                                     (Pexp_ident
+                                      ((txt (Lident Props))
+                                       (loc
+                                        ((loc_start
+                                          ((pos_fname generated_locations.ml)
+                                           (pos_lnum 10) (pos_bol 423)
+                                           (pos_cnum 446)))
+                                         (loc_end
+                                          ((pos_fname generated_locations.ml)
+                                           (pos_lnum 10) (pos_bol 423)
+                                           (pos_cnum 463)))
+                                         (loc_ghost false))))))
+                                    (pexp_loc
+                                     ((loc_start
+                                       ((pos_fname generated_locations.ml)
+                                        (pos_lnum 10) (pos_bol 423)
+                                        (pos_cnum 446)))
+                                      (loc_end
+                                       ((pos_fname generated_locations.ml)
+                                        (pos_lnum 10) (pos_bol 423)
+                                        (pos_cnum 463)))
+                                      (loc_ghost false)))
+                                    (pexp_loc_stack ()) (pexp_attributes ())))
+                                  (Nolabel
+                                   ((pexp_desc
+                                     (Pexp_ident
+                                      ((txt (Lident children))
+                                       (loc
+                                        ((loc_start
+                                          ((pos_fname generated_locations.ml)
+                                           (pos_lnum 10) (pos_bol 423)
+                                           (pos_cnum 446)))
+                                         (loc_end
+                                          ((pos_fname generated_locations.ml)
+                                           (pos_lnum 10) (pos_bol 423)
+                                           (pos_cnum 463)))
+                                         (loc_ghost false))))))
+                                    (pexp_loc
+                                     ((loc_start
+                                       ((pos_fname generated_locations.ml)
+                                        (pos_lnum 10) (pos_bol 423)
+                                        (pos_cnum 446)))
+                                      (loc_end
+                                       ((pos_fname generated_locations.ml)
+                                        (pos_lnum 10) (pos_bol 423)
+                                        (pos_cnum 463)))
+                                      (loc_ghost false)))
+                                    (pexp_loc_stack ()) (pexp_attributes ()))))))
+                               (pexp_loc
+                                ((loc_start
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 10) (pos_bol 423)
+                                   (pos_cnum 446)))
+                                 (loc_end
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 10) (pos_bol 423)
+                                   (pos_cnum 463)))
+                                 (loc_ghost false)))
+                               (pexp_loc_stack ()) (pexp_attributes ()))))))
+                          (pexp_loc
+                           ((loc_start
+                             ((pos_fname generated_locations.ml)
+                              (pos_lnum 10) (pos_bol 423) (pos_cnum 427)))
+                            (loc_end
+                             ((pos_fname generated_locations.ml)
+                              (pos_lnum 12) (pos_bol 553) (pos_cnum 622)))
+                            (loc_ghost true)))
+                          (pexp_loc_stack ()) (pexp_attributes ()))))
+                       (pexp_loc
+                        ((loc_start
+                          ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                           (pos_cnum -1)))
+                         (loc_end
+                          ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                           (pos_cnum -1)))
+                         (loc_ghost true)))
+                       (pexp_loc_stack ()) (pexp_attributes ())))
+                     (pvb_attributes
+                      (((attr_name
+                         ((txt merlin.hide)
+                          (loc
+                           ((loc_start
+                             ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                              (pos_cnum -1)))
+                            (loc_end
+                             ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                              (pos_cnum -1)))
+                            (loc_ghost true)))))
+                        (attr_payload (PStr ()))
+                        (attr_loc
+                         ((loc_start
+                           ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                            (pos_cnum -1)))
+                          (loc_end
+                           ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                            (pos_cnum -1)))
+                          (loc_ghost true))))))
+                     (pvb_loc
+                      ((loc_start
+                        ((pos_fname generated_locations.ml) (pos_lnum 10)
+                         (pos_bol 423) (pos_cnum 427)))
+                       (loc_end
+                        ((pos_fname generated_locations.ml) (pos_lnum 12)
+                         (pos_bol 553) (pos_cnum 622)))
+                       (loc_ghost true)))))
+                   ((pexp_desc
+                     (Pexp_ident
+                      ((txt (Lident Generated_locations$Uppercase))
+                       (loc
+                        ((loc_start
+                          ((pos_fname generated_locations.ml) (pos_lnum 10)
+                           (pos_bol 423) (pos_cnum 427)))
+                         (loc_end
+                          ((pos_fname generated_locations.ml) (pos_lnum 12)
+                           (pos_bol 553) (pos_cnum 622)))
+                         (loc_ghost true))))))
+                    (pexp_loc
+                     ((loc_start
+                       ((pos_fname generated_locations.ml) (pos_lnum 10)
+                        (pos_bol 423) (pos_cnum 427)))
+                      (loc_end
+                       ((pos_fname generated_locations.ml) (pos_lnum 12)
+                        (pos_bol 553) (pos_cnum 622)))
+                      (loc_ghost true)))
+                    (pexp_loc_stack ()) (pexp_attributes ()))))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (pvb_attributes ())
+               (pvb_loc
+                ((loc_start
+                  ((pos_fname generated_locations.ml) (pos_lnum 10)
+                   (pos_bol 423) (pos_cnum 427)))
+                 (loc_end
+                  ((pos_fname generated_locations.ml) (pos_lnum 12)
+                   (pos_bol 553) (pos_cnum 622)))
+                 (loc_ghost false)))))))
+           (pstr_loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 10) (pos_bol 423)
+               (pos_cnum 427)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 12) (pos_bol 553)
+               (pos_cnum 622)))
+             (loc_ghost true)))))))
+       (pmod_loc
+        ((loc_start
+          ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 414)
+           (pos_cnum 416)))
+         (loc_end
+          ((pos_fname generated_locations.ml) (pos_lnum 13) (pos_bol 623)
+           (pos_cnum 628)))
+         (loc_ghost false)))
+       (pmod_attributes ())))
+     (pmb_attributes ())
+     (pmb_loc
+      ((loc_start
+        ((pos_fname generated_locations.ml) (pos_lnum 8) (pos_bol 395)
+         (pos_cnum 395)))
+       (loc_end
+        ((pos_fname generated_locations.ml) (pos_lnum 13) (pos_bol 623)
+         (pos_cnum 628)))
+       (loc_ghost false))))))
+  (pstr_loc
+   ((loc_start
+     ((pos_fname generated_locations.ml) (pos_lnum 8) (pos_bol 395)
+      (pos_cnum 395)))
+    (loc_end
+     ((pos_fname generated_locations.ml) (pos_lnum 13) (pos_bol 623)
+      (pos_cnum 628)))
+    (loc_ghost false)))))

--- a/ppx/test/output_locations.expected
+++ b/ppx/test/output_locations.expected
@@ -463,11 +463,11 @@
       ((txt makeProps)
        (loc
         ((loc_start
-          ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-           (pos_cnum -1)))
+          ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+           (pos_cnum 0)))
          (loc_end
-          ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-           (pos_cnum -1)))
+          ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+           (pos_cnum 146)))
          (loc_ghost true)))))
      (pval_type
       ((ptyp_desc
@@ -489,20 +489,20 @@
                ((txt (Lident string))
                 (loc
                  ((loc_start
-                   ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                    (pos_cnum -1)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 1)
+                    (pos_bol 0) (pos_cnum 0)))
                   (loc_end
-                   ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                    (pos_cnum -1)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 3)
+                    (pos_bol 90) (pos_cnum 146)))
                   (loc_ghost true))))
                ()))
              (ptyp_loc
               ((loc_start
-                ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                 (pos_cnum -1)))
+                ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+                 (pos_cnum 0)))
                (loc_end
-                ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                 (pos_cnum -1)))
+                ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+                 (pos_cnum 146)))
                (loc_ghost true)))
              (ptyp_loc_stack ()) (ptyp_attributes ()))
             ((ptyp_desc
@@ -512,20 +512,20 @@
                   ((txt (Lident unit))
                    (loc
                     ((loc_start
-                      ((pos_fname Generated_locations) (pos_lnum 1)
-                       (pos_bol 0) (pos_cnum -1)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 1)
+                       (pos_bol 0) (pos_cnum 0)))
                      (loc_end
-                      ((pos_fname Generated_locations) (pos_lnum 1)
-                       (pos_bol 0) (pos_cnum -1)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 3)
+                       (pos_bol 90) (pos_cnum 146)))
                      (loc_ghost true))))
                   ()))
                 (ptyp_loc
                  ((loc_start
-                   ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                    (pos_cnum -1)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 1)
+                    (pos_bol 0) (pos_cnum 0)))
                   (loc_end
-                   ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                    (pos_cnum -1)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 3)
+                    (pos_bol 90) (pos_cnum 146)))
                   (loc_ghost true)))
                 (ptyp_loc_stack ()) (ptyp_attributes ()))
                ((ptyp_desc
@@ -533,11 +533,11 @@
                   ((txt (Ldot (Lident Js) t))
                    (loc
                     ((loc_start
-                      ((pos_fname Generated_locations) (pos_lnum 1)
-                       (pos_bol 0) (pos_cnum -1)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 1)
+                       (pos_bol 0) (pos_cnum 0)))
                      (loc_end
-                      ((pos_fname Generated_locations) (pos_lnum 1)
-                       (pos_bol 0) (pos_cnum -1)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 3)
+                       (pos_bol 90) (pos_cnum 146)))
                      (loc_ghost true))))
                   (((ptyp_desc
                      (Ptyp_object
@@ -546,11 +546,11 @@
                           ((txt lola)
                            (loc
                             ((loc_start
-                              ((pos_fname Generated_locations) (pos_lnum 1)
-                               (pos_bol 0) (pos_cnum -1)))
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
                              (loc_end
-                              ((pos_fname Generated_locations) (pos_lnum 1)
-                               (pos_bol 0) (pos_cnum -1)))
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 3) (pos_bol 90) (pos_cnum 146)))
                              (loc_ghost true))))
                           ((ptyp_desc (Ptyp_var lola))
                            (ptyp_loc
@@ -564,30 +564,30 @@
                            (ptyp_loc_stack ()) (ptyp_attributes ()))))
                         (pof_loc
                          ((loc_start
-                           ((pos_fname Generated_locations) (pos_lnum 1)
-                            (pos_bol 0) (pos_cnum -1)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 1)
+                            (pos_bol 0) (pos_cnum 0)))
                           (loc_end
-                           ((pos_fname Generated_locations) (pos_lnum 1)
-                            (pos_bol 0) (pos_cnum -1)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 3)
+                            (pos_bol 90) (pos_cnum 146)))
                           (loc_ghost true)))
                         (pof_attributes ())))
                       Closed))
                     (ptyp_loc
                      ((loc_start
-                       ((pos_fname Generated_locations) (pos_lnum 1)
-                        (pos_bol 0) (pos_cnum -1)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 1)
+                        (pos_bol 0) (pos_cnum 0)))
                       (loc_end
-                       ((pos_fname Generated_locations) (pos_lnum 1)
-                        (pos_bol 0) (pos_cnum -1)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 3)
+                        (pos_bol 90) (pos_cnum 146)))
                       (loc_ghost true)))
                     (ptyp_loc_stack ()) (ptyp_attributes ())))))
                 (ptyp_loc
                  ((loc_start
-                   ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                    (pos_cnum -1)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 1)
+                    (pos_bol 0) (pos_cnum 0)))
                   (loc_end
-                   ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                    (pos_cnum -1)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 3)
+                    (pos_bol 90) (pos_cnum 146)))
                   (loc_ghost true)))
                 (ptyp_loc_stack ()) (ptyp_attributes ()))))
              (ptyp_loc
@@ -599,11 +599,11 @@
              (ptyp_loc_stack ()) (ptyp_attributes ()))))
           (ptyp_loc
            ((loc_start
-             ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-              (pos_cnum -1)))
+             ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+              (pos_cnum 0)))
             (loc_end
-             ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-              (pos_cnum -1)))
+             ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+              (pos_cnum 146)))
             (loc_ghost true)))
           (ptyp_loc_stack ()) (ptyp_attributes ()))))
        (ptyp_loc
@@ -621,34 +621,36 @@
          ((txt bs.obj)
           (loc
            ((loc_start
-             ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-              (pos_cnum -1)))
+             ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+              (pos_cnum 0)))
             (loc_end
-             ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-              (pos_cnum -1)))
+             ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+              (pos_cnum 146)))
             (loc_ghost true)))))
         (attr_payload (PStr ()))
         (attr_loc
          ((loc_start
-           ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-            (pos_cnum -1)))
+           ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+            (pos_cnum 0)))
           (loc_end
-           ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-            (pos_cnum -1)))
+           ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+            (pos_cnum 146)))
           (loc_ghost true))))))
      (pval_loc
       ((loc_start
-        ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-         (pos_cnum -1)))
+        ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+         (pos_cnum 0)))
        (loc_end
-        ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-         (pos_cnum -1)))
+        ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+         (pos_cnum 146)))
        (loc_ghost true))))))
   (pstr_loc
    ((loc_start
-     ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+     ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+      (pos_cnum 0)))
     (loc_end
-     ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+     ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+      (pos_cnum 146)))
     (loc_ghost true))))
  ((pstr_desc
    (Pstr_value Nonrecursive
@@ -666,12 +668,12 @@
              (loc_ghost false))))))
         (ppat_loc
          ((loc_start
-           ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-            (pos_cnum -1)))
+           ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+            (pos_cnum 4)))
           (loc_end
-           ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-            (pos_cnum -1)))
-          (loc_ghost true)))
+           ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+            (pos_cnum 8)))
+          (loc_ghost false)))
         (ppat_loc_stack ()) (ppat_attributes ())))
       (pvb_expr
        ((pexp_desc
@@ -921,11 +923,11 @@
             ((txt warning)
              (loc
               ((loc_start
-                ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                 (pos_cnum -1)))
+                ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+                 (pos_cnum 0)))
                (loc_end
-                ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                 (pos_cnum -1)))
+                ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+                 (pos_cnum 146)))
                (loc_ghost true)))))
            (attr_payload
             (PStr
@@ -960,21 +962,21 @@
                  (loc_ghost true)))))))
            (attr_loc
             ((loc_start
-              ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-               (pos_cnum -1)))
+              ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum 0)))
              (loc_end
-              ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-               (pos_cnum -1)))
+              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+               (pos_cnum 146)))
              (loc_ghost true))))))))
       (pvb_attributes ())
       (pvb_loc
        ((loc_start
-         ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-          (pos_cnum -1)))
+         ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+          (pos_cnum 0)))
         (loc_end
-         ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-          (pos_cnum -1)))
-        (loc_ghost true)))))))
+         ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+          (pos_cnum 146)))
+        (loc_ghost false)))))))
   (pstr_loc
    ((loc_start
      ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
@@ -1015,19 +1017,19 @@
                 ((txt Generated_locations)
                  (loc
                   ((loc_start
-                    ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                     (pos_cnum -1)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 1)
+                     (pos_bol 0) (pos_cnum 0)))
                    (loc_end
-                    ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                     (pos_cnum -1)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 3)
+                     (pos_bol 90) (pos_cnum 146)))
                    (loc_ghost true))))))
               (ppat_loc
                ((loc_start
-                 ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                  (pos_cnum -1)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+                  (pos_cnum 0)))
                 (loc_end
-                 ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                  (pos_cnum -1)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 3)
+                  (pos_bol 90) (pos_cnum 146)))
                 (loc_ghost true)))
               (ppat_loc_stack ()) (ppat_attributes ())))
             (pvb_expr
@@ -1040,19 +1042,19 @@
                       ((txt Props)
                        (loc
                         ((loc_start
-                          ((pos_fname Generated_locations) (pos_lnum 1)
-                           (pos_bol 0) (pos_cnum -1)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 1)
+                           (pos_bol 0) (pos_cnum 0)))
                          (loc_end
-                          ((pos_fname Generated_locations) (pos_lnum 1)
-                           (pos_bol 0) (pos_cnum -1)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 3)
+                           (pos_bol 90) (pos_cnum 146)))
                          (loc_ghost true))))))
                     (ppat_loc
                      ((loc_start
-                       ((pos_fname Generated_locations) (pos_lnum 1)
-                        (pos_bol 0) (pos_cnum -1)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 1)
+                        (pos_bol 0) (pos_cnum 0)))
                       (loc_end
-                       ((pos_fname Generated_locations) (pos_lnum 1)
-                        (pos_bol 0) (pos_cnum -1)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 3)
+                        (pos_bol 90) (pos_cnum 146)))
                       (loc_ghost true)))
                     (ppat_loc_stack ()) (ppat_attributes ()))
                    ((ptyp_desc
@@ -1060,11 +1062,11 @@
                       ((txt (Ldot (Lident Js) t))
                        (loc
                         ((loc_start
-                          ((pos_fname Generated_locations) (pos_lnum 1)
-                           (pos_bol 0) (pos_cnum -1)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 1)
+                           (pos_bol 0) (pos_cnum 0)))
                          (loc_end
-                          ((pos_fname Generated_locations) (pos_lnum 1)
-                           (pos_bol 0) (pos_cnum -1)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 3)
+                           (pos_bol 90) (pos_cnum 146)))
                          (loc_ghost true))))
                       (((ptyp_desc
                          (Ptyp_object
@@ -1073,11 +1075,11 @@
                               ((txt lola)
                                (loc
                                 ((loc_start
-                                  ((pos_fname Generated_locations)
-                                   (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
                                  (loc_end
-                                  ((pos_fname Generated_locations)
-                                   (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 3) (pos_bol 90) (pos_cnum 146)))
                                  (loc_ghost true))))
                               ((ptyp_desc (Ptyp_var lola))
                                (ptyp_loc
@@ -1091,39 +1093,39 @@
                                (ptyp_loc_stack ()) (ptyp_attributes ()))))
                             (pof_loc
                              ((loc_start
-                               ((pos_fname Generated_locations) (pos_lnum 1)
-                                (pos_bol 0) (pos_cnum -1)))
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
                               (loc_end
-                               ((pos_fname Generated_locations) (pos_lnum 1)
-                                (pos_bol 0) (pos_cnum -1)))
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 3) (pos_bol 90) (pos_cnum 146)))
                               (loc_ghost true)))
                             (pof_attributes ())))
                           Closed))
                         (ptyp_loc
                          ((loc_start
-                           ((pos_fname Generated_locations) (pos_lnum 1)
-                            (pos_bol 0) (pos_cnum -1)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 1)
+                            (pos_bol 0) (pos_cnum 0)))
                           (loc_end
-                           ((pos_fname Generated_locations) (pos_lnum 1)
-                            (pos_bol 0) (pos_cnum -1)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 3)
+                            (pos_bol 90) (pos_cnum 146)))
                           (loc_ghost true)))
                         (ptyp_loc_stack ()) (ptyp_attributes ())))))
                     (ptyp_loc
                      ((loc_start
-                       ((pos_fname Generated_locations) (pos_lnum 1)
-                        (pos_bol 0) (pos_cnum -1)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 1)
+                        (pos_bol 0) (pos_cnum 0)))
                       (loc_end
-                       ((pos_fname Generated_locations) (pos_lnum 1)
-                        (pos_bol 0) (pos_cnum -1)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 3)
+                        (pos_bol 90) (pos_cnum 146)))
                       (loc_ghost true)))
                     (ptyp_loc_stack ()) (ptyp_attributes ()))))
                  (ppat_loc
                   ((loc_start
-                    ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                     (pos_cnum -1)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 1)
+                     (pos_bol 0) (pos_cnum 0)))
                    (loc_end
-                    ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                     (pos_cnum -1)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 3)
+                     (pos_bol 90) (pos_cnum 146)))
                    (loc_ghost true)))
                  (ppat_loc_stack ()) (ppat_attributes ()))
                 ((pexp_desc
@@ -1133,11 +1135,11 @@
                       ((txt (Lident make))
                        (loc
                         ((loc_start
-                          ((pos_fname Generated_locations) (pos_lnum 1)
-                           (pos_bol 0) (pos_cnum -1)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 1)
+                           (pos_bol 0) (pos_cnum 0)))
                          (loc_end
-                          ((pos_fname Generated_locations) (pos_lnum 1)
-                           (pos_bol 0) (pos_cnum -1)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 3)
+                           (pos_bol 90) (pos_cnum 146)))
                          (loc_ghost true))))))
                     (pexp_loc
                      ((loc_start
@@ -1258,30 +1260,30 @@
                  (loc_ghost true))))))
             (pvb_loc
              ((loc_start
-               ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                (pos_cnum -1)))
+               ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+                (pos_cnum 0)))
               (loc_end
-               ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                (pos_cnum -1)))
+               ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+                (pos_cnum 146)))
               (loc_ghost true)))))
           ((pexp_desc
             (Pexp_ident
              ((txt (Lident Generated_locations))
               (loc
                ((loc_start
-                 ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                  (pos_cnum -1)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+                  (pos_cnum 0)))
                 (loc_end
-                 ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-                  (pos_cnum -1)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 3)
+                  (pos_bol 90) (pos_cnum 146)))
                 (loc_ghost true))))))
            (pexp_loc
             ((loc_start
-              ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-               (pos_cnum -1)))
+              ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum 0)))
              (loc_end
-              ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
-               (pos_cnum -1)))
+              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+               (pos_cnum 146)))
              (loc_ghost true)))
            (pexp_loc_stack ()) (pexp_attributes ()))))
         (pexp_loc
@@ -1302,7 +1304,9 @@
         (loc_ghost false)))))))
   (pstr_loc
    ((loc_start
-     ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+     ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+      (pos_cnum 0)))
     (loc_end
-     ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+     ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+      (pos_cnum 146)))
     (loc_ghost true)))))

--- a/ppx/test/output_locations.expected
+++ b/ppx/test/output_locations.expected
@@ -1208,24 +1208,7 @@
                  ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
                 (loc_ghost true)))
               (pexp_loc_stack ()) (pexp_attributes ())))
-            (pvb_attributes
-             (((attr_name
-                ((txt merlin.hide)
-                 (loc
-                  ((loc_start
-                    ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                     (pos_cnum -1)))
-                   (loc_end
-                    ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                     (pos_cnum -1)))
-                   (loc_ghost true)))))
-               (attr_payload (PStr ()))
-               (attr_loc
-                ((loc_start
-                  ((pos_fname _none_) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
-                 (loc_end
-                  ((pos_fname _none_) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
-                 (loc_ghost true))))))
+            (pvb_attributes ())
             (pvb_loc
              ((loc_start
                ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
@@ -2548,24 +2531,7 @@
                  ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
                 (loc_ghost true)))
               (pexp_loc_stack ()) (pexp_attributes ())))
-            (pvb_attributes
-             (((attr_name
-                ((txt merlin.hide)
-                 (loc
-                  ((loc_start
-                    ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                     (pos_cnum -1)))
-                   (loc_end
-                    ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                     (pos_cnum -1)))
-                   (loc_ghost true)))))
-               (attr_payload (PStr ()))
-               (attr_loc
-                ((loc_start
-                  ((pos_fname _none_) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
-                 (loc_end
-                  ((pos_fname _none_) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
-                 (loc_ghost true))))))
+            (pvb_attributes ())
             (pvb_loc
              ((loc_start
                ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
@@ -2890,18 +2856,18 @@
                           (loc
                            ((loc_start
                              ((pos_fname generated_locations.ml)
-                              (pos_lnum 11) (pos_bol 467) (pos_cnum 475)))
+                              (pos_lnum 11) (pos_bol 467) (pos_cnum 473)))
                             (loc_end
                              ((pos_fname generated_locations.ml)
-                              (pos_lnum 11) (pos_bol 467) (pos_cnum 492)))
+                              (pos_lnum 11) (pos_bol 467) (pos_cnum 534)))
                             (loc_ghost false))))))
                        (pexp_loc
                         ((loc_start
                           ((pos_fname generated_locations.ml) (pos_lnum 11)
-                           (pos_bol 467) (pos_cnum 475)))
+                           (pos_bol 467) (pos_cnum 473)))
                          (loc_end
                           ((pos_fname generated_locations.ml) (pos_lnum 11)
-                           (pos_bol 467) (pos_cnum 492)))
+                           (pos_bol 467) (pos_cnum 534)))
                          (loc_ghost false)))
                        (pexp_loc_stack ()) (pexp_attributes ()))
                       ((Nolabel
@@ -2911,18 +2877,18 @@
                             (loc
                              ((loc_start
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 11) (pos_bol 467) (pos_cnum 475)))
+                                (pos_lnum 11) (pos_bol 467) (pos_cnum 473)))
                               (loc_end
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 11) (pos_bol 467) (pos_cnum 492)))
+                                (pos_lnum 11) (pos_bol 467) (pos_cnum 534)))
                               (loc_ghost false))))))
                          (pexp_loc
                           ((loc_start
                             ((pos_fname generated_locations.ml) (pos_lnum 11)
-                             (pos_bol 467) (pos_cnum 475)))
+                             (pos_bol 467) (pos_cnum 473)))
                            (loc_end
                             ((pos_fname generated_locations.ml) (pos_lnum 11)
-                             (pos_bol 467) (pos_cnum 492)))
+                             (pos_bol 467) (pos_cnum 534)))
                            (loc_ghost false)))
                          (pexp_loc_stack ()) (pexp_attributes ())))
                        (Nolabel
@@ -2935,19 +2901,19 @@
                                 ((loc_start
                                   ((pos_fname generated_locations.ml)
                                    (pos_lnum 11) (pos_bol 467)
-                                   (pos_cnum 475)))
+                                   (pos_cnum 473)))
                                  (loc_end
                                   ((pos_fname generated_locations.ml)
                                    (pos_lnum 11) (pos_bol 467)
-                                   (pos_cnum 492)))
+                                   (pos_cnum 534)))
                                  (loc_ghost false))))))
                             (pexp_loc
                              ((loc_start
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 11) (pos_bol 467) (pos_cnum 475)))
+                                (pos_lnum 11) (pos_bol 467) (pos_cnum 473)))
                               (loc_end
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 11) (pos_bol 467) (pos_cnum 492)))
+                                (pos_lnum 11) (pos_bol 467) (pos_cnum 534)))
                               (loc_ghost false)))
                             (pexp_loc_stack ()) (pexp_attributes ()))
                            (((Labelled children)
@@ -3000,39 +2966,19 @@
                          (pexp_loc
                           ((loc_start
                             ((pos_fname generated_locations.ml) (pos_lnum 11)
-                             (pos_bol 467) (pos_cnum 475)))
+                             (pos_bol 467) (pos_cnum 473)))
                            (loc_end
                             ((pos_fname generated_locations.ml) (pos_lnum 11)
-                             (pos_bol 467) (pos_cnum 492)))
+                             (pos_bol 467) (pos_cnum 534)))
                            (loc_ghost false)))
-                         (pexp_loc_stack ())
-                         (pexp_attributes
-                          (((attr_name
-                             ((txt merlin.hide)
-                              (loc
-                               ((loc_start
-                                 ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                                  (pos_cnum -1)))
-                                (loc_end
-                                 ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                                  (pos_cnum -1)))
-                                (loc_ghost true)))))
-                            (attr_payload (PStr ()))
-                            (attr_loc
-                             ((loc_start
-                               ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                                (pos_cnum -1)))
-                              (loc_end
-                               ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                                (pos_cnum -1)))
-                              (loc_ghost true)))))))))))
+                         (pexp_loc_stack ()) (pexp_attributes ()))))))
                     (pexp_loc
                      ((loc_start
                        ((pos_fname generated_locations.ml) (pos_lnum 11)
-                        (pos_bol 467) (pos_cnum 475)))
+                        (pos_bol 467) (pos_cnum 473)))
                       (loc_end
                        ((pos_fname generated_locations.ml) (pos_lnum 11)
-                        (pos_bol 467) (pos_cnum 492)))
+                        (pos_bol 467) (pos_cnum 534)))
                       (loc_ghost false)))
                     (pexp_loc_stack ()) (pexp_attributes ()))))
                  (pexp_loc
@@ -3403,26 +3349,7 @@
                            (pos_cnum -1)))
                          (loc_ghost true)))
                        (pexp_loc_stack ()) (pexp_attributes ())))
-                     (pvb_attributes
-                      (((attr_name
-                         ((txt merlin.hide)
-                          (loc
-                           ((loc_start
-                             ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                              (pos_cnum -1)))
-                            (loc_end
-                             ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                              (pos_cnum -1)))
-                            (loc_ghost true)))))
-                        (attr_payload (PStr ()))
-                        (attr_loc
-                         ((loc_start
-                           ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                            (pos_cnum -1)))
-                          (loc_end
-                           ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                            (pos_cnum -1)))
-                          (loc_ghost true))))))
+                     (pvb_attributes ())
                      (pvb_loc
                       ((loc_start
                         ((pos_fname generated_locations.ml) (pos_lnum 10)

--- a/ppx/test/output_locations.expected
+++ b/ppx/test/output_locations.expected
@@ -1,0 +1,1291 @@
+(((pstr_desc
+   (Pstr_attribute
+    ((attr_name
+      ((txt ocaml.ppx.context)
+       (loc
+        ((loc_start
+          ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+         (loc_end
+          ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+         (loc_ghost true)))))
+     (attr_payload
+      (PStr
+       (((pstr_desc
+          (Pstr_eval
+           ((pexp_desc
+             (Pexp_record
+              ((((txt (Lident tool_name))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_constant
+                   (Pconst_string ppxlib_driver
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))
+                    ())))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident include_dirs))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident []))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident load_path))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident []))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident open_modules))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident []))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident for_package))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident None))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident debug))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident false))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident use_threads))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident false))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident use_vmthreads))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident false))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident recursive_types))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident false))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident principal))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident false))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident transparent_modules))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident false))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident unboxed_types))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident false))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident unsafe_string))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident false))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ())))
+               (((txt (Lident cookies))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))
+                ((pexp_desc
+                  (Pexp_construct
+                   ((txt (Lident []))
+                    (loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))))
+                   ()))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ()))))
+              ()))
+            (pexp_loc
+             ((loc_start
+               ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+              (loc_end
+               ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+              (loc_ghost true)))
+            (pexp_loc_stack ()) (pexp_attributes ()))
+           ()))
+         (pstr_loc
+          ((loc_start
+            ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+           (loc_end
+            ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+           (loc_ghost true)))))))
+     (attr_loc
+      ((loc_start
+        ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+       (loc_end ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+       (loc_ghost true))))))
+  (pstr_loc
+   ((loc_start ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+    (loc_end ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+    (loc_ghost true))))
+ ((pstr_desc
+   (Pstr_primitive
+    ((pval_name
+      ((txt makeProps)
+       (loc
+        ((loc_start
+          ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+           (pos_cnum -1)))
+         (loc_end
+          ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+           (pos_cnum -1)))
+         (loc_ghost true)))))
+     (pval_type
+      ((ptyp_desc
+        (Ptyp_arrow (Labelled lola)
+         ((ptyp_desc (Ptyp_var lola))
+          (ptyp_loc
+           ((loc_start
+             ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+              (pos_cnum 10)))
+            (loc_end
+             ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+              (pos_cnum 14)))
+            (loc_ghost false)))
+          (ptyp_loc_stack ()) (ptyp_attributes ()))
+         ((ptyp_desc
+           (Ptyp_arrow (Optional key)
+            ((ptyp_desc
+              (Ptyp_constr
+               ((txt (Lident string))
+                (loc
+                 ((loc_start
+                   ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                    (pos_cnum -1)))
+                  (loc_end
+                   ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                    (pos_cnum -1)))
+                  (loc_ghost true))))
+               ()))
+             (ptyp_loc
+              ((loc_start
+                ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                 (pos_cnum -1)))
+               (loc_end
+                ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                 (pos_cnum -1)))
+               (loc_ghost true)))
+             (ptyp_loc_stack ()) (ptyp_attributes ()))
+            ((ptyp_desc
+              (Ptyp_arrow Nolabel
+               ((ptyp_desc
+                 (Ptyp_constr
+                  ((txt (Lident unit))
+                   (loc
+                    ((loc_start
+                      ((pos_fname Generated_locations) (pos_lnum 1)
+                       (pos_bol 0) (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname Generated_locations) (pos_lnum 1)
+                       (pos_bol 0) (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ()))
+                (ptyp_loc
+                 ((loc_start
+                   ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                    (pos_cnum -1)))
+                  (loc_end
+                   ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                    (pos_cnum -1)))
+                  (loc_ghost true)))
+                (ptyp_loc_stack ()) (ptyp_attributes ()))
+               ((ptyp_desc
+                 (Ptyp_constr
+                  ((txt (Ldot (Lident Js) t))
+                   (loc
+                    ((loc_start
+                      ((pos_fname Generated_locations) (pos_lnum 1)
+                       (pos_bol 0) (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname Generated_locations) (pos_lnum 1)
+                       (pos_bol 0) (pos_cnum -1)))
+                     (loc_ghost true))))
+                  (((ptyp_desc
+                     (Ptyp_object
+                      (((pof_desc
+                         (Otag
+                          ((txt lola)
+                           (loc
+                            ((loc_start
+                              ((pos_fname Generated_locations) (pos_lnum 1)
+                               (pos_bol 0) (pos_cnum -1)))
+                             (loc_end
+                              ((pos_fname Generated_locations) (pos_lnum 1)
+                               (pos_bol 0) (pos_cnum -1)))
+                             (loc_ghost true))))
+                          ((ptyp_desc (Ptyp_var lola))
+                           (ptyp_loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 1) (pos_bol 0) (pos_cnum 10)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 1) (pos_bol 0) (pos_cnum 14)))
+                             (loc_ghost false)))
+                           (ptyp_loc_stack ()) (ptyp_attributes ()))))
+                        (pof_loc
+                         ((loc_start
+                           ((pos_fname Generated_locations) (pos_lnum 1)
+                            (pos_bol 0) (pos_cnum -1)))
+                          (loc_end
+                           ((pos_fname Generated_locations) (pos_lnum 1)
+                            (pos_bol 0) (pos_cnum -1)))
+                          (loc_ghost true)))
+                        (pof_attributes ())))
+                      Closed))
+                    (ptyp_loc
+                     ((loc_start
+                       ((pos_fname Generated_locations) (pos_lnum 1)
+                        (pos_bol 0) (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname Generated_locations) (pos_lnum 1)
+                        (pos_bol 0) (pos_cnum -1)))
+                      (loc_ghost true)))
+                    (ptyp_loc_stack ()) (ptyp_attributes ())))))
+                (ptyp_loc
+                 ((loc_start
+                   ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                    (pos_cnum -1)))
+                  (loc_end
+                   ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                    (pos_cnum -1)))
+                  (loc_ghost true)))
+                (ptyp_loc_stack ()) (ptyp_attributes ()))))
+             (ptyp_loc
+              ((loc_start
+                ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+               (loc_end
+                ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+               (loc_ghost true)))
+             (ptyp_loc_stack ()) (ptyp_attributes ()))))
+          (ptyp_loc
+           ((loc_start
+             ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+              (pos_cnum -1)))
+            (loc_end
+             ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+              (pos_cnum -1)))
+            (loc_ghost true)))
+          (ptyp_loc_stack ()) (ptyp_attributes ()))))
+       (ptyp_loc
+        ((loc_start
+          ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+           (pos_cnum 10)))
+         (loc_end
+          ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+           (pos_cnum 14)))
+         (loc_ghost false)))
+       (ptyp_loc_stack ()) (ptyp_attributes ())))
+     (pval_prim (""))
+     (pval_attributes
+      (((attr_name
+         ((txt bs.obj)
+          (loc
+           ((loc_start
+             ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+              (pos_cnum -1)))
+            (loc_end
+             ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+              (pos_cnum -1)))
+            (loc_ghost true)))))
+        (attr_payload (PStr ()))
+        (attr_loc
+         ((loc_start
+           ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+            (pos_cnum -1)))
+          (loc_end
+           ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+            (pos_cnum -1)))
+          (loc_ghost true))))))
+     (pval_loc
+      ((loc_start
+        ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+         (pos_cnum -1)))
+       (loc_end
+        ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+         (pos_cnum -1)))
+       (loc_ghost true))))))
+  (pstr_loc
+   ((loc_start
+     ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+    (loc_end
+     ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+    (loc_ghost true))))
+ ((pstr_desc
+   (Pstr_value Nonrecursive
+    (((pvb_pat
+       ((ppat_desc
+         (Ppat_var
+          ((txt make)
+           (loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum 4)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum 8)))
+             (loc_ghost false))))))
+        (ppat_loc
+         ((loc_start
+           ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+            (pos_cnum -1)))
+          (loc_end
+           ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+            (pos_cnum -1)))
+          (loc_ghost true)))
+        (ppat_loc_stack ()) (ppat_attributes ())))
+      (pvb_expr
+       ((pexp_desc
+         (Pexp_fun (Labelled lola) ()
+          ((ppat_desc
+            (Ppat_var
+             ((txt lola)
+              (loc
+               ((loc_start
+                 ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+                  (pos_cnum 10)))
+                (loc_end
+                 ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+                  (pos_cnum 14)))
+                (loc_ghost false))))))
+           (ppat_loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum 10)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum 14)))
+             (loc_ghost false)))
+           (ppat_loc_stack ()) (ppat_attributes ()))
+          ((pexp_desc
+            (Pexp_apply
+             ((pexp_desc
+               (Pexp_ident
+                ((txt (Ldot (Lident ReactDOM) jsx))
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))))
+              (pexp_loc
+               ((loc_start
+                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                (loc_end
+                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                (loc_ghost true)))
+              (pexp_loc_stack ()) (pexp_attributes ()))
+             ((Nolabel
+               ((pexp_desc
+                 (Pexp_constant
+                  (Pconst_string div
+                   ((loc_start
+                     ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                      (pos_cnum -1)))
+                    (loc_end
+                     ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                      (pos_cnum -1)))
+                    (loc_ghost true))
+                   ())))
+                (pexp_loc
+                 ((loc_start
+                   ((pos_fname generated_locations.ml) (pos_lnum 2)
+                    (pos_bol 18) (pos_cnum 22)))
+                  (loc_end
+                   ((pos_fname generated_locations.ml) (pos_lnum 2)
+                    (pos_bol 18) (pos_cnum 25)))
+                  (loc_ghost false)))
+                (pexp_loc_stack ()) (pexp_attributes ())))
+              (Nolabel
+               ((pexp_desc
+                 (Pexp_apply
+                  ((pexp_desc
+                    (Pexp_ident
+                     ((txt (Ldot (Lident ReactDOM) domProps))
+                      (loc
+                       ((loc_start
+                         ((pos_fname generated_locations.ml) (pos_lnum 2)
+                          (pos_bol 18) (pos_cnum 22)))
+                        (loc_end
+                         ((pos_fname generated_locations.ml) (pos_lnum 2)
+                          (pos_bol 18) (pos_cnum 25)))
+                        (loc_ghost false))))))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname generated_locations.ml) (pos_lnum 2)
+                       (pos_bol 18) (pos_cnum 22)))
+                     (loc_end
+                      ((pos_fname generated_locations.ml) (pos_lnum 2)
+                       (pos_bol 18) (pos_cnum 25)))
+                     (loc_ghost false)))
+                   (pexp_loc_stack ()) (pexp_attributes ()))
+                  (((Labelled children)
+                    ((pexp_desc
+                      (Pexp_apply
+                       ((pexp_desc
+                         (Pexp_ident
+                          ((txt (Ldot (Lident React) string))
+                           (loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 2) (pos_bol 18) (pos_cnum 39)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 2) (pos_bol 18) (pos_cnum 51)))
+                             (loc_ghost false))))))
+                        (pexp_loc
+                         ((loc_start
+                           ((pos_fname generated_locations.ml) (pos_lnum 2)
+                            (pos_bol 18) (pos_cnum 39)))
+                          (loc_end
+                           ((pos_fname generated_locations.ml) (pos_lnum 2)
+                            (pos_bol 18) (pos_cnum 51)))
+                          (loc_ghost false)))
+                        (pexp_loc_stack ()) (pexp_attributes ()))
+                       ((Nolabel
+                         ((pexp_desc
+                           (Pexp_ident
+                            ((txt (Lident lola))
+                             (loc
+                              ((loc_start
+                                ((pos_fname generated_locations.ml)
+                                 (pos_lnum 2) (pos_bol 18) (pos_cnum 52)))
+                               (loc_end
+                                ((pos_fname generated_locations.ml)
+                                 (pos_lnum 2) (pos_bol 18) (pos_cnum 56)))
+                               (loc_ghost false))))))
+                          (pexp_loc
+                           ((loc_start
+                             ((pos_fname generated_locations.ml) (pos_lnum 2)
+                              (pos_bol 18) (pos_cnum 52)))
+                            (loc_end
+                             ((pos_fname generated_locations.ml) (pos_lnum 2)
+                              (pos_bol 18) (pos_cnum 56)))
+                            (loc_ghost false)))
+                          (pexp_loc_stack ()) (pexp_attributes ()))))))
+                     (pexp_loc
+                      ((loc_start
+                        ((pos_fname generated_locations.ml) (pos_lnum 2)
+                         (pos_bol 18) (pos_cnum 37)))
+                       (loc_end
+                        ((pos_fname generated_locations.ml) (pos_lnum 2)
+                         (pos_bol 18) (pos_cnum 84)))
+                       (loc_ghost false)))
+                     (pexp_loc_stack
+                      (((loc_start
+                         ((pos_fname generated_locations.ml) (pos_lnum 2)
+                          (pos_bol 18) (pos_cnum 38)))
+                        (loc_end
+                         ((pos_fname generated_locations.ml) (pos_lnum 2)
+                          (pos_bol 18) (pos_cnum 57)))
+                        (loc_ghost false))
+                       ((loc_start
+                         ((pos_fname generated_locations.ml) (pos_lnum 2)
+                          (pos_bol 18) (pos_cnum 39)))
+                        (loc_end
+                         ((pos_fname generated_locations.ml) (pos_lnum 2)
+                          (pos_bol 18) (pos_cnum 56)))
+                        (loc_ghost false))))
+                     (pexp_attributes
+                      (((attr_name
+                         ((txt reason.preserve_braces)
+                          (loc
+                           ((loc_start
+                             ((pos_fname generated_locations.ml) (pos_lnum 2)
+                              (pos_bol 18) (pos_cnum 59)))
+                            (loc_end
+                             ((pos_fname generated_locations.ml) (pos_lnum 2)
+                              (pos_bol 18) (pos_cnum 81)))
+                            (loc_ghost false)))))
+                        (attr_payload (PStr ()))
+                        (attr_loc
+                         ((loc_start
+                           ((pos_fname generated_locations.ml) (pos_lnum 2)
+                            (pos_bol 18) (pos_cnum 57)))
+                          (loc_end
+                           ((pos_fname generated_locations.ml) (pos_lnum 2)
+                            (pos_bol 18) (pos_cnum 83)))
+                          (loc_ghost false))))))))
+                   (Nolabel
+                    ((pexp_desc
+                      (Pexp_construct
+                       ((txt (Lident "()"))
+                        (loc
+                         ((loc_start
+                           ((pos_fname generated_locations.ml) (pos_lnum 2)
+                            (pos_bol 18) (pos_cnum 86)))
+                          (loc_end
+                           ((pos_fname generated_locations.ml) (pos_lnum 2)
+                            (pos_bol 18) (pos_cnum 88)))
+                          (loc_ghost false))))
+                       ()))
+                     (pexp_loc
+                      ((loc_start
+                        ((pos_fname generated_locations.ml) (pos_lnum 2)
+                         (pos_bol 18) (pos_cnum 86)))
+                       (loc_end
+                        ((pos_fname generated_locations.ml) (pos_lnum 2)
+                         (pos_bol 18) (pos_cnum 88)))
+                       (loc_ghost false)))
+                     (pexp_loc_stack ()) (pexp_attributes ()))))))
+                (pexp_loc
+                 ((loc_start
+                   ((pos_fname generated_locations.ml) (pos_lnum 2)
+                    (pos_bol 18) (pos_cnum 22)))
+                  (loc_end
+                   ((pos_fname generated_locations.ml) (pos_lnum 2)
+                    (pos_bol 18) (pos_cnum 25)))
+                  (loc_ghost false)))
+                (pexp_loc_stack ()) (pexp_attributes ()))))))
+           (pexp_loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 18)
+               (pos_cnum 22)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 18)
+               (pos_cnum 25)))
+             (loc_ghost false)))
+           (pexp_loc_stack ())
+           (pexp_attributes
+            (((attr_name
+               ((txt reason.preserve_braces)
+                (loc
+                 ((loc_start
+                   ((pos_fname generated_locations.ml) (pos_lnum 3)
+                    (pos_bol 90) (pos_cnum 94)))
+                  (loc_end
+                   ((pos_fname generated_locations.ml) (pos_lnum 3)
+                    (pos_bol 90) (pos_cnum 116)))
+                  (loc_ghost false)))))
+              (attr_payload (PStr ()))
+              (attr_loc
+               ((loc_start
+                 ((pos_fname generated_locations.ml) (pos_lnum 3)
+                  (pos_bol 90) (pos_cnum 92)))
+                (loc_end
+                 ((pos_fname generated_locations.ml) (pos_lnum 3)
+                  (pos_bol 90) (pos_cnum 118)))
+                (loc_ghost false)))))))))
+        (pexp_loc
+         ((loc_start
+           ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+            (pos_cnum 9)))
+          (loc_end
+           ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+            (pos_cnum 126)))
+          (loc_ghost true)))
+        (pexp_loc_stack ())
+        (pexp_attributes
+         (((attr_name
+            ((txt warning)
+             (loc
+              ((loc_start
+                ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                 (pos_cnum -1)))
+               (loc_end
+                ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                 (pos_cnum -1)))
+               (loc_ghost true)))))
+           (attr_payload
+            (PStr
+             (((pstr_desc
+                (Pstr_eval
+                 ((pexp_desc
+                   (Pexp_constant
+                    (Pconst_string -16
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))
+                     ())))
+                  (pexp_loc
+                   ((loc_start
+                     ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                      (pos_cnum -1)))
+                    (loc_end
+                     ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                      (pos_cnum -1)))
+                    (loc_ghost true)))
+                  (pexp_loc_stack ()) (pexp_attributes ()))
+                 ()))
+               (pstr_loc
+                ((loc_start
+                  ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                 (loc_end
+                  ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                 (loc_ghost true)))))))
+           (attr_loc
+            ((loc_start
+              ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum -1)))
+             (loc_end
+              ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum -1)))
+             (loc_ghost true))))))))
+      (pvb_attributes ())
+      (pvb_loc
+       ((loc_start
+         ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+          (pos_cnum -1)))
+        (loc_end
+         ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+          (pos_cnum -1)))
+        (loc_ghost true)))))))
+  (pstr_loc
+   ((loc_start
+     ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+      (pos_cnum 0)))
+    (loc_end
+     ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+      (pos_cnum 146)))
+    (loc_ghost false))))
+ ((pstr_desc
+   (Pstr_value Nonrecursive
+    (((pvb_pat
+       ((ppat_desc
+         (Ppat_var
+          ((txt make)
+           (loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum 4)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum 8)))
+             (loc_ghost false))))))
+        (ppat_loc
+         ((loc_start
+           ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+            (pos_cnum 4)))
+          (loc_end
+           ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+            (pos_cnum 8)))
+          (loc_ghost false)))
+        (ppat_loc_stack ()) (ppat_attributes ())))
+      (pvb_expr
+       ((pexp_desc
+         (Pexp_let Nonrecursive
+          (((pvb_pat
+             ((ppat_desc
+               (Ppat_var
+                ((txt Generated_locations)
+                 (loc
+                  ((loc_start
+                    ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true))))))
+              (ppat_loc
+               ((loc_start
+                 ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                  (pos_cnum -1)))
+                (loc_end
+                 ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                  (pos_cnum -1)))
+                (loc_ghost true)))
+              (ppat_loc_stack ()) (ppat_attributes ())))
+            (pvb_expr
+             ((pexp_desc
+               (Pexp_fun Nolabel ()
+                ((ppat_desc
+                  (Ppat_constraint
+                   ((ppat_desc
+                     (Ppat_var
+                      ((txt Props)
+                       (loc
+                        ((loc_start
+                          ((pos_fname Generated_locations) (pos_lnum 1)
+                           (pos_bol 0) (pos_cnum -1)))
+                         (loc_end
+                          ((pos_fname Generated_locations) (pos_lnum 1)
+                           (pos_bol 0) (pos_cnum -1)))
+                         (loc_ghost true))))))
+                    (ppat_loc
+                     ((loc_start
+                       ((pos_fname Generated_locations) (pos_lnum 1)
+                        (pos_bol 0) (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname Generated_locations) (pos_lnum 1)
+                        (pos_bol 0) (pos_cnum -1)))
+                      (loc_ghost true)))
+                    (ppat_loc_stack ()) (ppat_attributes ()))
+                   ((ptyp_desc
+                     (Ptyp_constr
+                      ((txt (Ldot (Lident Js) t))
+                       (loc
+                        ((loc_start
+                          ((pos_fname Generated_locations) (pos_lnum 1)
+                           (pos_bol 0) (pos_cnum -1)))
+                         (loc_end
+                          ((pos_fname Generated_locations) (pos_lnum 1)
+                           (pos_bol 0) (pos_cnum -1)))
+                         (loc_ghost true))))
+                      (((ptyp_desc
+                         (Ptyp_object
+                          (((pof_desc
+                             (Otag
+                              ((txt lola)
+                               (loc
+                                ((loc_start
+                                  ((pos_fname Generated_locations)
+                                   (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+                                 (loc_end
+                                  ((pos_fname Generated_locations)
+                                   (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+                                 (loc_ghost true))))
+                              ((ptyp_desc (Ptyp_var lola))
+                               (ptyp_loc
+                                ((loc_start
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 1) (pos_bol 0) (pos_cnum 10)))
+                                 (loc_end
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 1) (pos_bol 0) (pos_cnum 14)))
+                                 (loc_ghost false)))
+                               (ptyp_loc_stack ()) (ptyp_attributes ()))))
+                            (pof_loc
+                             ((loc_start
+                               ((pos_fname Generated_locations) (pos_lnum 1)
+                                (pos_bol 0) (pos_cnum -1)))
+                              (loc_end
+                               ((pos_fname Generated_locations) (pos_lnum 1)
+                                (pos_bol 0) (pos_cnum -1)))
+                              (loc_ghost true)))
+                            (pof_attributes ())))
+                          Closed))
+                        (ptyp_loc
+                         ((loc_start
+                           ((pos_fname Generated_locations) (pos_lnum 1)
+                            (pos_bol 0) (pos_cnum -1)))
+                          (loc_end
+                           ((pos_fname Generated_locations) (pos_lnum 1)
+                            (pos_bol 0) (pos_cnum -1)))
+                          (loc_ghost true)))
+                        (ptyp_loc_stack ()) (ptyp_attributes ())))))
+                    (ptyp_loc
+                     ((loc_start
+                       ((pos_fname Generated_locations) (pos_lnum 1)
+                        (pos_bol 0) (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname Generated_locations) (pos_lnum 1)
+                        (pos_bol 0) (pos_cnum -1)))
+                      (loc_ghost true)))
+                    (ptyp_loc_stack ()) (ptyp_attributes ()))))
+                 (ppat_loc
+                  ((loc_start
+                    ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (ppat_loc_stack ()) (ppat_attributes ()))
+                ((pexp_desc
+                  (Pexp_apply
+                   ((pexp_desc
+                     (Pexp_ident
+                      ((txt (Lident make))
+                       (loc
+                        ((loc_start
+                          ((pos_fname Generated_locations) (pos_lnum 1)
+                           (pos_bol 0) (pos_cnum -1)))
+                         (loc_end
+                          ((pos_fname Generated_locations) (pos_lnum 1)
+                           (pos_bol 0) (pos_cnum -1)))
+                         (loc_ghost true))))))
+                    (pexp_loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true)))
+                    (pexp_loc_stack ()) (pexp_attributes ()))
+                   (((Labelled lola)
+                     ((pexp_desc
+                       (Pexp_apply
+                        ((pexp_desc
+                          (Pexp_ident
+                           ((txt (Lident ##))
+                            (loc
+                             ((loc_start
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 1) (pos_bol 0) (pos_cnum 10)))
+                              (loc_end
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 1) (pos_bol 0) (pos_cnum 14)))
+                              (loc_ghost false))))))
+                         (pexp_loc
+                          ((loc_start
+                            ((pos_fname generated_locations.ml) (pos_lnum 1)
+                             (pos_bol 0) (pos_cnum 10)))
+                           (loc_end
+                            ((pos_fname generated_locations.ml) (pos_lnum 1)
+                             (pos_bol 0) (pos_cnum 14)))
+                           (loc_ghost false)))
+                         (pexp_loc_stack ()) (pexp_attributes ()))
+                        ((Nolabel
+                          ((pexp_desc
+                            (Pexp_ident
+                             ((txt (Lident Props))
+                              (loc
+                               ((loc_start
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 1) (pos_bol 0) (pos_cnum 10)))
+                                (loc_end
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 1) (pos_bol 0) (pos_cnum 14)))
+                                (loc_ghost false))))))
+                           (pexp_loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 1) (pos_bol 0) (pos_cnum 10)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 1) (pos_bol 0) (pos_cnum 14)))
+                             (loc_ghost false)))
+                           (pexp_loc_stack ()) (pexp_attributes ())))
+                         (Nolabel
+                          ((pexp_desc
+                            (Pexp_ident
+                             ((txt (Lident lola))
+                              (loc
+                               ((loc_start
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 1) (pos_bol 0) (pos_cnum 10)))
+                                (loc_end
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 1) (pos_bol 0) (pos_cnum 14)))
+                                (loc_ghost false))))))
+                           (pexp_loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 1) (pos_bol 0) (pos_cnum 10)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 1) (pos_bol 0) (pos_cnum 14)))
+                             (loc_ghost false)))
+                           (pexp_loc_stack ()) (pexp_attributes ()))))))
+                      (pexp_loc
+                       ((loc_start
+                         ((pos_fname generated_locations.ml) (pos_lnum 1)
+                          (pos_bol 0) (pos_cnum 10)))
+                        (loc_end
+                         ((pos_fname generated_locations.ml) (pos_lnum 1)
+                          (pos_bol 0) (pos_cnum 14)))
+                        (loc_ghost false)))
+                      (pexp_loc_stack ()) (pexp_attributes ()))))))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ()))))
+              (pexp_loc
+               ((loc_start
+                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                (loc_end
+                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                (loc_ghost true)))
+              (pexp_loc_stack ()) (pexp_attributes ())))
+            (pvb_attributes ())
+            (pvb_loc
+             ((loc_start
+               ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                (pos_cnum -1)))
+              (loc_end
+               ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                (pos_cnum -1)))
+              (loc_ghost true)))))
+          ((pexp_desc
+            (Pexp_ident
+             ((txt (Lident Generated_locations))
+              (loc
+               ((loc_start
+                 ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                  (pos_cnum -1)))
+                (loc_end
+                 ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+                  (pos_cnum -1)))
+                (loc_ghost true))))))
+           (pexp_loc
+            ((loc_start
+              ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum -1)))
+             (loc_end
+              ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum -1)))
+             (loc_ghost true)))
+           (pexp_loc_stack ()) (pexp_attributes ()))))
+        (pexp_loc
+         ((loc_start
+           ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+          (loc_end
+           ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+          (loc_ghost true)))
+        (pexp_loc_stack ()) (pexp_attributes ())))
+      (pvb_attributes ())
+      (pvb_loc
+       ((loc_start
+         ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+          (pos_cnum 0)))
+        (loc_end
+         ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+          (pos_cnum 146)))
+        (loc_ghost false)))))))
+  (pstr_loc
+   ((loc_start
+     ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+    (loc_end
+     ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+    (loc_ghost true)))))

--- a/ppx/test/output_locations.expected
+++ b/ppx/test/output_locations.expected
@@ -1238,7 +1238,24 @@
                  ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
                 (loc_ghost true)))
               (pexp_loc_stack ()) (pexp_attributes ())))
-            (pvb_attributes ())
+            (pvb_attributes
+             (((attr_name
+                ((txt merlin.hide)
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))))
+               (attr_payload (PStr ()))
+               (attr_loc
+                ((loc_start
+                  ((pos_fname _none_) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+                 (loc_end
+                  ((pos_fname _none_) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+                 (loc_ghost true))))))
             (pvb_loc
              ((loc_start
                ((pos_fname Generated_locations) (pos_lnum 1) (pos_bol 0)

--- a/ppx/test/output_locations.expected
+++ b/ppx/test/output_locations.expected
@@ -466,8 +466,8 @@
           ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
            (pos_cnum 0)))
          (loc_end
-          ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-           (pos_cnum 146)))
+          ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+           (pos_cnum 152)))
          (loc_ghost true)))))
      (pval_type
       ((ptyp_desc
@@ -492,8 +492,8 @@
                    ((pos_fname generated_locations.ml) (pos_lnum 1)
                     (pos_bol 0) (pos_cnum 0)))
                   (loc_end
-                   ((pos_fname generated_locations.ml) (pos_lnum 3)
-                    (pos_bol 90) (pos_cnum 146)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 2)
+                    (pos_bol 84) (pos_cnum 152)))
                   (loc_ghost true))))
                ()))
              (ptyp_loc
@@ -501,8 +501,8 @@
                 ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
                  (pos_cnum 0)))
                (loc_end
-                ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-                 (pos_cnum 146)))
+                ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+                 (pos_cnum 152)))
                (loc_ghost true)))
              (ptyp_loc_stack ()) (ptyp_attributes ()))
             ((ptyp_desc
@@ -515,8 +515,8 @@
                       ((pos_fname generated_locations.ml) (pos_lnum 1)
                        (pos_bol 0) (pos_cnum 0)))
                      (loc_end
-                      ((pos_fname generated_locations.ml) (pos_lnum 3)
-                       (pos_bol 90) (pos_cnum 146)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 2)
+                       (pos_bol 84) (pos_cnum 152)))
                      (loc_ghost true))))
                   ()))
                 (ptyp_loc
@@ -524,8 +524,8 @@
                    ((pos_fname generated_locations.ml) (pos_lnum 1)
                     (pos_bol 0) (pos_cnum 0)))
                   (loc_end
-                   ((pos_fname generated_locations.ml) (pos_lnum 3)
-                    (pos_bol 90) (pos_cnum 146)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 2)
+                    (pos_bol 84) (pos_cnum 152)))
                   (loc_ghost true)))
                 (ptyp_loc_stack ()) (ptyp_attributes ()))
                ((ptyp_desc
@@ -536,8 +536,8 @@
                       ((pos_fname generated_locations.ml) (pos_lnum 1)
                        (pos_bol 0) (pos_cnum 0)))
                      (loc_end
-                      ((pos_fname generated_locations.ml) (pos_lnum 3)
-                       (pos_bol 90) (pos_cnum 146)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 2)
+                       (pos_bol 84) (pos_cnum 152)))
                      (loc_ghost true))))
                   (((ptyp_desc
                      (Ptyp_object
@@ -550,7 +550,7 @@
                                (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
                              (loc_end
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 3) (pos_bol 90) (pos_cnum 146)))
+                               (pos_lnum 2) (pos_bol 84) (pos_cnum 152)))
                              (loc_ghost true))))
                           ((ptyp_desc (Ptyp_var lola))
                            (ptyp_loc
@@ -567,8 +567,8 @@
                            ((pos_fname generated_locations.ml) (pos_lnum 1)
                             (pos_bol 0) (pos_cnum 0)))
                           (loc_end
-                           ((pos_fname generated_locations.ml) (pos_lnum 3)
-                            (pos_bol 90) (pos_cnum 146)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 2)
+                            (pos_bol 84) (pos_cnum 152)))
                           (loc_ghost true)))
                         (pof_attributes ())))
                       Closed))
@@ -577,8 +577,8 @@
                        ((pos_fname generated_locations.ml) (pos_lnum 1)
                         (pos_bol 0) (pos_cnum 0)))
                       (loc_end
-                       ((pos_fname generated_locations.ml) (pos_lnum 3)
-                        (pos_bol 90) (pos_cnum 146)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 2)
+                        (pos_bol 84) (pos_cnum 152)))
                       (loc_ghost true)))
                     (ptyp_loc_stack ()) (ptyp_attributes ())))))
                 (ptyp_loc
@@ -586,8 +586,8 @@
                    ((pos_fname generated_locations.ml) (pos_lnum 1)
                     (pos_bol 0) (pos_cnum 0)))
                   (loc_end
-                   ((pos_fname generated_locations.ml) (pos_lnum 3)
-                    (pos_bol 90) (pos_cnum 146)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 2)
+                    (pos_bol 84) (pos_cnum 152)))
                   (loc_ghost true)))
                 (ptyp_loc_stack ()) (ptyp_attributes ()))))
              (ptyp_loc
@@ -602,8 +602,8 @@
              ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
               (pos_cnum 0)))
             (loc_end
-             ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-              (pos_cnum 146)))
+             ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+              (pos_cnum 152)))
             (loc_ghost true)))
           (ptyp_loc_stack ()) (ptyp_attributes ()))))
        (ptyp_loc
@@ -624,8 +624,8 @@
              ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
               (pos_cnum 0)))
             (loc_end
-             ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-              (pos_cnum 146)))
+             ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+              (pos_cnum 152)))
             (loc_ghost true)))))
         (attr_payload (PStr ()))
         (attr_loc
@@ -633,24 +633,24 @@
            ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
             (pos_cnum 0)))
           (loc_end
-           ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-            (pos_cnum 146)))
+           ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+            (pos_cnum 152)))
           (loc_ghost true))))))
      (pval_loc
       ((loc_start
         ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
          (pos_cnum 0)))
        (loc_end
-        ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-         (pos_cnum 146)))
+        ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+         (pos_cnum 152)))
        (loc_ghost true))))))
   (pstr_loc
    ((loc_start
      ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
       (pos_cnum 0)))
     (loc_end
-     ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-      (pos_cnum 146)))
+     ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+      (pos_cnum 152)))
     (loc_ghost true))))
  ((pstr_desc
    (Pstr_value Nonrecursive
@@ -705,19 +705,19 @@
                 ((txt (Ldot (Lident ReactDOM) jsx))
                  (loc
                   ((loc_start
-                    ((pos_fname generated_locations.ml) (pos_lnum 2)
-                     (pos_bol 18) (pos_cnum 20)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 1)
+                     (pos_bol 0) (pos_cnum 18)))
                    (loc_end
-                    ((pos_fname generated_locations.ml) (pos_lnum 3)
-                     (pos_bol 90) (pos_cnum 126)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 1)
+                     (pos_bol 0) (pos_cnum 65)))
                    (loc_ghost false))))))
               (pexp_loc
                ((loc_start
-                 ((pos_fname generated_locations.ml) (pos_lnum 2)
-                  (pos_bol 18) (pos_cnum 20)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+                  (pos_cnum 18)))
                 (loc_end
-                 ((pos_fname generated_locations.ml) (pos_lnum 3)
-                  (pos_bol 90) (pos_cnum 126)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+                  (pos_cnum 65)))
                 (loc_ghost false)))
               (pexp_loc_stack ()) (pexp_attributes ()))
              ((Nolabel
@@ -734,11 +734,11 @@
                    ())))
                 (pexp_loc
                  ((loc_start
-                   ((pos_fname generated_locations.ml) (pos_lnum 2)
-                    (pos_bol 18) (pos_cnum 22)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 1)
+                    (pos_bol 0) (pos_cnum 20)))
                   (loc_end
-                   ((pos_fname generated_locations.ml) (pos_lnum 2)
-                    (pos_bol 18) (pos_cnum 25)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 1)
+                    (pos_bol 0) (pos_cnum 23)))
                   (loc_ghost false)))
                 (pexp_loc_stack ()) (pexp_attributes ())))
               (Nolabel
@@ -749,19 +749,19 @@
                      ((txt (Ldot (Lident ReactDOM) domProps))
                       (loc
                        ((loc_start
-                         ((pos_fname generated_locations.ml) (pos_lnum 2)
-                          (pos_bol 18) (pos_cnum 22)))
+                         ((pos_fname generated_locations.ml) (pos_lnum 1)
+                          (pos_bol 0) (pos_cnum 20)))
                         (loc_end
-                         ((pos_fname generated_locations.ml) (pos_lnum 2)
-                          (pos_bol 18) (pos_cnum 25)))
+                         ((pos_fname generated_locations.ml) (pos_lnum 1)
+                          (pos_bol 0) (pos_cnum 23)))
                         (loc_ghost false))))))
                    (pexp_loc
                     ((loc_start
-                      ((pos_fname generated_locations.ml) (pos_lnum 2)
-                       (pos_bol 18) (pos_cnum 20)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 1)
+                       (pos_bol 0) (pos_cnum 18)))
                      (loc_end
-                      ((pos_fname generated_locations.ml) (pos_lnum 3)
-                       (pos_bol 90) (pos_cnum 126)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 1)
+                       (pos_bol 0) (pos_cnum 65)))
                      (loc_ghost false)))
                    (pexp_loc_stack ())
                    (pexp_attributes
@@ -793,18 +793,18 @@
                            (loc
                             ((loc_start
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 2) (pos_bol 18) (pos_cnum 39)))
+                               (pos_lnum 1) (pos_bol 0) (pos_cnum 35)))
                              (loc_end
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 2) (pos_bol 18) (pos_cnum 51)))
+                               (pos_lnum 1) (pos_bol 0) (pos_cnum 47)))
                              (loc_ghost false))))))
                         (pexp_loc
                          ((loc_start
-                           ((pos_fname generated_locations.ml) (pos_lnum 2)
-                            (pos_bol 18) (pos_cnum 39)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 1)
+                            (pos_bol 0) (pos_cnum 35)))
                           (loc_end
-                           ((pos_fname generated_locations.ml) (pos_lnum 2)
-                            (pos_bol 18) (pos_cnum 51)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 1)
+                            (pos_bol 0) (pos_cnum 47)))
                           (loc_ghost false)))
                         (pexp_loc_stack ()) (pexp_attributes ()))
                        ((Nolabel
@@ -814,130 +814,76 @@
                              (loc
                               ((loc_start
                                 ((pos_fname generated_locations.ml)
-                                 (pos_lnum 2) (pos_bol 18) (pos_cnum 52)))
+                                 (pos_lnum 1) (pos_bol 0) (pos_cnum 48)))
                                (loc_end
                                 ((pos_fname generated_locations.ml)
-                                 (pos_lnum 2) (pos_bol 18) (pos_cnum 56)))
+                                 (pos_lnum 1) (pos_bol 0) (pos_cnum 52)))
                                (loc_ghost false))))))
                           (pexp_loc
                            ((loc_start
-                             ((pos_fname generated_locations.ml) (pos_lnum 2)
-                              (pos_bol 18) (pos_cnum 52)))
+                             ((pos_fname generated_locations.ml) (pos_lnum 1)
+                              (pos_bol 0) (pos_cnum 48)))
                             (loc_end
-                             ((pos_fname generated_locations.ml) (pos_lnum 2)
-                              (pos_bol 18) (pos_cnum 56)))
+                             ((pos_fname generated_locations.ml) (pos_lnum 1)
+                              (pos_bol 0) (pos_cnum 52)))
                             (loc_ghost false)))
                           (pexp_loc_stack ()) (pexp_attributes ()))))))
                      (pexp_loc
                       ((loc_start
-                        ((pos_fname generated_locations.ml) (pos_lnum 2)
-                         (pos_bol 18) (pos_cnum 37)))
+                        ((pos_fname generated_locations.ml) (pos_lnum 1)
+                         (pos_bol 0) (pos_cnum 35)))
                        (loc_end
-                        ((pos_fname generated_locations.ml) (pos_lnum 2)
-                         (pos_bol 18) (pos_cnum 84)))
+                        ((pos_fname generated_locations.ml) (pos_lnum 1)
+                         (pos_bol 0) (pos_cnum 52)))
                        (loc_ghost false)))
-                     (pexp_loc_stack
-                      (((loc_start
-                         ((pos_fname generated_locations.ml) (pos_lnum 2)
-                          (pos_bol 18) (pos_cnum 38)))
-                        (loc_end
-                         ((pos_fname generated_locations.ml) (pos_lnum 2)
-                          (pos_bol 18) (pos_cnum 57)))
-                        (loc_ghost false))
-                       ((loc_start
-                         ((pos_fname generated_locations.ml) (pos_lnum 2)
-                          (pos_bol 18) (pos_cnum 39)))
-                        (loc_end
-                         ((pos_fname generated_locations.ml) (pos_lnum 2)
-                          (pos_bol 18) (pos_cnum 56)))
-                        (loc_ghost false))))
-                     (pexp_attributes
-                      (((attr_name
-                         ((txt reason.preserve_braces)
-                          (loc
-                           ((loc_start
-                             ((pos_fname generated_locations.ml) (pos_lnum 2)
-                              (pos_bol 18) (pos_cnum 59)))
-                            (loc_end
-                             ((pos_fname generated_locations.ml) (pos_lnum 2)
-                              (pos_bol 18) (pos_cnum 81)))
-                            (loc_ghost false)))))
-                        (attr_payload (PStr ()))
-                        (attr_loc
-                         ((loc_start
-                           ((pos_fname generated_locations.ml) (pos_lnum 2)
-                            (pos_bol 18) (pos_cnum 57)))
-                          (loc_end
-                           ((pos_fname generated_locations.ml) (pos_lnum 2)
-                            (pos_bol 18) (pos_cnum 83)))
-                          (loc_ghost false))))))))
+                     (pexp_loc_stack ()) (pexp_attributes ())))
                    (Nolabel
                     ((pexp_desc
                       (Pexp_construct
                        ((txt (Lident "()"))
                         (loc
                          ((loc_start
-                           ((pos_fname generated_locations.ml) (pos_lnum 2)
-                            (pos_bol 18) (pos_cnum 86)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 1)
+                            (pos_bol 0) (pos_cnum 54)))
                           (loc_end
-                           ((pos_fname generated_locations.ml) (pos_lnum 2)
-                            (pos_bol 18) (pos_cnum 88)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 1)
+                            (pos_bol 0) (pos_cnum 56)))
                           (loc_ghost false))))
                        ()))
                      (pexp_loc
                       ((loc_start
-                        ((pos_fname generated_locations.ml) (pos_lnum 2)
-                         (pos_bol 18) (pos_cnum 86)))
+                        ((pos_fname generated_locations.ml) (pos_lnum 1)
+                         (pos_bol 0) (pos_cnum 54)))
                        (loc_end
-                        ((pos_fname generated_locations.ml) (pos_lnum 2)
-                         (pos_bol 18) (pos_cnum 88)))
+                        ((pos_fname generated_locations.ml) (pos_lnum 1)
+                         (pos_bol 0) (pos_cnum 56)))
                        (loc_ghost false)))
                      (pexp_loc_stack ()) (pexp_attributes ()))))))
                 (pexp_loc
                  ((loc_start
-                   ((pos_fname generated_locations.ml) (pos_lnum 2)
-                    (pos_bol 18) (pos_cnum 20)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 1)
+                    (pos_bol 0) (pos_cnum 18)))
                   (loc_end
-                   ((pos_fname generated_locations.ml) (pos_lnum 3)
-                    (pos_bol 90) (pos_cnum 126)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 1)
+                    (pos_bol 0) (pos_cnum 65)))
                   (loc_ghost false)))
                 (pexp_loc_stack ()) (pexp_attributes ()))))))
            (pexp_loc
             ((loc_start
-              ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 18)
-               (pos_cnum 20)))
+              ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum 18)))
              (loc_end
-              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-               (pos_cnum 126)))
+              ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+               (pos_cnum 65)))
              (loc_ghost false)))
-           (pexp_loc_stack ())
-           (pexp_attributes
-            (((attr_name
-               ((txt reason.preserve_braces)
-                (loc
-                 ((loc_start
-                   ((pos_fname generated_locations.ml) (pos_lnum 3)
-                    (pos_bol 90) (pos_cnum 94)))
-                  (loc_end
-                   ((pos_fname generated_locations.ml) (pos_lnum 3)
-                    (pos_bol 90) (pos_cnum 116)))
-                  (loc_ghost false)))))
-              (attr_payload (PStr ()))
-              (attr_loc
-               ((loc_start
-                 ((pos_fname generated_locations.ml) (pos_lnum 3)
-                  (pos_bol 90) (pos_cnum 92)))
-                (loc_end
-                 ((pos_fname generated_locations.ml) (pos_lnum 3)
-                  (pos_bol 90) (pos_cnum 118)))
-                (loc_ghost false)))))))))
+           (pexp_loc_stack ()) (pexp_attributes ()))))
         (pexp_loc
          ((loc_start
            ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
             (pos_cnum 9)))
           (loc_end
-           ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-            (pos_cnum 126)))
+           ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
+            (pos_cnum 65)))
           (loc_ghost true)))
         (pexp_loc_stack ())
         (pexp_attributes
@@ -948,8 +894,8 @@
                 ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
                  (pos_cnum 0)))
                (loc_end
-                ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-                 (pos_cnum 146)))
+                ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+                 (pos_cnum 152)))
                (loc_ghost true)))))
            (attr_payload
             (PStr
@@ -987,8 +933,8 @@
               ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
                (pos_cnum 0)))
              (loc_end
-              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-               (pos_cnum 146)))
+              ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+               (pos_cnum 152)))
              (loc_ghost true))))))))
       (pvb_attributes ())
       (pvb_loc
@@ -996,16 +942,16 @@
          ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
           (pos_cnum 0)))
         (loc_end
-         ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-          (pos_cnum 146)))
+         ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+          (pos_cnum 152)))
         (loc_ghost false)))))))
   (pstr_loc
    ((loc_start
      ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
       (pos_cnum 0)))
     (loc_end
-     ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-      (pos_cnum 146)))
+     ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+      (pos_cnum 152)))
     (loc_ghost false))))
  ((pstr_desc
    (Pstr_value Nonrecursive
@@ -1042,16 +988,16 @@
                     ((pos_fname generated_locations.ml) (pos_lnum 1)
                      (pos_bol 0) (pos_cnum 0)))
                    (loc_end
-                    ((pos_fname generated_locations.ml) (pos_lnum 3)
-                     (pos_bol 90) (pos_cnum 146)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 2)
+                     (pos_bol 84) (pos_cnum 152)))
                    (loc_ghost true))))))
               (ppat_loc
                ((loc_start
                  ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
                   (pos_cnum 0)))
                 (loc_end
-                 ((pos_fname generated_locations.ml) (pos_lnum 3)
-                  (pos_bol 90) (pos_cnum 146)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 2)
+                  (pos_bol 84) (pos_cnum 152)))
                 (loc_ghost true)))
               (ppat_loc_stack ()) (ppat_attributes ())))
             (pvb_expr
@@ -1067,16 +1013,16 @@
                           ((pos_fname generated_locations.ml) (pos_lnum 1)
                            (pos_bol 0) (pos_cnum 0)))
                          (loc_end
-                          ((pos_fname generated_locations.ml) (pos_lnum 3)
-                           (pos_bol 90) (pos_cnum 146)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 2)
+                           (pos_bol 84) (pos_cnum 152)))
                          (loc_ghost true))))))
                     (ppat_loc
                      ((loc_start
                        ((pos_fname generated_locations.ml) (pos_lnum 1)
                         (pos_bol 0) (pos_cnum 0)))
                       (loc_end
-                       ((pos_fname generated_locations.ml) (pos_lnum 3)
-                        (pos_bol 90) (pos_cnum 146)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 2)
+                        (pos_bol 84) (pos_cnum 152)))
                       (loc_ghost true)))
                     (ppat_loc_stack ()) (ppat_attributes ()))
                    ((ptyp_desc
@@ -1087,8 +1033,8 @@
                           ((pos_fname generated_locations.ml) (pos_lnum 1)
                            (pos_bol 0) (pos_cnum 0)))
                          (loc_end
-                          ((pos_fname generated_locations.ml) (pos_lnum 3)
-                           (pos_bol 90) (pos_cnum 146)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 2)
+                           (pos_bol 84) (pos_cnum 152)))
                          (loc_ghost true))))
                       (((ptyp_desc
                          (Ptyp_object
@@ -1101,7 +1047,7 @@
                                    (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
                                  (loc_end
                                   ((pos_fname generated_locations.ml)
-                                   (pos_lnum 3) (pos_bol 90) (pos_cnum 146)))
+                                   (pos_lnum 2) (pos_bol 84) (pos_cnum 152)))
                                  (loc_ghost true))))
                               ((ptyp_desc (Ptyp_var lola))
                                (ptyp_loc
@@ -1119,7 +1065,7 @@
                                 (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
                               (loc_end
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 3) (pos_bol 90) (pos_cnum 146)))
+                                (pos_lnum 2) (pos_bol 84) (pos_cnum 152)))
                               (loc_ghost true)))
                             (pof_attributes ())))
                           Closed))
@@ -1128,8 +1074,8 @@
                            ((pos_fname generated_locations.ml) (pos_lnum 1)
                             (pos_bol 0) (pos_cnum 0)))
                           (loc_end
-                           ((pos_fname generated_locations.ml) (pos_lnum 3)
-                            (pos_bol 90) (pos_cnum 146)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 2)
+                            (pos_bol 84) (pos_cnum 152)))
                           (loc_ghost true)))
                         (ptyp_loc_stack ()) (ptyp_attributes ())))))
                     (ptyp_loc
@@ -1137,8 +1083,8 @@
                        ((pos_fname generated_locations.ml) (pos_lnum 1)
                         (pos_bol 0) (pos_cnum 0)))
                       (loc_end
-                       ((pos_fname generated_locations.ml) (pos_lnum 3)
-                        (pos_bol 90) (pos_cnum 146)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 2)
+                        (pos_bol 84) (pos_cnum 152)))
                       (loc_ghost true)))
                     (ptyp_loc_stack ()) (ptyp_attributes ()))))
                  (ppat_loc
@@ -1146,8 +1092,8 @@
                     ((pos_fname generated_locations.ml) (pos_lnum 1)
                      (pos_bol 0) (pos_cnum 0)))
                    (loc_end
-                    ((pos_fname generated_locations.ml) (pos_lnum 3)
-                     (pos_bol 90) (pos_cnum 146)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 2)
+                     (pos_bol 84) (pos_cnum 152)))
                    (loc_ghost true)))
                  (ppat_loc_stack ()) (ppat_attributes ()))
                 ((pexp_desc
@@ -1160,8 +1106,8 @@
                           ((pos_fname generated_locations.ml) (pos_lnum 1)
                            (pos_bol 0) (pos_cnum 0)))
                          (loc_end
-                          ((pos_fname generated_locations.ml) (pos_lnum 3)
-                           (pos_bol 90) (pos_cnum 146)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 2)
+                           (pos_bol 84) (pos_cnum 152)))
                          (loc_ghost true))))))
                     (pexp_loc
                      ((loc_start
@@ -1251,8 +1197,8 @@
                     ((pos_fname generated_locations.ml) (pos_lnum 1)
                      (pos_bol 0) (pos_cnum 0)))
                    (loc_end
-                    ((pos_fname generated_locations.ml) (pos_lnum 3)
-                     (pos_bol 90) (pos_cnum 146)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 2)
+                     (pos_bol 84) (pos_cnum 152)))
                    (loc_ghost true)))
                  (pexp_loc_stack ()) (pexp_attributes ()))))
               (pexp_loc
@@ -1285,8 +1231,8 @@
                ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
                 (pos_cnum 0)))
               (loc_end
-               ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-                (pos_cnum 146)))
+               ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+                (pos_cnum 152)))
               (loc_ghost true)))))
           ((pexp_desc
             (Pexp_ident
@@ -1296,16 +1242,16 @@
                  ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
                   (pos_cnum 0)))
                 (loc_end
-                 ((pos_fname generated_locations.ml) (pos_lnum 3)
-                  (pos_bol 90) (pos_cnum 146)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 2)
+                  (pos_bol 84) (pos_cnum 152)))
                 (loc_ghost true))))))
            (pexp_loc
             ((loc_start
               ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
                (pos_cnum 0)))
              (loc_end
-              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-               (pos_cnum 146)))
+              ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+               (pos_cnum 152)))
              (loc_ghost true)))
            (pexp_loc_stack ()) (pexp_attributes ()))))
         (pexp_loc
@@ -1321,16 +1267,16 @@
          ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
           (pos_cnum 0)))
         (loc_end
-         ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-          (pos_cnum 146)))
+         ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+          (pos_cnum 152)))
         (loc_ghost false)))))))
   (pstr_loc
    ((loc_start
      ((pos_fname generated_locations.ml) (pos_lnum 1) (pos_bol 0)
       (pos_cnum 0)))
     (loc_end
-     ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
-      (pos_cnum 146)))
+     ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 84)
+      (pos_cnum 152)))
     (loc_ghost true))))
  ((pstr_desc
    (Pstr_primitive
@@ -1338,11 +1284,11 @@
       ((txt makeProps)
        (loc
         ((loc_start
-          ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-           (pos_cnum 147)))
+          ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+           (pos_cnum 153)))
          (loc_end
-          ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-           (pos_cnum 456)))
+          ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+           (pos_cnum 394)))
          (loc_ghost true)))))
      (pval_type
       ((ptyp_desc
@@ -1350,11 +1296,11 @@
          ((ptyp_desc (Ptyp_var initialValue))
           (ptyp_loc
            ((loc_start
-             ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-              (pos_cnum 158)))
+             ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+              (pos_cnum 164)))
             (loc_end
-             ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-              (pos_cnum 170)))
+             ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+              (pos_cnum 176)))
             (loc_ghost false)))
           (ptyp_loc_stack ()) (ptyp_attributes ()))
          ((ptyp_desc
@@ -1364,20 +1310,20 @@
                ((txt (Lident string))
                 (loc
                  ((loc_start
-                   ((pos_fname generated_locations.ml) (pos_lnum 4)
-                    (pos_bol 147) (pos_cnum 147)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 3)
+                    (pos_bol 153) (pos_cnum 153)))
                   (loc_end
-                   ((pos_fname generated_locations.ml) (pos_lnum 9)
-                    (pos_bol 407) (pos_cnum 456)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 7)
+                    (pos_bol 362) (pos_cnum 394)))
                   (loc_ghost true))))
                ()))
              (ptyp_loc
               ((loc_start
-                ((pos_fname generated_locations.ml) (pos_lnum 4)
-                 (pos_bol 147) (pos_cnum 147)))
+                ((pos_fname generated_locations.ml) (pos_lnum 3)
+                 (pos_bol 153) (pos_cnum 153)))
                (loc_end
-                ((pos_fname generated_locations.ml) (pos_lnum 9)
-                 (pos_bol 407) (pos_cnum 456)))
+                ((pos_fname generated_locations.ml) (pos_lnum 7)
+                 (pos_bol 362) (pos_cnum 394)))
                (loc_ghost true)))
              (ptyp_loc_stack ()) (ptyp_attributes ()))
             ((ptyp_desc
@@ -1387,20 +1333,20 @@
                   ((txt (Lident unit))
                    (loc
                     ((loc_start
-                      ((pos_fname generated_locations.ml) (pos_lnum 4)
-                       (pos_bol 147) (pos_cnum 147)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 3)
+                       (pos_bol 153) (pos_cnum 153)))
                      (loc_end
-                      ((pos_fname generated_locations.ml) (pos_lnum 9)
-                       (pos_bol 407) (pos_cnum 456)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 7)
+                       (pos_bol 362) (pos_cnum 394)))
                      (loc_ghost true))))
                   ()))
                 (ptyp_loc
                  ((loc_start
-                   ((pos_fname generated_locations.ml) (pos_lnum 4)
-                    (pos_bol 147) (pos_cnum 147)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 3)
+                    (pos_bol 153) (pos_cnum 153)))
                   (loc_end
-                   ((pos_fname generated_locations.ml) (pos_lnum 9)
-                    (pos_bol 407) (pos_cnum 456)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 7)
+                    (pos_bol 362) (pos_cnum 394)))
                   (loc_ghost true)))
                 (ptyp_loc_stack ()) (ptyp_attributes ()))
                ((ptyp_desc
@@ -1408,11 +1354,11 @@
                   ((txt (Ldot (Lident Js) t))
                    (loc
                     ((loc_start
-                      ((pos_fname generated_locations.ml) (pos_lnum 4)
-                       (pos_bol 147) (pos_cnum 147)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 3)
+                       (pos_bol 153) (pos_cnum 153)))
                      (loc_end
-                      ((pos_fname generated_locations.ml) (pos_lnum 9)
-                       (pos_bol 407) (pos_cnum 456)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 7)
+                       (pos_bol 362) (pos_cnum 394)))
                      (loc_ghost true))))
                   (((ptyp_desc
                      (Ptyp_object
@@ -1422,10 +1368,10 @@
                            (loc
                             ((loc_start
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 4) (pos_bol 147) (pos_cnum 147)))
+                               (pos_lnum 3) (pos_bol 153) (pos_cnum 153)))
                              (loc_end
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 9) (pos_bol 407) (pos_cnum 456)))
+                               (pos_lnum 7) (pos_bol 362) (pos_cnum 394)))
                              (loc_ghost true))))
                           ((ptyp_desc
                             (Ptyp_constr
@@ -1433,56 +1379,56 @@
                               (loc
                                ((loc_start
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                                  (pos_lnum 3) (pos_bol 153) (pos_cnum 164)))
                                 (loc_end
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                                  (pos_lnum 3) (pos_bol 153) (pos_cnum 176)))
                                 (loc_ghost false))))
                              (((ptyp_desc (Ptyp_var initialValue))
                                (ptyp_loc
                                 ((loc_start
                                   ((pos_fname generated_locations.ml)
-                                   (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                                   (pos_lnum 3) (pos_bol 153) (pos_cnum 164)))
                                  (loc_end
                                   ((pos_fname generated_locations.ml)
-                                   (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                                   (pos_lnum 3) (pos_bol 153) (pos_cnum 176)))
                                  (loc_ghost false)))
                                (ptyp_loc_stack ()) (ptyp_attributes ())))))
                            (ptyp_loc
                             ((loc_start
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                               (pos_lnum 3) (pos_bol 153) (pos_cnum 164)))
                              (loc_end
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                               (pos_lnum 3) (pos_bol 153) (pos_cnum 176)))
                              (loc_ghost false)))
                            (ptyp_loc_stack ()) (ptyp_attributes ()))))
                         (pof_loc
                          ((loc_start
-                           ((pos_fname generated_locations.ml) (pos_lnum 4)
-                            (pos_bol 147) (pos_cnum 147)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 3)
+                            (pos_bol 153) (pos_cnum 153)))
                           (loc_end
-                           ((pos_fname generated_locations.ml) (pos_lnum 9)
-                            (pos_bol 407) (pos_cnum 456)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 7)
+                            (pos_bol 362) (pos_cnum 394)))
                           (loc_ghost true)))
                         (pof_attributes ())))
                       Closed))
                     (ptyp_loc
                      ((loc_start
-                       ((pos_fname generated_locations.ml) (pos_lnum 4)
-                        (pos_bol 147) (pos_cnum 147)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 3)
+                        (pos_bol 153) (pos_cnum 153)))
                       (loc_end
-                       ((pos_fname generated_locations.ml) (pos_lnum 9)
-                        (pos_bol 407) (pos_cnum 456)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 7)
+                        (pos_bol 362) (pos_cnum 394)))
                       (loc_ghost true)))
                     (ptyp_loc_stack ()) (ptyp_attributes ())))))
                 (ptyp_loc
                  ((loc_start
-                   ((pos_fname generated_locations.ml) (pos_lnum 4)
-                    (pos_bol 147) (pos_cnum 147)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 3)
+                    (pos_bol 153) (pos_cnum 153)))
                   (loc_end
-                   ((pos_fname generated_locations.ml) (pos_lnum 9)
-                    (pos_bol 407) (pos_cnum 456)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 7)
+                    (pos_bol 362) (pos_cnum 394)))
                   (loc_ghost true)))
                 (ptyp_loc_stack ()) (ptyp_attributes ()))))
              (ptyp_loc
@@ -1494,20 +1440,20 @@
              (ptyp_loc_stack ()) (ptyp_attributes ()))))
           (ptyp_loc
            ((loc_start
-             ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-              (pos_cnum 147)))
+             ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+              (pos_cnum 153)))
             (loc_end
-             ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-              (pos_cnum 456)))
+             ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+              (pos_cnum 394)))
             (loc_ghost true)))
           (ptyp_loc_stack ()) (ptyp_attributes ()))))
        (ptyp_loc
         ((loc_start
-          ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-           (pos_cnum 158)))
+          ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+           (pos_cnum 164)))
          (loc_end
-          ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-           (pos_cnum 170)))
+          ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+           (pos_cnum 176)))
          (loc_ghost false)))
        (ptyp_loc_stack ()) (ptyp_attributes ())))
      (pval_prim (""))
@@ -1516,36 +1462,36 @@
          ((txt bs.obj)
           (loc
            ((loc_start
-             ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-              (pos_cnum 147)))
+             ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+              (pos_cnum 153)))
             (loc_end
-             ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-              (pos_cnum 456)))
+             ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+              (pos_cnum 394)))
             (loc_ghost true)))))
         (attr_payload (PStr ()))
         (attr_loc
          ((loc_start
-           ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-            (pos_cnum 147)))
+           ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+            (pos_cnum 153)))
           (loc_end
-           ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-            (pos_cnum 456)))
+           ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+            (pos_cnum 394)))
           (loc_ghost true))))))
      (pval_loc
       ((loc_start
-        ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-         (pos_cnum 147)))
+        ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+         (pos_cnum 153)))
        (loc_end
-        ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-         (pos_cnum 456)))
+        ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+         (pos_cnum 394)))
        (loc_ghost true))))))
   (pstr_loc
    ((loc_start
-     ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-      (pos_cnum 147)))
+     ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+      (pos_cnum 153)))
     (loc_end
-     ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-      (pos_cnum 456)))
+     ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+      (pos_cnum 394)))
     (loc_ghost true))))
  ((pstr_desc
    (Pstr_value Nonrecursive
@@ -1555,19 +1501,19 @@
           ((txt make)
            (loc
             ((loc_start
-              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-               (pos_cnum 151)))
+              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+               (pos_cnum 157)))
              (loc_end
-              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-               (pos_cnum 155)))
+              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+               (pos_cnum 161)))
              (loc_ghost false))))))
         (ppat_loc
          ((loc_start
-           ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-            (pos_cnum 151)))
+           ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+            (pos_cnum 157)))
           (loc_end
-           ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-            (pos_cnum 155)))
+           ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+            (pos_cnum 161)))
           (loc_ghost false)))
         (ppat_loc_stack ()) (ppat_attributes ())))
       (pvb_expr
@@ -1576,11 +1522,11 @@
           (((pexp_desc (Pexp_constant (Pconst_integer 0 ())))
             (pexp_loc
              ((loc_start
-               ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-                (pos_cnum 172)))
+               ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+                (pos_cnum 178)))
               (loc_end
-               ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-                (pos_cnum 173)))
+               ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+                (pos_cnum 179)))
               (loc_ghost false)))
             (pexp_loc_stack ()) (pexp_attributes ())))
           ((ppat_desc
@@ -1588,19 +1534,19 @@
              ((txt initialValue)
               (loc
                ((loc_start
-                 ((pos_fname generated_locations.ml) (pos_lnum 4)
-                  (pos_bol 147) (pos_cnum 158)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 3)
+                  (pos_bol 153) (pos_cnum 164)))
                 (loc_end
-                 ((pos_fname generated_locations.ml) (pos_lnum 4)
-                  (pos_bol 147) (pos_cnum 170)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 3)
+                  (pos_bol 153) (pos_cnum 176)))
                 (loc_ghost false))))))
            (ppat_loc
             ((loc_start
-              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-               (pos_cnum 158)))
+              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+               (pos_cnum 164)))
              (loc_end
-              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-               (pos_cnum 170)))
+              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+               (pos_cnum 176)))
              (loc_ghost false)))
            (ppat_loc_stack ()) (ppat_attributes ()))
           ((pexp_desc
@@ -1610,20 +1556,20 @@
                 ((txt (Lident "()"))
                  (loc
                   ((loc_start
-                    ((pos_fname generated_locations.ml) (pos_lnum 4)
-                     (pos_bol 147) (pos_cnum 176)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 3)
+                     (pos_bol 153) (pos_cnum 182)))
                    (loc_end
-                    ((pos_fname generated_locations.ml) (pos_lnum 4)
-                     (pos_bol 147) (pos_cnum 178)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 3)
+                     (pos_bol 153) (pos_cnum 184)))
                    (loc_ghost false))))
                 ()))
               (ppat_loc
                ((loc_start
-                 ((pos_fname generated_locations.ml) (pos_lnum 4)
-                  (pos_bol 147) (pos_cnum 176)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 3)
+                  (pos_bol 153) (pos_cnum 182)))
                 (loc_end
-                 ((pos_fname generated_locations.ml) (pos_lnum 4)
-                  (pos_bol 147) (pos_cnum 178)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 3)
+                  (pos_bol 153) (pos_cnum 184)))
                 (loc_ghost false)))
               (ppat_loc_stack ()) (ppat_attributes ()))
              ((pexp_desc
@@ -1637,18 +1583,18 @@
                            (loc
                             ((loc_start
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 5) (pos_bol 181) (pos_cnum 190)))
+                               (pos_lnum 4) (pos_bol 187) (pos_cnum 194)))
                              (loc_end
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 5) (pos_bol 181) (pos_cnum 195)))
+                               (pos_lnum 4) (pos_bol 187) (pos_cnum 199)))
                              (loc_ghost false))))))
                         (ppat_loc
                          ((loc_start
-                           ((pos_fname generated_locations.ml) (pos_lnum 5)
-                            (pos_bol 181) (pos_cnum 190)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 4)
+                            (pos_bol 187) (pos_cnum 194)))
                           (loc_end
-                           ((pos_fname generated_locations.ml) (pos_lnum 5)
-                            (pos_bol 181) (pos_cnum 195)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 4)
+                            (pos_bol 187) (pos_cnum 199)))
                           (loc_ghost false)))
                         (ppat_loc_stack ()) (ppat_attributes ()))
                        ((ppat_desc
@@ -1657,35 +1603,35 @@
                            (loc
                             ((loc_start
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 5) (pos_bol 181) (pos_cnum 197)))
+                               (pos_lnum 4) (pos_bol 187) (pos_cnum 201)))
                              (loc_end
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 5) (pos_bol 181) (pos_cnum 205)))
+                               (pos_lnum 4) (pos_bol 187) (pos_cnum 209)))
                              (loc_ghost false))))))
                         (ppat_loc
                          ((loc_start
-                           ((pos_fname generated_locations.ml) (pos_lnum 5)
-                            (pos_bol 181) (pos_cnum 197)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 4)
+                            (pos_bol 187) (pos_cnum 201)))
                           (loc_end
-                           ((pos_fname generated_locations.ml) (pos_lnum 5)
-                            (pos_bol 181) (pos_cnum 205)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 4)
+                            (pos_bol 187) (pos_cnum 209)))
                           (loc_ghost false)))
                         (ppat_loc_stack ()) (ppat_attributes ())))))
                     (ppat_loc
                      ((loc_start
-                       ((pos_fname generated_locations.ml) (pos_lnum 5)
-                        (pos_bol 181) (pos_cnum 189)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 4)
+                        (pos_bol 187) (pos_cnum 193)))
                       (loc_end
-                       ((pos_fname generated_locations.ml) (pos_lnum 5)
-                        (pos_bol 181) (pos_cnum 206)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 4)
+                        (pos_bol 187) (pos_cnum 210)))
                       (loc_ghost false)))
                     (ppat_loc_stack
                      (((loc_start
-                        ((pos_fname generated_locations.ml) (pos_lnum 5)
-                         (pos_bol 181) (pos_cnum 190)))
+                        ((pos_fname generated_locations.ml) (pos_lnum 4)
+                         (pos_bol 187) (pos_cnum 194)))
                        (loc_end
-                        ((pos_fname generated_locations.ml) (pos_lnum 5)
-                         (pos_bol 181) (pos_cnum 205)))
+                        ((pos_fname generated_locations.ml) (pos_lnum 4)
+                         (pos_bol 187) (pos_cnum 209)))
                        (loc_ghost false))))
                     (ppat_attributes ())))
                   (pvb_expr
@@ -1696,19 +1642,19 @@
                          ((txt (Ldot (Lident React) useState))
                           (loc
                            ((loc_start
-                             ((pos_fname generated_locations.ml) (pos_lnum 5)
-                              (pos_bol 181) (pos_cnum 209)))
+                             ((pos_fname generated_locations.ml) (pos_lnum 4)
+                              (pos_bol 187) (pos_cnum 213)))
                             (loc_end
-                             ((pos_fname generated_locations.ml) (pos_lnum 5)
-                              (pos_bol 181) (pos_cnum 223)))
+                             ((pos_fname generated_locations.ml) (pos_lnum 4)
+                              (pos_bol 187) (pos_cnum 227)))
                             (loc_ghost false))))))
                        (pexp_loc
                         ((loc_start
-                          ((pos_fname generated_locations.ml) (pos_lnum 5)
-                           (pos_bol 181) (pos_cnum 209)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 4)
+                           (pos_bol 187) (pos_cnum 213)))
                          (loc_end
-                          ((pos_fname generated_locations.ml) (pos_lnum 5)
-                           (pos_bol 181) (pos_cnum 223)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 4)
+                           (pos_bol 187) (pos_cnum 227)))
                          (loc_ghost false)))
                        (pexp_loc_stack ()) (pexp_attributes ()))
                       ((Nolabel
@@ -1720,19 +1666,19 @@
                                (loc
                                 ((loc_start
                                   ((pos_fname generated_locations.ml)
-                                   (pos_lnum 5) (pos_bol 181) (pos_cnum 229)))
+                                   (pos_lnum 4) (pos_bol 187) (pos_cnum 233)))
                                  (loc_end
                                   ((pos_fname generated_locations.ml)
-                                   (pos_lnum 5) (pos_bol 181) (pos_cnum 231)))
+                                   (pos_lnum 4) (pos_bol 187) (pos_cnum 235)))
                                  (loc_ghost false))))
                               ()))
                             (ppat_loc
                              ((loc_start
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 5) (pos_bol 181) (pos_cnum 229)))
+                                (pos_lnum 4) (pos_bol 187) (pos_cnum 233)))
                               (loc_end
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 5) (pos_bol 181) (pos_cnum 231)))
+                                (pos_lnum 4) (pos_bol 187) (pos_cnum 235)))
                               (loc_ghost false)))
                             (ppat_loc_stack ()) (ppat_attributes ()))
                            ((pexp_desc
@@ -1741,54 +1687,54 @@
                                (loc
                                 ((loc_start
                                   ((pos_fname generated_locations.ml)
-                                   (pos_lnum 5) (pos_bol 181) (pos_cnum 235)))
+                                   (pos_lnum 4) (pos_bol 187) (pos_cnum 239)))
                                  (loc_end
                                   ((pos_fname generated_locations.ml)
-                                   (pos_lnum 5) (pos_bol 181) (pos_cnum 247)))
+                                   (pos_lnum 4) (pos_bol 187) (pos_cnum 251)))
                                  (loc_ghost false))))))
                             (pexp_loc
                              ((loc_start
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 5) (pos_bol 181) (pos_cnum 235)))
+                                (pos_lnum 4) (pos_bol 187) (pos_cnum 239)))
                               (loc_end
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 5) (pos_bol 181) (pos_cnum 247)))
+                                (pos_lnum 4) (pos_bol 187) (pos_cnum 251)))
                               (loc_ghost false)))
                             (pexp_loc_stack ()) (pexp_attributes ()))))
                          (pexp_loc
                           ((loc_start
-                            ((pos_fname generated_locations.ml) (pos_lnum 5)
-                             (pos_bol 181) (pos_cnum 224)))
+                            ((pos_fname generated_locations.ml) (pos_lnum 4)
+                             (pos_bol 187) (pos_cnum 228)))
                            (loc_end
-                            ((pos_fname generated_locations.ml) (pos_lnum 5)
-                             (pos_bol 181) (pos_cnum 248)))
+                            ((pos_fname generated_locations.ml) (pos_lnum 4)
+                             (pos_bol 187) (pos_cnum 252)))
                            (loc_ghost false)))
                          (pexp_loc_stack
                           (((loc_start
-                             ((pos_fname generated_locations.ml) (pos_lnum 5)
-                              (pos_bol 181) (pos_cnum 225)))
+                             ((pos_fname generated_locations.ml) (pos_lnum 4)
+                              (pos_bol 187) (pos_cnum 229)))
                             (loc_end
-                             ((pos_fname generated_locations.ml) (pos_lnum 5)
-                              (pos_bol 181) (pos_cnum 247)))
+                             ((pos_fname generated_locations.ml) (pos_lnum 4)
+                              (pos_bol 187) (pos_cnum 251)))
                             (loc_ghost false))))
                          (pexp_attributes ()))))))
                     (pexp_loc
                      ((loc_start
-                       ((pos_fname generated_locations.ml) (pos_lnum 5)
-                        (pos_bol 181) (pos_cnum 209)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 4)
+                        (pos_bol 187) (pos_cnum 213)))
                       (loc_end
-                       ((pos_fname generated_locations.ml) (pos_lnum 5)
-                        (pos_bol 181) (pos_cnum 248)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 4)
+                        (pos_bol 187) (pos_cnum 252)))
                       (loc_ghost false)))
                     (pexp_loc_stack ()) (pexp_attributes ())))
                   (pvb_attributes ())
                   (pvb_loc
                    ((loc_start
-                     ((pos_fname generated_locations.ml) (pos_lnum 5)
-                      (pos_bol 181) (pos_cnum 185)))
+                     ((pos_fname generated_locations.ml) (pos_lnum 4)
+                      (pos_bol 187) (pos_cnum 189)))
                     (loc_end
-                     ((pos_fname generated_locations.ml) (pos_lnum 5)
-                      (pos_bol 181) (pos_cnum 248)))
+                     ((pos_fname generated_locations.ml) (pos_lnum 4)
+                      (pos_bol 187) (pos_cnum 252)))
                     (loc_ghost false)))))
                 ((pexp_desc
                   (Pexp_apply
@@ -1797,19 +1743,19 @@
                       ((txt (Ldot (Lident ReactDOM) jsx))
                        (loc
                         ((loc_start
-                          ((pos_fname generated_locations.ml) (pos_lnum 6)
-                           (pos_bol 252) (pos_cnum 256)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 5)
+                           (pos_bol 256) (pos_cnum 258)))
                          (loc_end
-                          ((pos_fname generated_locations.ml) (pos_lnum 8)
-                           (pos_bol 391) (pos_cnum 405)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 7)
+                           (pos_bol 362) (pos_cnum 374)))
                          (loc_ghost false))))))
                     (pexp_loc
                      ((loc_start
-                       ((pos_fname generated_locations.ml) (pos_lnum 6)
-                        (pos_bol 252) (pos_cnum 256)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 5)
+                        (pos_bol 256) (pos_cnum 258)))
                       (loc_end
-                       ((pos_fname generated_locations.ml) (pos_lnum 8)
-                        (pos_bol 391) (pos_cnum 405)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 7)
+                        (pos_bol 362) (pos_cnum 374)))
                       (loc_ghost false)))
                     (pexp_loc_stack ()) (pexp_attributes ()))
                    ((Nolabel
@@ -1826,11 +1772,11 @@
                          ())))
                       (pexp_loc
                        ((loc_start
-                         ((pos_fname generated_locations.ml) (pos_lnum 6)
-                          (pos_bol 252) (pos_cnum 258)))
+                         ((pos_fname generated_locations.ml) (pos_lnum 5)
+                          (pos_bol 256) (pos_cnum 260)))
                         (loc_end
-                         ((pos_fname generated_locations.ml) (pos_lnum 6)
-                          (pos_bol 252) (pos_cnum 264)))
+                         ((pos_fname generated_locations.ml) (pos_lnum 5)
+                          (pos_bol 256) (pos_cnum 266)))
                         (loc_ghost false)))
                       (pexp_loc_stack ()) (pexp_attributes ())))
                     (Nolabel
@@ -1842,18 +1788,18 @@
                             (loc
                              ((loc_start
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 6) (pos_bol 252) (pos_cnum 258)))
+                                (pos_lnum 5) (pos_bol 256) (pos_cnum 260)))
                               (loc_end
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 6) (pos_bol 252) (pos_cnum 264)))
+                                (pos_lnum 5) (pos_bol 256) (pos_cnum 266)))
                               (loc_ghost false))))))
                          (pexp_loc
                           ((loc_start
-                            ((pos_fname generated_locations.ml) (pos_lnum 6)
-                             (pos_bol 252) (pos_cnum 256)))
+                            ((pos_fname generated_locations.ml) (pos_lnum 5)
+                             (pos_bol 256) (pos_cnum 258)))
                            (loc_end
-                            ((pos_fname generated_locations.ml) (pos_lnum 8)
-                             (pos_bol 391) (pos_cnum 405)))
+                            ((pos_fname generated_locations.ml) (pos_lnum 7)
+                             (pos_bol 362) (pos_cnum 374)))
                            (loc_ghost false)))
                          (pexp_loc_stack ())
                          (pexp_attributes
@@ -1885,20 +1831,20 @@
                                  (loc
                                   ((loc_start
                                     ((pos_fname generated_locations.ml)
-                                     (pos_lnum 7) (pos_bol 320)
-                                     (pos_cnum 373)))
+                                     (pos_lnum 6) (pos_bol 321)
+                                     (pos_cnum 344)))
                                    (loc_end
                                     ((pos_fname generated_locations.ml)
-                                     (pos_lnum 7) (pos_bol 320)
-                                     (pos_cnum 375)))
+                                     (pos_lnum 6) (pos_bol 321)
+                                     (pos_cnum 346)))
                                    (loc_ghost false))))))
                               (pexp_loc
                                ((loc_start
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 7) (pos_bol 320) (pos_cnum 373)))
+                                  (pos_lnum 6) (pos_bol 321) (pos_cnum 344)))
                                 (loc_end
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 7) (pos_bol 320) (pos_cnum 375)))
+                                  (pos_lnum 6) (pos_bol 321) (pos_cnum 346)))
                                 (loc_ghost false)))
                               (pexp_loc_stack ()) (pexp_attributes ()))
                              ((Nolabel
@@ -1908,22 +1854,22 @@
                                    (loc
                                     ((loc_start
                                       ((pos_fname generated_locations.ml)
-                                       (pos_lnum 7) (pos_bol 320)
-                                       (pos_cnum 367)))
+                                       (pos_lnum 6) (pos_bol 321)
+                                       (pos_cnum 338)))
                                      (loc_end
                                       ((pos_fname generated_locations.ml)
-                                       (pos_lnum 7) (pos_bol 320)
-                                       (pos_cnum 372)))
+                                       (pos_lnum 6) (pos_bol 321)
+                                       (pos_cnum 343)))
                                      (loc_ghost false))))))
                                 (pexp_loc
                                  ((loc_start
                                    ((pos_fname generated_locations.ml)
-                                    (pos_lnum 7) (pos_bol 320)
-                                    (pos_cnum 367)))
+                                    (pos_lnum 6) (pos_bol 321)
+                                    (pos_cnum 338)))
                                   (loc_end
                                    ((pos_fname generated_locations.ml)
-                                    (pos_lnum 7) (pos_bol 320)
-                                    (pos_cnum 372)))
+                                    (pos_lnum 6) (pos_bol 321)
+                                    (pos_cnum 343)))
                                   (loc_ghost false)))
                                 (pexp_loc_stack ()) (pexp_attributes ())))
                               (Nolabel
@@ -1933,31 +1879,31 @@
                                    (loc
                                     ((loc_start
                                       ((pos_fname generated_locations.ml)
-                                       (pos_lnum 7) (pos_bol 320)
-                                       (pos_cnum 376)))
+                                       (pos_lnum 6) (pos_bol 321)
+                                       (pos_cnum 347)))
                                      (loc_end
                                       ((pos_fname generated_locations.ml)
-                                       (pos_lnum 7) (pos_bol 320)
-                                       (pos_cnum 385)))
+                                       (pos_lnum 6) (pos_bol 321)
+                                       (pos_cnum 356)))
                                      (loc_ghost false))))))
                                 (pexp_loc
                                  ((loc_start
                                    ((pos_fname generated_locations.ml)
-                                    (pos_lnum 7) (pos_bol 320)
-                                    (pos_cnum 376)))
+                                    (pos_lnum 6) (pos_bol 321)
+                                    (pos_cnum 347)))
                                   (loc_end
                                    ((pos_fname generated_locations.ml)
-                                    (pos_lnum 7) (pos_bol 320)
-                                    (pos_cnum 385)))
+                                    (pos_lnum 6) (pos_bol 321)
+                                    (pos_cnum 356)))
                                   (loc_ghost false)))
                                 (pexp_loc_stack ()) (pexp_attributes ()))))))
                            (pexp_loc
                             ((loc_start
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 7) (pos_bol 320) (pos_cnum 367)))
+                               (pos_lnum 6) (pos_bol 321) (pos_cnum 338)))
                              (loc_end
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 7) (pos_bol 320) (pos_cnum 385)))
+                               (pos_lnum 6) (pos_bol 321) (pos_cnum 356)))
                              (loc_ghost false)))
                            (pexp_loc_stack ()) (pexp_attributes ())))
                          ((Labelled onClick)
@@ -1967,10 +1913,10 @@
                               (ppat_loc
                                ((loc_start
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 6) (pos_bol 252) (pos_cnum 280)))
+                                  (pos_lnum 5) (pos_bol 256) (pos_cnum 281)))
                                 (loc_end
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 6) (pos_bol 252) (pos_cnum 281)))
+                                  (pos_lnum 5) (pos_bol 256) (pos_cnum 282)))
                                 (loc_ghost false)))
                               (ppat_loc_stack ()) (ppat_attributes ()))
                              ((pexp_desc
@@ -1981,22 +1927,22 @@
                                     (loc
                                      ((loc_start
                                        ((pos_fname generated_locations.ml)
-                                        (pos_lnum 6) (pos_bol 252)
-                                        (pos_cnum 285)))
+                                        (pos_lnum 5) (pos_bol 256)
+                                        (pos_cnum 286)))
                                       (loc_end
                                        ((pos_fname generated_locations.ml)
-                                        (pos_lnum 6) (pos_bol 252)
-                                        (pos_cnum 293)))
+                                        (pos_lnum 5) (pos_bol 256)
+                                        (pos_cnum 294)))
                                       (loc_ghost false))))))
                                  (pexp_loc
                                   ((loc_start
                                     ((pos_fname generated_locations.ml)
-                                     (pos_lnum 6) (pos_bol 252)
-                                     (pos_cnum 285)))
+                                     (pos_lnum 5) (pos_bol 256)
+                                     (pos_cnum 286)))
                                    (loc_end
                                     ((pos_fname generated_locations.ml)
-                                     (pos_lnum 6) (pos_bol 252)
-                                     (pos_cnum 293)))
+                                     (pos_lnum 5) (pos_bol 256)
+                                     (pos_cnum 294)))
                                    (loc_ghost false)))
                                  (pexp_loc_stack ()) (pexp_attributes ()))
                                 ((Nolabel
@@ -2009,23 +1955,23 @@
                                           ((loc_start
                                             ((pos_fname
                                               generated_locations.ml)
-                                             (pos_lnum 6) (pos_bol 252)
-                                             (pos_cnum 299)))
+                                             (pos_lnum 5) (pos_bol 256)
+                                             (pos_cnum 300)))
                                            (loc_end
                                             ((pos_fname
                                               generated_locations.ml)
-                                             (pos_lnum 6) (pos_bol 252)
-                                             (pos_cnum 304)))
+                                             (pos_lnum 5) (pos_bol 256)
+                                             (pos_cnum 305)))
                                            (loc_ghost false))))))
                                       (ppat_loc
                                        ((loc_start
                                          ((pos_fname generated_locations.ml)
-                                          (pos_lnum 6) (pos_bol 252)
-                                          (pos_cnum 299)))
+                                          (pos_lnum 5) (pos_bol 256)
+                                          (pos_cnum 300)))
                                         (loc_end
                                          ((pos_fname generated_locations.ml)
-                                          (pos_lnum 6) (pos_bol 252)
-                                          (pos_cnum 304)))
+                                          (pos_lnum 5) (pos_bol 256)
+                                          (pos_cnum 305)))
                                         (loc_ghost false)))
                                       (ppat_loc_stack ())
                                       (ppat_attributes ()))
@@ -2038,25 +1984,25 @@
                                              ((loc_start
                                                ((pos_fname
                                                  generated_locations.ml)
-                                                (pos_lnum 6) (pos_bol 252)
-                                                (pos_cnum 314)))
+                                                (pos_lnum 5) (pos_bol 256)
+                                                (pos_cnum 315)))
                                               (loc_end
                                                ((pos_fname
                                                  generated_locations.ml)
-                                                (pos_lnum 6) (pos_bol 252)
-                                                (pos_cnum 315)))
+                                                (pos_lnum 5) (pos_bol 256)
+                                                (pos_cnum 316)))
                                               (loc_ghost false))))))
                                          (pexp_loc
                                           ((loc_start
                                             ((pos_fname
                                               generated_locations.ml)
-                                             (pos_lnum 6) (pos_bol 252)
-                                             (pos_cnum 314)))
+                                             (pos_lnum 5) (pos_bol 256)
+                                             (pos_cnum 315)))
                                            (loc_end
                                             ((pos_fname
                                               generated_locations.ml)
-                                             (pos_lnum 6) (pos_bol 252)
-                                             (pos_cnum 315)))
+                                             (pos_lnum 5) (pos_bol 256)
+                                             (pos_cnum 316)))
                                            (loc_ghost false)))
                                          (pexp_loc_stack ())
                                          (pexp_attributes ()))
@@ -2068,25 +2014,25 @@
                                                ((loc_start
                                                  ((pos_fname
                                                    generated_locations.ml)
-                                                  (pos_lnum 6) (pos_bol 252)
-                                                  (pos_cnum 308)))
+                                                  (pos_lnum 5) (pos_bol 256)
+                                                  (pos_cnum 309)))
                                                 (loc_end
                                                  ((pos_fname
                                                    generated_locations.ml)
-                                                  (pos_lnum 6) (pos_bol 252)
-                                                  (pos_cnum 313)))
+                                                  (pos_lnum 5) (pos_bol 256)
+                                                  (pos_cnum 314)))
                                                 (loc_ghost false))))))
                                            (pexp_loc
                                             ((loc_start
                                               ((pos_fname
                                                 generated_locations.ml)
-                                               (pos_lnum 6) (pos_bol 252)
-                                               (pos_cnum 308)))
+                                               (pos_lnum 5) (pos_bol 256)
+                                               (pos_cnum 309)))
                                              (loc_end
                                               ((pos_fname
                                                 generated_locations.ml)
-                                               (pos_lnum 6) (pos_bol 252)
-                                               (pos_cnum 313)))
+                                               (pos_lnum 5) (pos_bol 256)
+                                               (pos_cnum 314)))
                                              (loc_ghost false)))
                                            (pexp_loc_stack ())
                                            (pexp_attributes ())))
@@ -2098,103 +2044,75 @@
                                             ((loc_start
                                               ((pos_fname
                                                 generated_locations.ml)
-                                               (pos_lnum 6) (pos_bol 252)
-                                               (pos_cnum 316)))
+                                               (pos_lnum 5) (pos_bol 256)
+                                               (pos_cnum 317)))
                                              (loc_end
                                               ((pos_fname
                                                 generated_locations.ml)
-                                               (pos_lnum 6) (pos_bol 252)
-                                               (pos_cnum 317)))
+                                               (pos_lnum 5) (pos_bol 256)
+                                               (pos_cnum 318)))
                                              (loc_ghost false)))
                                            (pexp_loc_stack ())
                                            (pexp_attributes ()))))))
                                       (pexp_loc
                                        ((loc_start
                                          ((pos_fname generated_locations.ml)
-                                          (pos_lnum 6) (pos_bol 252)
-                                          (pos_cnum 308)))
+                                          (pos_lnum 5) (pos_bol 256)
+                                          (pos_cnum 309)))
                                         (loc_end
                                          ((pos_fname generated_locations.ml)
-                                          (pos_lnum 6) (pos_bol 252)
-                                          (pos_cnum 317)))
+                                          (pos_lnum 5) (pos_bol 256)
+                                          (pos_cnum 318)))
                                         (loc_ghost false)))
                                       (pexp_loc_stack ())
                                       (pexp_attributes ()))))
                                    (pexp_loc
                                     ((loc_start
                                       ((pos_fname generated_locations.ml)
-                                       (pos_lnum 6) (pos_bol 252)
-                                       (pos_cnum 294)))
+                                       (pos_lnum 5) (pos_bol 256)
+                                       (pos_cnum 295)))
                                      (loc_end
                                       ((pos_fname generated_locations.ml)
-                                       (pos_lnum 6) (pos_bol 252)
-                                       (pos_cnum 318)))
+                                       (pos_lnum 5) (pos_bol 256)
+                                       (pos_cnum 319)))
                                      (loc_ghost false)))
                                    (pexp_loc_stack
                                     (((loc_start
                                        ((pos_fname generated_locations.ml)
-                                        (pos_lnum 6) (pos_bol 252)
-                                        (pos_cnum 295)))
+                                        (pos_lnum 5) (pos_bol 256)
+                                        (pos_cnum 296)))
                                       (loc_end
                                        ((pos_fname generated_locations.ml)
-                                        (pos_lnum 6) (pos_bol 252)
-                                        (pos_cnum 317)))
+                                        (pos_lnum 5) (pos_bol 256)
+                                        (pos_cnum 318)))
                                       (loc_ghost false))))
                                    (pexp_attributes ()))))))
                               (pexp_loc
                                ((loc_start
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 6) (pos_bol 252) (pos_cnum 285)))
+                                  (pos_lnum 5) (pos_bol 256) (pos_cnum 286)))
                                 (loc_end
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 6) (pos_bol 252) (pos_cnum 318)))
+                                  (pos_lnum 5) (pos_bol 256) (pos_cnum 319)))
                                 (loc_ghost false)))
                               (pexp_loc_stack ()) (pexp_attributes ()))))
                            (pexp_loc
                             ((loc_start
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 6) (pos_bol 252) (pos_cnum 274)))
+                               (pos_lnum 5) (pos_bol 256) (pos_cnum 276)))
                              (loc_end
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 7) (pos_bol 320) (pos_cnum 355)))
+                               (pos_lnum 5) (pos_bol 256) (pos_cnum 320)))
                              (loc_ghost false)))
                            (pexp_loc_stack
                             (((loc_start
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 6) (pos_bol 252) (pos_cnum 275)))
+                                (pos_lnum 5) (pos_bol 256) (pos_cnum 277)))
                               (loc_end
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 6) (pos_bol 252) (pos_cnum 319)))
-                              (loc_ghost false))
-                             ((loc_start
-                               ((pos_fname generated_locations.ml)
-                                (pos_lnum 6) (pos_bol 252) (pos_cnum 276)))
-                              (loc_end
-                               ((pos_fname generated_locations.ml)
-                                (pos_lnum 6) (pos_bol 252) (pos_cnum 318)))
+                                (pos_lnum 5) (pos_bol 256) (pos_cnum 319)))
                               (loc_ghost false))))
-                           (pexp_attributes
-                            (((attr_name
-                               ((txt reason.preserve_braces)
-                                (loc
-                                 ((loc_start
-                                   ((pos_fname generated_locations.ml)
-                                    (pos_lnum 7) (pos_bol 320)
-                                    (pos_cnum 330)))
-                                  (loc_end
-                                   ((pos_fname generated_locations.ml)
-                                    (pos_lnum 7) (pos_bol 320)
-                                    (pos_cnum 352)))
-                                  (loc_ghost false)))))
-                              (attr_payload (PStr ()))
-                              (attr_loc
-                               ((loc_start
-                                 ((pos_fname generated_locations.ml)
-                                  (pos_lnum 7) (pos_bol 320) (pos_cnum 328)))
-                                (loc_end
-                                 ((pos_fname generated_locations.ml)
-                                  (pos_lnum 7) (pos_bol 320) (pos_cnum 354)))
-                                (loc_ghost false))))))))
+                           (pexp_attributes ())))
                          (Nolabel
                           ((pexp_desc
                             (Pexp_construct
@@ -2202,98 +2120,64 @@
                               (loc
                                ((loc_start
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 7) (pos_bol 320) (pos_cnum 387)))
+                                  (pos_lnum 6) (pos_bol 321) (pos_cnum 358)))
                                 (loc_end
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 7) (pos_bol 320) (pos_cnum 389)))
+                                  (pos_lnum 6) (pos_bol 321) (pos_cnum 360)))
                                 (loc_ghost false))))
                              ()))
                            (pexp_loc
                             ((loc_start
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 7) (pos_bol 320) (pos_cnum 387)))
+                               (pos_lnum 6) (pos_bol 321) (pos_cnum 358)))
                              (loc_end
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 7) (pos_bol 320) (pos_cnum 389)))
+                               (pos_lnum 6) (pos_bol 321) (pos_cnum 360)))
                              (loc_ghost false)))
                            (pexp_loc_stack ()) (pexp_attributes ()))))))
                       (pexp_loc
                        ((loc_start
-                         ((pos_fname generated_locations.ml) (pos_lnum 6)
-                          (pos_bol 252) (pos_cnum 256)))
+                         ((pos_fname generated_locations.ml) (pos_lnum 5)
+                          (pos_bol 256) (pos_cnum 258)))
                         (loc_end
-                         ((pos_fname generated_locations.ml) (pos_lnum 8)
-                          (pos_bol 391) (pos_cnum 405)))
+                         ((pos_fname generated_locations.ml) (pos_lnum 7)
+                          (pos_bol 362) (pos_cnum 374)))
                         (loc_ghost false)))
                       (pexp_loc_stack ()) (pexp_attributes ()))))))
                  (pexp_loc
                   ((loc_start
-                    ((pos_fname generated_locations.ml) (pos_lnum 6)
-                     (pos_bol 252) (pos_cnum 256)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 5)
+                     (pos_bol 256) (pos_cnum 258)))
                    (loc_end
-                    ((pos_fname generated_locations.ml) (pos_lnum 8)
-                     (pos_bol 391) (pos_cnum 405)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 7)
+                     (pos_bol 362) (pos_cnum 374)))
                    (loc_ghost false)))
                  (pexp_loc_stack ()) (pexp_attributes ()))))
               (pexp_loc
                ((loc_start
-                 ((pos_fname generated_locations.ml) (pos_lnum 5)
-                  (pos_bol 181) (pos_cnum 183)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 4)
+                  (pos_bol 187) (pos_cnum 189)))
                 (loc_end
-                 ((pos_fname generated_locations.ml) (pos_lnum 9)
-                  (pos_bol 407) (pos_cnum 436)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 7)
+                  (pos_bol 362) (pos_cnum 374)))
                 (loc_ghost false)))
-              (pexp_loc_stack
-               (((loc_start
-                  ((pos_fname generated_locations.ml) (pos_lnum 5)
-                   (pos_bol 181) (pos_cnum 184)))
-                 (loc_end
-                  ((pos_fname generated_locations.ml) (pos_lnum 8)
-                   (pos_bol 391) (pos_cnum 406)))
-                 (loc_ghost false))
-                ((loc_start
-                  ((pos_fname generated_locations.ml) (pos_lnum 5)
-                   (pos_bol 181) (pos_cnum 185)))
-                 (loc_end
-                  ((pos_fname generated_locations.ml) (pos_lnum 8)
-                   (pos_bol 391) (pos_cnum 405)))
-                 (loc_ghost false))))
-              (pexp_attributes
-               (((attr_name
-                  ((txt reason.preserve_braces)
-                   (loc
-                    ((loc_start
-                      ((pos_fname generated_locations.ml) (pos_lnum 9)
-                       (pos_bol 407) (pos_cnum 411)))
-                     (loc_end
-                      ((pos_fname generated_locations.ml) (pos_lnum 9)
-                       (pos_bol 407) (pos_cnum 433)))
-                     (loc_ghost false)))))
-                 (attr_payload (PStr ()))
-                 (attr_loc
-                  ((loc_start
-                    ((pos_fname generated_locations.ml) (pos_lnum 9)
-                     (pos_bol 407) (pos_cnum 409)))
-                   (loc_end
-                    ((pos_fname generated_locations.ml) (pos_lnum 9)
-                     (pos_bol 407) (pos_cnum 435)))
-                   (loc_ghost false)))))))))
+              (pexp_loc_stack ()) (pexp_attributes ()))))
            (pexp_loc
             ((loc_start
-              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-               (pos_cnum 176)))
+              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+               (pos_cnum 182)))
              (loc_end
-              ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-               (pos_cnum 436)))
+              ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+               (pos_cnum 374)))
              (loc_ghost true)))
            (pexp_loc_stack ()) (pexp_attributes ()))))
         (pexp_loc
          ((loc_start
-           ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-            (pos_cnum 156)))
+           ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+            (pos_cnum 162)))
           (loc_end
-           ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-            (pos_cnum 436)))
+           ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+            (pos_cnum 374)))
           (loc_ghost true)))
         (pexp_loc_stack ())
         (pexp_attributes
@@ -2301,11 +2185,11 @@
             ((txt warning)
              (loc
               ((loc_start
-                ((pos_fname generated_locations.ml) (pos_lnum 4)
-                 (pos_bol 147) (pos_cnum 147)))
+                ((pos_fname generated_locations.ml) (pos_lnum 3)
+                 (pos_bol 153) (pos_cnum 153)))
                (loc_end
-                ((pos_fname generated_locations.ml) (pos_lnum 9)
-                 (pos_bol 407) (pos_cnum 456)))
+                ((pos_fname generated_locations.ml) (pos_lnum 7)
+                 (pos_bol 362) (pos_cnum 394)))
                (loc_ghost true)))))
            (attr_payload
             (PStr
@@ -2340,28 +2224,28 @@
                  (loc_ghost true)))))))
            (attr_loc
             ((loc_start
-              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-               (pos_cnum 147)))
+              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+               (pos_cnum 153)))
              (loc_end
-              ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-               (pos_cnum 456)))
+              ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+               (pos_cnum 394)))
              (loc_ghost true))))))))
       (pvb_attributes ())
       (pvb_loc
        ((loc_start
-         ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-          (pos_cnum 147)))
+         ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+          (pos_cnum 153)))
         (loc_end
-         ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-          (pos_cnum 456)))
+         ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+          (pos_cnum 394)))
         (loc_ghost false)))))))
   (pstr_loc
    ((loc_start
-     ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-      (pos_cnum 147)))
+     ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+      (pos_cnum 153)))
     (loc_end
-     ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-      (pos_cnum 456)))
+     ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+      (pos_cnum 394)))
     (loc_ghost false))))
  ((pstr_desc
    (Pstr_value Nonrecursive
@@ -2371,19 +2255,19 @@
           ((txt make)
            (loc
             ((loc_start
-              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-               (pos_cnum 151)))
+              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+               (pos_cnum 157)))
              (loc_end
-              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-               (pos_cnum 155)))
+              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+               (pos_cnum 161)))
              (loc_ghost false))))))
         (ppat_loc
          ((loc_start
-           ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-            (pos_cnum 151)))
+           ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+            (pos_cnum 157)))
           (loc_end
-           ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-            (pos_cnum 155)))
+           ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+            (pos_cnum 161)))
           (loc_ghost false)))
         (ppat_loc_stack ()) (ppat_attributes ())))
       (pvb_expr
@@ -2395,19 +2279,19 @@
                 ((txt Generated_locations)
                  (loc
                   ((loc_start
-                    ((pos_fname generated_locations.ml) (pos_lnum 4)
-                     (pos_bol 147) (pos_cnum 147)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 3)
+                     (pos_bol 153) (pos_cnum 153)))
                    (loc_end
-                    ((pos_fname generated_locations.ml) (pos_lnum 9)
-                     (pos_bol 407) (pos_cnum 456)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 7)
+                     (pos_bol 362) (pos_cnum 394)))
                    (loc_ghost true))))))
               (ppat_loc
                ((loc_start
-                 ((pos_fname generated_locations.ml) (pos_lnum 4)
-                  (pos_bol 147) (pos_cnum 147)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 3)
+                  (pos_bol 153) (pos_cnum 153)))
                 (loc_end
-                 ((pos_fname generated_locations.ml) (pos_lnum 9)
-                  (pos_bol 407) (pos_cnum 456)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 7)
+                  (pos_bol 362) (pos_cnum 394)))
                 (loc_ghost true)))
               (ppat_loc_stack ()) (ppat_attributes ())))
             (pvb_expr
@@ -2420,19 +2304,19 @@
                       ((txt Props)
                        (loc
                         ((loc_start
-                          ((pos_fname generated_locations.ml) (pos_lnum 4)
-                           (pos_bol 147) (pos_cnum 147)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 3)
+                           (pos_bol 153) (pos_cnum 153)))
                          (loc_end
-                          ((pos_fname generated_locations.ml) (pos_lnum 9)
-                           (pos_bol 407) (pos_cnum 456)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 7)
+                           (pos_bol 362) (pos_cnum 394)))
                          (loc_ghost true))))))
                     (ppat_loc
                      ((loc_start
-                       ((pos_fname generated_locations.ml) (pos_lnum 4)
-                        (pos_bol 147) (pos_cnum 147)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 3)
+                        (pos_bol 153) (pos_cnum 153)))
                       (loc_end
-                       ((pos_fname generated_locations.ml) (pos_lnum 9)
-                        (pos_bol 407) (pos_cnum 456)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 7)
+                        (pos_bol 362) (pos_cnum 394)))
                       (loc_ghost true)))
                     (ppat_loc_stack ()) (ppat_attributes ()))
                    ((ptyp_desc
@@ -2440,11 +2324,11 @@
                       ((txt (Ldot (Lident Js) t))
                        (loc
                         ((loc_start
-                          ((pos_fname generated_locations.ml) (pos_lnum 4)
-                           (pos_bol 147) (pos_cnum 147)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 3)
+                           (pos_bol 153) (pos_cnum 153)))
                          (loc_end
-                          ((pos_fname generated_locations.ml) (pos_lnum 9)
-                           (pos_bol 407) (pos_cnum 456)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 7)
+                           (pos_bol 362) (pos_cnum 394)))
                          (loc_ghost true))))
                       (((ptyp_desc
                          (Ptyp_object
@@ -2454,10 +2338,10 @@
                                (loc
                                 ((loc_start
                                   ((pos_fname generated_locations.ml)
-                                   (pos_lnum 4) (pos_bol 147) (pos_cnum 147)))
+                                   (pos_lnum 3) (pos_bol 153) (pos_cnum 153)))
                                  (loc_end
                                   ((pos_fname generated_locations.ml)
-                                   (pos_lnum 9) (pos_bol 407) (pos_cnum 456)))
+                                   (pos_lnum 7) (pos_bol 362) (pos_cnum 394)))
                                  (loc_ghost true))))
                               ((ptyp_desc
                                 (Ptyp_constr
@@ -2465,69 +2349,69 @@
                                   (loc
                                    ((loc_start
                                      ((pos_fname generated_locations.ml)
-                                      (pos_lnum 4) (pos_bol 147)
-                                      (pos_cnum 158)))
+                                      (pos_lnum 3) (pos_bol 153)
+                                      (pos_cnum 164)))
                                     (loc_end
                                      ((pos_fname generated_locations.ml)
-                                      (pos_lnum 4) (pos_bol 147)
-                                      (pos_cnum 170)))
+                                      (pos_lnum 3) (pos_bol 153)
+                                      (pos_cnum 176)))
                                     (loc_ghost false))))
                                  (((ptyp_desc (Ptyp_var initialValue))
                                    (ptyp_loc
                                     ((loc_start
                                       ((pos_fname generated_locations.ml)
-                                       (pos_lnum 4) (pos_bol 147)
-                                       (pos_cnum 158)))
+                                       (pos_lnum 3) (pos_bol 153)
+                                       (pos_cnum 164)))
                                      (loc_end
                                       ((pos_fname generated_locations.ml)
-                                       (pos_lnum 4) (pos_bol 147)
-                                       (pos_cnum 170)))
+                                       (pos_lnum 3) (pos_bol 153)
+                                       (pos_cnum 176)))
                                      (loc_ghost false)))
                                    (ptyp_loc_stack ()) (ptyp_attributes ())))))
                                (ptyp_loc
                                 ((loc_start
                                   ((pos_fname generated_locations.ml)
-                                   (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                                   (pos_lnum 3) (pos_bol 153) (pos_cnum 164)))
                                  (loc_end
                                   ((pos_fname generated_locations.ml)
-                                   (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                                   (pos_lnum 3) (pos_bol 153) (pos_cnum 176)))
                                  (loc_ghost false)))
                                (ptyp_loc_stack ()) (ptyp_attributes ()))))
                             (pof_loc
                              ((loc_start
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 4) (pos_bol 147) (pos_cnum 147)))
+                                (pos_lnum 3) (pos_bol 153) (pos_cnum 153)))
                               (loc_end
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 9) (pos_bol 407) (pos_cnum 456)))
+                                (pos_lnum 7) (pos_bol 362) (pos_cnum 394)))
                               (loc_ghost true)))
                             (pof_attributes ())))
                           Closed))
                         (ptyp_loc
                          ((loc_start
-                           ((pos_fname generated_locations.ml) (pos_lnum 4)
-                            (pos_bol 147) (pos_cnum 147)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 3)
+                            (pos_bol 153) (pos_cnum 153)))
                           (loc_end
-                           ((pos_fname generated_locations.ml) (pos_lnum 9)
-                            (pos_bol 407) (pos_cnum 456)))
+                           ((pos_fname generated_locations.ml) (pos_lnum 7)
+                            (pos_bol 362) (pos_cnum 394)))
                           (loc_ghost true)))
                         (ptyp_loc_stack ()) (ptyp_attributes ())))))
                     (ptyp_loc
                      ((loc_start
-                       ((pos_fname generated_locations.ml) (pos_lnum 4)
-                        (pos_bol 147) (pos_cnum 147)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 3)
+                        (pos_bol 153) (pos_cnum 153)))
                       (loc_end
-                       ((pos_fname generated_locations.ml) (pos_lnum 9)
-                        (pos_bol 407) (pos_cnum 456)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 7)
+                        (pos_bol 362) (pos_cnum 394)))
                       (loc_ghost true)))
                     (ptyp_loc_stack ()) (ptyp_attributes ()))))
                  (ppat_loc
                   ((loc_start
-                    ((pos_fname generated_locations.ml) (pos_lnum 4)
-                     (pos_bol 147) (pos_cnum 147)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 3)
+                     (pos_bol 153) (pos_cnum 153)))
                    (loc_end
-                    ((pos_fname generated_locations.ml) (pos_lnum 9)
-                     (pos_bol 407) (pos_cnum 456)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 7)
+                     (pos_bol 362) (pos_cnum 394)))
                    (loc_ghost true)))
                  (ppat_loc_stack ()) (ppat_attributes ()))
                 ((pexp_desc
@@ -2537,11 +2421,11 @@
                       ((txt (Lident make))
                        (loc
                         ((loc_start
-                          ((pos_fname generated_locations.ml) (pos_lnum 4)
-                           (pos_bol 147) (pos_cnum 147)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 3)
+                           (pos_bol 153) (pos_cnum 153)))
                          (loc_end
-                          ((pos_fname generated_locations.ml) (pos_lnum 9)
-                           (pos_bol 407) (pos_cnum 456)))
+                          ((pos_fname generated_locations.ml) (pos_lnum 7)
+                           (pos_bol 362) (pos_cnum 394)))
                          (loc_ghost true))))))
                     (pexp_loc
                      ((loc_start
@@ -2561,18 +2445,18 @@
                             (loc
                              ((loc_start
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                                (pos_lnum 3) (pos_bol 153) (pos_cnum 164)))
                               (loc_end
                                ((pos_fname generated_locations.ml)
-                                (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                                (pos_lnum 3) (pos_bol 153) (pos_cnum 176)))
                               (loc_ghost false))))))
                          (pexp_loc
                           ((loc_start
-                            ((pos_fname generated_locations.ml) (pos_lnum 4)
-                             (pos_bol 147) (pos_cnum 158)))
+                            ((pos_fname generated_locations.ml) (pos_lnum 3)
+                             (pos_bol 153) (pos_cnum 164)))
                            (loc_end
-                            ((pos_fname generated_locations.ml) (pos_lnum 4)
-                             (pos_bol 147) (pos_cnum 170)))
+                            ((pos_fname generated_locations.ml) (pos_lnum 3)
+                             (pos_bol 153) (pos_cnum 176)))
                            (loc_ghost false)))
                          (pexp_loc_stack ()) (pexp_attributes ()))
                         ((Nolabel
@@ -2582,18 +2466,18 @@
                               (loc
                                ((loc_start
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                                  (pos_lnum 3) (pos_bol 153) (pos_cnum 164)))
                                 (loc_end
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                                  (pos_lnum 3) (pos_bol 153) (pos_cnum 176)))
                                 (loc_ghost false))))))
                            (pexp_loc
                             ((loc_start
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                               (pos_lnum 3) (pos_bol 153) (pos_cnum 164)))
                              (loc_end
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                               (pos_lnum 3) (pos_bol 153) (pos_cnum 176)))
                              (loc_ghost false)))
                            (pexp_loc_stack ()) (pexp_attributes ())))
                          (Nolabel
@@ -2603,27 +2487,27 @@
                               (loc
                                ((loc_start
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                                  (pos_lnum 3) (pos_bol 153) (pos_cnum 164)))
                                 (loc_end
                                  ((pos_fname generated_locations.ml)
-                                  (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                                  (pos_lnum 3) (pos_bol 153) (pos_cnum 176)))
                                 (loc_ghost false))))))
                            (pexp_loc
                             ((loc_start
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                               (pos_lnum 3) (pos_bol 153) (pos_cnum 164)))
                              (loc_end
                               ((pos_fname generated_locations.ml)
-                               (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                               (pos_lnum 3) (pos_bol 153) (pos_cnum 176)))
                              (loc_ghost false)))
                            (pexp_loc_stack ()) (pexp_attributes ()))))))
                       (pexp_loc
                        ((loc_start
-                         ((pos_fname generated_locations.ml) (pos_lnum 4)
-                          (pos_bol 147) (pos_cnum 158)))
+                         ((pos_fname generated_locations.ml) (pos_lnum 3)
+                          (pos_bol 153) (pos_cnum 164)))
                         (loc_end
-                         ((pos_fname generated_locations.ml) (pos_lnum 4)
-                          (pos_bol 147) (pos_cnum 170)))
+                         ((pos_fname generated_locations.ml) (pos_lnum 3)
+                          (pos_bol 153) (pos_cnum 176)))
                         (loc_ghost false)))
                       (pexp_loc_stack ()) (pexp_attributes ())))
                     (Nolabel
@@ -2632,11 +2516,11 @@
                         ((txt (Lident "()"))
                          (loc
                           ((loc_start
-                            ((pos_fname generated_locations.ml) (pos_lnum 4)
-                             (pos_bol 147) (pos_cnum 147)))
+                            ((pos_fname generated_locations.ml) (pos_lnum 3)
+                             (pos_bol 153) (pos_cnum 153)))
                            (loc_end
-                            ((pos_fname generated_locations.ml) (pos_lnum 9)
-                             (pos_bol 407) (pos_cnum 456)))
+                            ((pos_fname generated_locations.ml) (pos_lnum 7)
+                             (pos_bol 362) (pos_cnum 394)))
                            (loc_ghost true))))
                         ()))
                       (pexp_loc
@@ -2650,11 +2534,11 @@
                       (pexp_loc_stack ()) (pexp_attributes ()))))))
                  (pexp_loc
                   ((loc_start
-                    ((pos_fname generated_locations.ml) (pos_lnum 4)
-                     (pos_bol 147) (pos_cnum 147)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 3)
+                     (pos_bol 153) (pos_cnum 153)))
                    (loc_end
-                    ((pos_fname generated_locations.ml) (pos_lnum 9)
-                     (pos_bol 407) (pos_cnum 456)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 7)
+                     (pos_bol 362) (pos_cnum 394)))
                    (loc_ghost true)))
                  (pexp_loc_stack ()) (pexp_attributes ()))))
               (pexp_loc
@@ -2684,30 +2568,30 @@
                  (loc_ghost true))))))
             (pvb_loc
              ((loc_start
-               ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-                (pos_cnum 147)))
+               ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+                (pos_cnum 153)))
               (loc_end
-               ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-                (pos_cnum 456)))
+               ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+                (pos_cnum 394)))
               (loc_ghost true)))))
           ((pexp_desc
             (Pexp_ident
              ((txt (Lident Generated_locations))
               (loc
                ((loc_start
-                 ((pos_fname generated_locations.ml) (pos_lnum 4)
-                  (pos_bol 147) (pos_cnum 147)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 3)
+                  (pos_bol 153) (pos_cnum 153)))
                 (loc_end
-                 ((pos_fname generated_locations.ml) (pos_lnum 9)
-                  (pos_bol 407) (pos_cnum 456)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 7)
+                  (pos_bol 362) (pos_cnum 394)))
                 (loc_ghost true))))))
            (pexp_loc
             ((loc_start
-              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-               (pos_cnum 147)))
+              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+               (pos_cnum 153)))
              (loc_end
-              ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-               (pos_cnum 456)))
+              ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+               (pos_cnum 394)))
              (loc_ghost true)))
            (pexp_loc_stack ()) (pexp_attributes ()))))
         (pexp_loc
@@ -2720,17 +2604,17 @@
       (pvb_attributes ())
       (pvb_loc
        ((loc_start
-         ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-          (pos_cnum 147)))
+         ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+          (pos_cnum 153)))
         (loc_end
-         ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-          (pos_cnum 456)))
+         ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+          (pos_cnum 394)))
         (loc_ghost false)))))))
   (pstr_loc
    ((loc_start
-     ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
-      (pos_cnum 147)))
+     ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 153)
+      (pos_cnum 153)))
     (loc_end
-     ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
-      (pos_cnum 456)))
+     ((pos_fname generated_locations.ml) (pos_lnum 7) (pos_bol 362)
+      (pos_cnum 394)))
     (loc_ghost true)))))

--- a/ppx/test/output_locations.expected
+++ b/ppx/test/output_locations.expected
@@ -713,10 +713,12 @@
                    (loc_ghost false))))))
               (pexp_loc
                ((loc_start
-                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 2)
+                  (pos_bol 18) (pos_cnum 20)))
                 (loc_end
-                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-                (loc_ghost true)))
+                 ((pos_fname generated_locations.ml) (pos_lnum 3)
+                  (pos_bol 90) (pos_cnum 126)))
+                (loc_ghost false)))
               (pexp_loc_stack ()) (pexp_attributes ()))
              ((Nolabel
                ((pexp_desc
@@ -1803,12 +1805,12 @@
                          (loc_ghost false))))))
                     (pexp_loc
                      ((loc_start
-                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                        (pos_cnum -1)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 6)
+                        (pos_bol 252) (pos_cnum 256)))
                       (loc_end
-                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                        (pos_cnum -1)))
-                      (loc_ghost true)))
+                       ((pos_fname generated_locations.ml) (pos_lnum 8)
+                        (pos_bol 391) (pos_cnum 405)))
+                      (loc_ghost false)))
                     (pexp_loc_stack ()) (pexp_attributes ()))
                    ((Nolabel
                      ((pexp_desc

--- a/ppx/test/output_locations.expected
+++ b/ppx/test/output_locations.expected
@@ -705,12 +705,12 @@
                 ((txt (Ldot (Lident ReactDOM) jsx))
                  (loc
                   ((loc_start
-                    ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                     (pos_cnum -1)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 2)
+                     (pos_bol 18) (pos_cnum 20)))
                    (loc_end
-                    ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
-                     (pos_cnum -1)))
-                   (loc_ghost true))))))
+                    ((pos_fname generated_locations.ml) (pos_lnum 3)
+                     (pos_bol 90) (pos_cnum 126)))
+                   (loc_ghost false))))))
               (pexp_loc
                ((loc_start
                  ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
@@ -756,12 +756,32 @@
                    (pexp_loc
                     ((loc_start
                       ((pos_fname generated_locations.ml) (pos_lnum 2)
-                       (pos_bol 18) (pos_cnum 22)))
+                       (pos_bol 18) (pos_cnum 20)))
                      (loc_end
-                      ((pos_fname generated_locations.ml) (pos_lnum 2)
-                       (pos_bol 18) (pos_cnum 25)))
+                      ((pos_fname generated_locations.ml) (pos_lnum 3)
+                       (pos_bol 90) (pos_cnum 126)))
                      (loc_ghost false)))
-                   (pexp_loc_stack ()) (pexp_attributes ()))
+                   (pexp_loc_stack ())
+                   (pexp_attributes
+                    (((attr_name
+                       ((txt merlin.hide)
+                        (loc
+                         ((loc_start
+                           ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                            (pos_cnum -1)))
+                          (loc_end
+                           ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                            (pos_cnum -1)))
+                          (loc_ghost true)))))
+                      (attr_payload (PStr ()))
+                      (attr_loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true)))))))
                   (((Labelled children)
                     ((pexp_desc
                       (Pexp_apply
@@ -874,19 +894,19 @@
                 (pexp_loc
                  ((loc_start
                    ((pos_fname generated_locations.ml) (pos_lnum 2)
-                    (pos_bol 18) (pos_cnum 22)))
+                    (pos_bol 18) (pos_cnum 20)))
                   (loc_end
-                   ((pos_fname generated_locations.ml) (pos_lnum 2)
-                    (pos_bol 18) (pos_cnum 25)))
+                   ((pos_fname generated_locations.ml) (pos_lnum 3)
+                    (pos_bol 90) (pos_cnum 126)))
                   (loc_ghost false)))
                 (pexp_loc_stack ()) (pexp_attributes ()))))))
            (pexp_loc
             ((loc_start
               ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 18)
-               (pos_cnum 22)))
+               (pos_cnum 20)))
              (loc_end
-              ((pos_fname generated_locations.ml) (pos_lnum 2) (pos_bol 18)
-               (pos_cnum 25)))
+              ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
+               (pos_cnum 126)))
              (loc_ghost false)))
            (pexp_loc_stack ())
            (pexp_attributes
@@ -1226,11 +1246,11 @@
                       (pexp_loc_stack ()) (pexp_attributes ()))))))
                  (pexp_loc
                   ((loc_start
-                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                     (pos_cnum -1)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 1)
+                     (pos_bol 0) (pos_cnum 0)))
                    (loc_end
-                    ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                     (pos_cnum -1)))
+                    ((pos_fname generated_locations.ml) (pos_lnum 3)
+                     (pos_bol 90) (pos_cnum 146)))
                    (loc_ghost true)))
                  (pexp_loc_stack ()) (pexp_attributes ()))))
               (pexp_loc
@@ -1309,4 +1329,1406 @@
     (loc_end
      ((pos_fname generated_locations.ml) (pos_lnum 3) (pos_bol 90)
       (pos_cnum 146)))
+    (loc_ghost true))))
+ ((pstr_desc
+   (Pstr_primitive
+    ((pval_name
+      ((txt makeProps)
+       (loc
+        ((loc_start
+          ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+           (pos_cnum 147)))
+         (loc_end
+          ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+           (pos_cnum 456)))
+         (loc_ghost true)))))
+     (pval_type
+      ((ptyp_desc
+        (Ptyp_arrow (Optional initialValue)
+         ((ptyp_desc (Ptyp_var initialValue))
+          (ptyp_loc
+           ((loc_start
+             ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+              (pos_cnum 158)))
+            (loc_end
+             ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+              (pos_cnum 170)))
+            (loc_ghost false)))
+          (ptyp_loc_stack ()) (ptyp_attributes ()))
+         ((ptyp_desc
+           (Ptyp_arrow (Optional key)
+            ((ptyp_desc
+              (Ptyp_constr
+               ((txt (Lident string))
+                (loc
+                 ((loc_start
+                   ((pos_fname generated_locations.ml) (pos_lnum 4)
+                    (pos_bol 147) (pos_cnum 147)))
+                  (loc_end
+                   ((pos_fname generated_locations.ml) (pos_lnum 9)
+                    (pos_bol 407) (pos_cnum 456)))
+                  (loc_ghost true))))
+               ()))
+             (ptyp_loc
+              ((loc_start
+                ((pos_fname generated_locations.ml) (pos_lnum 4)
+                 (pos_bol 147) (pos_cnum 147)))
+               (loc_end
+                ((pos_fname generated_locations.ml) (pos_lnum 9)
+                 (pos_bol 407) (pos_cnum 456)))
+               (loc_ghost true)))
+             (ptyp_loc_stack ()) (ptyp_attributes ()))
+            ((ptyp_desc
+              (Ptyp_arrow Nolabel
+               ((ptyp_desc
+                 (Ptyp_constr
+                  ((txt (Lident unit))
+                   (loc
+                    ((loc_start
+                      ((pos_fname generated_locations.ml) (pos_lnum 4)
+                       (pos_bol 147) (pos_cnum 147)))
+                     (loc_end
+                      ((pos_fname generated_locations.ml) (pos_lnum 9)
+                       (pos_bol 407) (pos_cnum 456)))
+                     (loc_ghost true))))
+                  ()))
+                (ptyp_loc
+                 ((loc_start
+                   ((pos_fname generated_locations.ml) (pos_lnum 4)
+                    (pos_bol 147) (pos_cnum 147)))
+                  (loc_end
+                   ((pos_fname generated_locations.ml) (pos_lnum 9)
+                    (pos_bol 407) (pos_cnum 456)))
+                  (loc_ghost true)))
+                (ptyp_loc_stack ()) (ptyp_attributes ()))
+               ((ptyp_desc
+                 (Ptyp_constr
+                  ((txt (Ldot (Lident Js) t))
+                   (loc
+                    ((loc_start
+                      ((pos_fname generated_locations.ml) (pos_lnum 4)
+                       (pos_bol 147) (pos_cnum 147)))
+                     (loc_end
+                      ((pos_fname generated_locations.ml) (pos_lnum 9)
+                       (pos_bol 407) (pos_cnum 456)))
+                     (loc_ghost true))))
+                  (((ptyp_desc
+                     (Ptyp_object
+                      (((pof_desc
+                         (Otag
+                          ((txt initialValue)
+                           (loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 4) (pos_bol 147) (pos_cnum 147)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 9) (pos_bol 407) (pos_cnum 456)))
+                             (loc_ghost true))))
+                          ((ptyp_desc
+                            (Ptyp_constr
+                             ((txt (Lident option))
+                              (loc
+                               ((loc_start
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                                (loc_end
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                                (loc_ghost false))))
+                             (((ptyp_desc (Ptyp_var initialValue))
+                               (ptyp_loc
+                                ((loc_start
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                                 (loc_end
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                                 (loc_ghost false)))
+                               (ptyp_loc_stack ()) (ptyp_attributes ())))))
+                           (ptyp_loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                             (loc_ghost false)))
+                           (ptyp_loc_stack ()) (ptyp_attributes ()))))
+                        (pof_loc
+                         ((loc_start
+                           ((pos_fname generated_locations.ml) (pos_lnum 4)
+                            (pos_bol 147) (pos_cnum 147)))
+                          (loc_end
+                           ((pos_fname generated_locations.ml) (pos_lnum 9)
+                            (pos_bol 407) (pos_cnum 456)))
+                          (loc_ghost true)))
+                        (pof_attributes ())))
+                      Closed))
+                    (ptyp_loc
+                     ((loc_start
+                       ((pos_fname generated_locations.ml) (pos_lnum 4)
+                        (pos_bol 147) (pos_cnum 147)))
+                      (loc_end
+                       ((pos_fname generated_locations.ml) (pos_lnum 9)
+                        (pos_bol 407) (pos_cnum 456)))
+                      (loc_ghost true)))
+                    (ptyp_loc_stack ()) (ptyp_attributes ())))))
+                (ptyp_loc
+                 ((loc_start
+                   ((pos_fname generated_locations.ml) (pos_lnum 4)
+                    (pos_bol 147) (pos_cnum 147)))
+                  (loc_end
+                   ((pos_fname generated_locations.ml) (pos_lnum 9)
+                    (pos_bol 407) (pos_cnum 456)))
+                  (loc_ghost true)))
+                (ptyp_loc_stack ()) (ptyp_attributes ()))))
+             (ptyp_loc
+              ((loc_start
+                ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+               (loc_end
+                ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+               (loc_ghost true)))
+             (ptyp_loc_stack ()) (ptyp_attributes ()))))
+          (ptyp_loc
+           ((loc_start
+             ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+              (pos_cnum 147)))
+            (loc_end
+             ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+              (pos_cnum 456)))
+            (loc_ghost true)))
+          (ptyp_loc_stack ()) (ptyp_attributes ()))))
+       (ptyp_loc
+        ((loc_start
+          ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+           (pos_cnum 158)))
+         (loc_end
+          ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+           (pos_cnum 170)))
+         (loc_ghost false)))
+       (ptyp_loc_stack ()) (ptyp_attributes ())))
+     (pval_prim (""))
+     (pval_attributes
+      (((attr_name
+         ((txt bs.obj)
+          (loc
+           ((loc_start
+             ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+              (pos_cnum 147)))
+            (loc_end
+             ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+              (pos_cnum 456)))
+            (loc_ghost true)))))
+        (attr_payload (PStr ()))
+        (attr_loc
+         ((loc_start
+           ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+            (pos_cnum 147)))
+          (loc_end
+           ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+            (pos_cnum 456)))
+          (loc_ghost true))))))
+     (pval_loc
+      ((loc_start
+        ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+         (pos_cnum 147)))
+       (loc_end
+        ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+         (pos_cnum 456)))
+       (loc_ghost true))))))
+  (pstr_loc
+   ((loc_start
+     ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+      (pos_cnum 147)))
+    (loc_end
+     ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+      (pos_cnum 456)))
+    (loc_ghost true))))
+ ((pstr_desc
+   (Pstr_value Nonrecursive
+    (((pvb_pat
+       ((ppat_desc
+         (Ppat_var
+          ((txt make)
+           (loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+               (pos_cnum 151)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+               (pos_cnum 155)))
+             (loc_ghost false))))))
+        (ppat_loc
+         ((loc_start
+           ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+            (pos_cnum 151)))
+          (loc_end
+           ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+            (pos_cnum 155)))
+          (loc_ghost false)))
+        (ppat_loc_stack ()) (ppat_attributes ())))
+      (pvb_expr
+       ((pexp_desc
+         (Pexp_fun (Optional initialValue)
+          (((pexp_desc (Pexp_constant (Pconst_integer 0 ())))
+            (pexp_loc
+             ((loc_start
+               ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+                (pos_cnum 172)))
+              (loc_end
+               ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+                (pos_cnum 173)))
+              (loc_ghost false)))
+            (pexp_loc_stack ()) (pexp_attributes ())))
+          ((ppat_desc
+            (Ppat_var
+             ((txt initialValue)
+              (loc
+               ((loc_start
+                 ((pos_fname generated_locations.ml) (pos_lnum 4)
+                  (pos_bol 147) (pos_cnum 158)))
+                (loc_end
+                 ((pos_fname generated_locations.ml) (pos_lnum 4)
+                  (pos_bol 147) (pos_cnum 170)))
+                (loc_ghost false))))))
+           (ppat_loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+               (pos_cnum 158)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+               (pos_cnum 170)))
+             (loc_ghost false)))
+           (ppat_loc_stack ()) (ppat_attributes ()))
+          ((pexp_desc
+            (Pexp_fun Nolabel ()
+             ((ppat_desc
+               (Ppat_construct
+                ((txt (Lident "()"))
+                 (loc
+                  ((loc_start
+                    ((pos_fname generated_locations.ml) (pos_lnum 4)
+                     (pos_bol 147) (pos_cnum 176)))
+                   (loc_end
+                    ((pos_fname generated_locations.ml) (pos_lnum 4)
+                     (pos_bol 147) (pos_cnum 178)))
+                   (loc_ghost false))))
+                ()))
+              (ppat_loc
+               ((loc_start
+                 ((pos_fname generated_locations.ml) (pos_lnum 4)
+                  (pos_bol 147) (pos_cnum 176)))
+                (loc_end
+                 ((pos_fname generated_locations.ml) (pos_lnum 4)
+                  (pos_bol 147) (pos_cnum 178)))
+                (loc_ghost false)))
+              (ppat_loc_stack ()) (ppat_attributes ()))
+             ((pexp_desc
+               (Pexp_let Nonrecursive
+                (((pvb_pat
+                   ((ppat_desc
+                     (Ppat_tuple
+                      (((ppat_desc
+                         (Ppat_var
+                          ((txt value)
+                           (loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 5) (pos_bol 181) (pos_cnum 190)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 5) (pos_bol 181) (pos_cnum 195)))
+                             (loc_ghost false))))))
+                        (ppat_loc
+                         ((loc_start
+                           ((pos_fname generated_locations.ml) (pos_lnum 5)
+                            (pos_bol 181) (pos_cnum 190)))
+                          (loc_end
+                           ((pos_fname generated_locations.ml) (pos_lnum 5)
+                            (pos_bol 181) (pos_cnum 195)))
+                          (loc_ghost false)))
+                        (ppat_loc_stack ()) (ppat_attributes ()))
+                       ((ppat_desc
+                         (Ppat_var
+                          ((txt setValue)
+                           (loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 5) (pos_bol 181) (pos_cnum 197)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 5) (pos_bol 181) (pos_cnum 205)))
+                             (loc_ghost false))))))
+                        (ppat_loc
+                         ((loc_start
+                           ((pos_fname generated_locations.ml) (pos_lnum 5)
+                            (pos_bol 181) (pos_cnum 197)))
+                          (loc_end
+                           ((pos_fname generated_locations.ml) (pos_lnum 5)
+                            (pos_bol 181) (pos_cnum 205)))
+                          (loc_ghost false)))
+                        (ppat_loc_stack ()) (ppat_attributes ())))))
+                    (ppat_loc
+                     ((loc_start
+                       ((pos_fname generated_locations.ml) (pos_lnum 5)
+                        (pos_bol 181) (pos_cnum 189)))
+                      (loc_end
+                       ((pos_fname generated_locations.ml) (pos_lnum 5)
+                        (pos_bol 181) (pos_cnum 206)))
+                      (loc_ghost false)))
+                    (ppat_loc_stack
+                     (((loc_start
+                        ((pos_fname generated_locations.ml) (pos_lnum 5)
+                         (pos_bol 181) (pos_cnum 190)))
+                       (loc_end
+                        ((pos_fname generated_locations.ml) (pos_lnum 5)
+                         (pos_bol 181) (pos_cnum 205)))
+                       (loc_ghost false))))
+                    (ppat_attributes ())))
+                  (pvb_expr
+                   ((pexp_desc
+                     (Pexp_apply
+                      ((pexp_desc
+                        (Pexp_ident
+                         ((txt (Ldot (Lident React) useState))
+                          (loc
+                           ((loc_start
+                             ((pos_fname generated_locations.ml) (pos_lnum 5)
+                              (pos_bol 181) (pos_cnum 209)))
+                            (loc_end
+                             ((pos_fname generated_locations.ml) (pos_lnum 5)
+                              (pos_bol 181) (pos_cnum 223)))
+                            (loc_ghost false))))))
+                       (pexp_loc
+                        ((loc_start
+                          ((pos_fname generated_locations.ml) (pos_lnum 5)
+                           (pos_bol 181) (pos_cnum 209)))
+                         (loc_end
+                          ((pos_fname generated_locations.ml) (pos_lnum 5)
+                           (pos_bol 181) (pos_cnum 223)))
+                         (loc_ghost false)))
+                       (pexp_loc_stack ()) (pexp_attributes ()))
+                      ((Nolabel
+                        ((pexp_desc
+                          (Pexp_fun Nolabel ()
+                           ((ppat_desc
+                             (Ppat_construct
+                              ((txt (Lident "()"))
+                               (loc
+                                ((loc_start
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 5) (pos_bol 181) (pos_cnum 229)))
+                                 (loc_end
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 5) (pos_bol 181) (pos_cnum 231)))
+                                 (loc_ghost false))))
+                              ()))
+                            (ppat_loc
+                             ((loc_start
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 5) (pos_bol 181) (pos_cnum 229)))
+                              (loc_end
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 5) (pos_bol 181) (pos_cnum 231)))
+                              (loc_ghost false)))
+                            (ppat_loc_stack ()) (ppat_attributes ()))
+                           ((pexp_desc
+                             (Pexp_ident
+                              ((txt (Lident initialValue))
+                               (loc
+                                ((loc_start
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 5) (pos_bol 181) (pos_cnum 235)))
+                                 (loc_end
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 5) (pos_bol 181) (pos_cnum 247)))
+                                 (loc_ghost false))))))
+                            (pexp_loc
+                             ((loc_start
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 5) (pos_bol 181) (pos_cnum 235)))
+                              (loc_end
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 5) (pos_bol 181) (pos_cnum 247)))
+                              (loc_ghost false)))
+                            (pexp_loc_stack ()) (pexp_attributes ()))))
+                         (pexp_loc
+                          ((loc_start
+                            ((pos_fname generated_locations.ml) (pos_lnum 5)
+                             (pos_bol 181) (pos_cnum 224)))
+                           (loc_end
+                            ((pos_fname generated_locations.ml) (pos_lnum 5)
+                             (pos_bol 181) (pos_cnum 248)))
+                           (loc_ghost false)))
+                         (pexp_loc_stack
+                          (((loc_start
+                             ((pos_fname generated_locations.ml) (pos_lnum 5)
+                              (pos_bol 181) (pos_cnum 225)))
+                            (loc_end
+                             ((pos_fname generated_locations.ml) (pos_lnum 5)
+                              (pos_bol 181) (pos_cnum 247)))
+                            (loc_ghost false))))
+                         (pexp_attributes ()))))))
+                    (pexp_loc
+                     ((loc_start
+                       ((pos_fname generated_locations.ml) (pos_lnum 5)
+                        (pos_bol 181) (pos_cnum 209)))
+                      (loc_end
+                       ((pos_fname generated_locations.ml) (pos_lnum 5)
+                        (pos_bol 181) (pos_cnum 248)))
+                      (loc_ghost false)))
+                    (pexp_loc_stack ()) (pexp_attributes ())))
+                  (pvb_attributes ())
+                  (pvb_loc
+                   ((loc_start
+                     ((pos_fname generated_locations.ml) (pos_lnum 5)
+                      (pos_bol 181) (pos_cnum 185)))
+                    (loc_end
+                     ((pos_fname generated_locations.ml) (pos_lnum 5)
+                      (pos_bol 181) (pos_cnum 248)))
+                    (loc_ghost false)))))
+                ((pexp_desc
+                  (Pexp_apply
+                   ((pexp_desc
+                     (Pexp_ident
+                      ((txt (Ldot (Lident ReactDOM) jsx))
+                       (loc
+                        ((loc_start
+                          ((pos_fname generated_locations.ml) (pos_lnum 6)
+                           (pos_bol 252) (pos_cnum 256)))
+                         (loc_end
+                          ((pos_fname generated_locations.ml) (pos_lnum 8)
+                           (pos_bol 391) (pos_cnum 405)))
+                         (loc_ghost false))))))
+                    (pexp_loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true)))
+                    (pexp_loc_stack ()) (pexp_attributes ()))
+                   ((Nolabel
+                     ((pexp_desc
+                       (Pexp_constant
+                        (Pconst_string button
+                         ((loc_start
+                           ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                            (pos_cnum -1)))
+                          (loc_end
+                           ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                            (pos_cnum -1)))
+                          (loc_ghost true))
+                         ())))
+                      (pexp_loc
+                       ((loc_start
+                         ((pos_fname generated_locations.ml) (pos_lnum 6)
+                          (pos_bol 252) (pos_cnum 258)))
+                        (loc_end
+                         ((pos_fname generated_locations.ml) (pos_lnum 6)
+                          (pos_bol 252) (pos_cnum 264)))
+                        (loc_ghost false)))
+                      (pexp_loc_stack ()) (pexp_attributes ())))
+                    (Nolabel
+                     ((pexp_desc
+                       (Pexp_apply
+                        ((pexp_desc
+                          (Pexp_ident
+                           ((txt (Ldot (Lident ReactDOM) domProps))
+                            (loc
+                             ((loc_start
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 6) (pos_bol 252) (pos_cnum 258)))
+                              (loc_end
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 6) (pos_bol 252) (pos_cnum 264)))
+                              (loc_ghost false))))))
+                         (pexp_loc
+                          ((loc_start
+                            ((pos_fname generated_locations.ml) (pos_lnum 6)
+                             (pos_bol 252) (pos_cnum 256)))
+                           (loc_end
+                            ((pos_fname generated_locations.ml) (pos_lnum 8)
+                             (pos_bol 391) (pos_cnum 405)))
+                           (loc_ghost false)))
+                         (pexp_loc_stack ())
+                         (pexp_attributes
+                          (((attr_name
+                             ((txt merlin.hide)
+                              (loc
+                               ((loc_start
+                                 ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                                  (pos_cnum -1)))
+                                (loc_end
+                                 ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                                  (pos_cnum -1)))
+                                (loc_ghost true)))))
+                            (attr_payload (PStr ()))
+                            (attr_loc
+                             ((loc_start
+                               ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                                (pos_cnum -1)))
+                              (loc_end
+                               ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                                (pos_cnum -1)))
+                              (loc_ghost true)))))))
+                        (((Labelled children)
+                          ((pexp_desc
+                            (Pexp_apply
+                             ((pexp_desc
+                               (Pexp_ident
+                                ((txt (Lident |.))
+                                 (loc
+                                  ((loc_start
+                                    ((pos_fname generated_locations.ml)
+                                     (pos_lnum 7) (pos_bol 320)
+                                     (pos_cnum 373)))
+                                   (loc_end
+                                    ((pos_fname generated_locations.ml)
+                                     (pos_lnum 7) (pos_bol 320)
+                                     (pos_cnum 375)))
+                                   (loc_ghost false))))))
+                              (pexp_loc
+                               ((loc_start
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 7) (pos_bol 320) (pos_cnum 373)))
+                                (loc_end
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 7) (pos_bol 320) (pos_cnum 375)))
+                                (loc_ghost false)))
+                              (pexp_loc_stack ()) (pexp_attributes ()))
+                             ((Nolabel
+                               ((pexp_desc
+                                 (Pexp_ident
+                                  ((txt (Lident value))
+                                   (loc
+                                    ((loc_start
+                                      ((pos_fname generated_locations.ml)
+                                       (pos_lnum 7) (pos_bol 320)
+                                       (pos_cnum 367)))
+                                     (loc_end
+                                      ((pos_fname generated_locations.ml)
+                                       (pos_lnum 7) (pos_bol 320)
+                                       (pos_cnum 372)))
+                                     (loc_ghost false))))))
+                                (pexp_loc
+                                 ((loc_start
+                                   ((pos_fname generated_locations.ml)
+                                    (pos_lnum 7) (pos_bol 320)
+                                    (pos_cnum 367)))
+                                  (loc_end
+                                   ((pos_fname generated_locations.ml)
+                                    (pos_lnum 7) (pos_bol 320)
+                                    (pos_cnum 372)))
+                                  (loc_ghost false)))
+                                (pexp_loc_stack ()) (pexp_attributes ())))
+                              (Nolabel
+                               ((pexp_desc
+                                 (Pexp_ident
+                                  ((txt (Ldot (Lident React) int))
+                                   (loc
+                                    ((loc_start
+                                      ((pos_fname generated_locations.ml)
+                                       (pos_lnum 7) (pos_bol 320)
+                                       (pos_cnum 376)))
+                                     (loc_end
+                                      ((pos_fname generated_locations.ml)
+                                       (pos_lnum 7) (pos_bol 320)
+                                       (pos_cnum 385)))
+                                     (loc_ghost false))))))
+                                (pexp_loc
+                                 ((loc_start
+                                   ((pos_fname generated_locations.ml)
+                                    (pos_lnum 7) (pos_bol 320)
+                                    (pos_cnum 376)))
+                                  (loc_end
+                                   ((pos_fname generated_locations.ml)
+                                    (pos_lnum 7) (pos_bol 320)
+                                    (pos_cnum 385)))
+                                  (loc_ghost false)))
+                                (pexp_loc_stack ()) (pexp_attributes ()))))))
+                           (pexp_loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 7) (pos_bol 320) (pos_cnum 367)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 7) (pos_bol 320) (pos_cnum 385)))
+                             (loc_ghost false)))
+                           (pexp_loc_stack ()) (pexp_attributes ())))
+                         ((Labelled onClick)
+                          ((pexp_desc
+                            (Pexp_fun Nolabel ()
+                             ((ppat_desc Ppat_any)
+                              (ppat_loc
+                               ((loc_start
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 6) (pos_bol 252) (pos_cnum 280)))
+                                (loc_end
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 6) (pos_bol 252) (pos_cnum 281)))
+                                (loc_ghost false)))
+                              (ppat_loc_stack ()) (ppat_attributes ()))
+                             ((pexp_desc
+                               (Pexp_apply
+                                ((pexp_desc
+                                  (Pexp_ident
+                                   ((txt (Lident setValue))
+                                    (loc
+                                     ((loc_start
+                                       ((pos_fname generated_locations.ml)
+                                        (pos_lnum 6) (pos_bol 252)
+                                        (pos_cnum 285)))
+                                      (loc_end
+                                       ((pos_fname generated_locations.ml)
+                                        (pos_lnum 6) (pos_bol 252)
+                                        (pos_cnum 293)))
+                                      (loc_ghost false))))))
+                                 (pexp_loc
+                                  ((loc_start
+                                    ((pos_fname generated_locations.ml)
+                                     (pos_lnum 6) (pos_bol 252)
+                                     (pos_cnum 285)))
+                                   (loc_end
+                                    ((pos_fname generated_locations.ml)
+                                     (pos_lnum 6) (pos_bol 252)
+                                     (pos_cnum 293)))
+                                   (loc_ghost false)))
+                                 (pexp_loc_stack ()) (pexp_attributes ()))
+                                ((Nolabel
+                                  ((pexp_desc
+                                    (Pexp_fun Nolabel ()
+                                     ((ppat_desc
+                                       (Ppat_var
+                                        ((txt value)
+                                         (loc
+                                          ((loc_start
+                                            ((pos_fname
+                                              generated_locations.ml)
+                                             (pos_lnum 6) (pos_bol 252)
+                                             (pos_cnum 299)))
+                                           (loc_end
+                                            ((pos_fname
+                                              generated_locations.ml)
+                                             (pos_lnum 6) (pos_bol 252)
+                                             (pos_cnum 304)))
+                                           (loc_ghost false))))))
+                                      (ppat_loc
+                                       ((loc_start
+                                         ((pos_fname generated_locations.ml)
+                                          (pos_lnum 6) (pos_bol 252)
+                                          (pos_cnum 299)))
+                                        (loc_end
+                                         ((pos_fname generated_locations.ml)
+                                          (pos_lnum 6) (pos_bol 252)
+                                          (pos_cnum 304)))
+                                        (loc_ghost false)))
+                                      (ppat_loc_stack ())
+                                      (ppat_attributes ()))
+                                     ((pexp_desc
+                                       (Pexp_apply
+                                        ((pexp_desc
+                                          (Pexp_ident
+                                           ((txt (Lident +))
+                                            (loc
+                                             ((loc_start
+                                               ((pos_fname
+                                                 generated_locations.ml)
+                                                (pos_lnum 6) (pos_bol 252)
+                                                (pos_cnum 314)))
+                                              (loc_end
+                                               ((pos_fname
+                                                 generated_locations.ml)
+                                                (pos_lnum 6) (pos_bol 252)
+                                                (pos_cnum 315)))
+                                              (loc_ghost false))))))
+                                         (pexp_loc
+                                          ((loc_start
+                                            ((pos_fname
+                                              generated_locations.ml)
+                                             (pos_lnum 6) (pos_bol 252)
+                                             (pos_cnum 314)))
+                                           (loc_end
+                                            ((pos_fname
+                                              generated_locations.ml)
+                                             (pos_lnum 6) (pos_bol 252)
+                                             (pos_cnum 315)))
+                                           (loc_ghost false)))
+                                         (pexp_loc_stack ())
+                                         (pexp_attributes ()))
+                                        ((Nolabel
+                                          ((pexp_desc
+                                            (Pexp_ident
+                                             ((txt (Lident value))
+                                              (loc
+                                               ((loc_start
+                                                 ((pos_fname
+                                                   generated_locations.ml)
+                                                  (pos_lnum 6) (pos_bol 252)
+                                                  (pos_cnum 308)))
+                                                (loc_end
+                                                 ((pos_fname
+                                                   generated_locations.ml)
+                                                  (pos_lnum 6) (pos_bol 252)
+                                                  (pos_cnum 313)))
+                                                (loc_ghost false))))))
+                                           (pexp_loc
+                                            ((loc_start
+                                              ((pos_fname
+                                                generated_locations.ml)
+                                               (pos_lnum 6) (pos_bol 252)
+                                               (pos_cnum 308)))
+                                             (loc_end
+                                              ((pos_fname
+                                                generated_locations.ml)
+                                               (pos_lnum 6) (pos_bol 252)
+                                               (pos_cnum 313)))
+                                             (loc_ghost false)))
+                                           (pexp_loc_stack ())
+                                           (pexp_attributes ())))
+                                         (Nolabel
+                                          ((pexp_desc
+                                            (Pexp_constant
+                                             (Pconst_integer 1 ())))
+                                           (pexp_loc
+                                            ((loc_start
+                                              ((pos_fname
+                                                generated_locations.ml)
+                                               (pos_lnum 6) (pos_bol 252)
+                                               (pos_cnum 316)))
+                                             (loc_end
+                                              ((pos_fname
+                                                generated_locations.ml)
+                                               (pos_lnum 6) (pos_bol 252)
+                                               (pos_cnum 317)))
+                                             (loc_ghost false)))
+                                           (pexp_loc_stack ())
+                                           (pexp_attributes ()))))))
+                                      (pexp_loc
+                                       ((loc_start
+                                         ((pos_fname generated_locations.ml)
+                                          (pos_lnum 6) (pos_bol 252)
+                                          (pos_cnum 308)))
+                                        (loc_end
+                                         ((pos_fname generated_locations.ml)
+                                          (pos_lnum 6) (pos_bol 252)
+                                          (pos_cnum 317)))
+                                        (loc_ghost false)))
+                                      (pexp_loc_stack ())
+                                      (pexp_attributes ()))))
+                                   (pexp_loc
+                                    ((loc_start
+                                      ((pos_fname generated_locations.ml)
+                                       (pos_lnum 6) (pos_bol 252)
+                                       (pos_cnum 294)))
+                                     (loc_end
+                                      ((pos_fname generated_locations.ml)
+                                       (pos_lnum 6) (pos_bol 252)
+                                       (pos_cnum 318)))
+                                     (loc_ghost false)))
+                                   (pexp_loc_stack
+                                    (((loc_start
+                                       ((pos_fname generated_locations.ml)
+                                        (pos_lnum 6) (pos_bol 252)
+                                        (pos_cnum 295)))
+                                      (loc_end
+                                       ((pos_fname generated_locations.ml)
+                                        (pos_lnum 6) (pos_bol 252)
+                                        (pos_cnum 317)))
+                                      (loc_ghost false))))
+                                   (pexp_attributes ()))))))
+                              (pexp_loc
+                               ((loc_start
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 6) (pos_bol 252) (pos_cnum 285)))
+                                (loc_end
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 6) (pos_bol 252) (pos_cnum 318)))
+                                (loc_ghost false)))
+                              (pexp_loc_stack ()) (pexp_attributes ()))))
+                           (pexp_loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 6) (pos_bol 252) (pos_cnum 274)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 7) (pos_bol 320) (pos_cnum 355)))
+                             (loc_ghost false)))
+                           (pexp_loc_stack
+                            (((loc_start
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 6) (pos_bol 252) (pos_cnum 275)))
+                              (loc_end
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 6) (pos_bol 252) (pos_cnum 319)))
+                              (loc_ghost false))
+                             ((loc_start
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 6) (pos_bol 252) (pos_cnum 276)))
+                              (loc_end
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 6) (pos_bol 252) (pos_cnum 318)))
+                              (loc_ghost false))))
+                           (pexp_attributes
+                            (((attr_name
+                               ((txt reason.preserve_braces)
+                                (loc
+                                 ((loc_start
+                                   ((pos_fname generated_locations.ml)
+                                    (pos_lnum 7) (pos_bol 320)
+                                    (pos_cnum 330)))
+                                  (loc_end
+                                   ((pos_fname generated_locations.ml)
+                                    (pos_lnum 7) (pos_bol 320)
+                                    (pos_cnum 352)))
+                                  (loc_ghost false)))))
+                              (attr_payload (PStr ()))
+                              (attr_loc
+                               ((loc_start
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 7) (pos_bol 320) (pos_cnum 328)))
+                                (loc_end
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 7) (pos_bol 320) (pos_cnum 354)))
+                                (loc_ghost false))))))))
+                         (Nolabel
+                          ((pexp_desc
+                            (Pexp_construct
+                             ((txt (Lident "()"))
+                              (loc
+                               ((loc_start
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 7) (pos_bol 320) (pos_cnum 387)))
+                                (loc_end
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 7) (pos_bol 320) (pos_cnum 389)))
+                                (loc_ghost false))))
+                             ()))
+                           (pexp_loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 7) (pos_bol 320) (pos_cnum 387)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 7) (pos_bol 320) (pos_cnum 389)))
+                             (loc_ghost false)))
+                           (pexp_loc_stack ()) (pexp_attributes ()))))))
+                      (pexp_loc
+                       ((loc_start
+                         ((pos_fname generated_locations.ml) (pos_lnum 6)
+                          (pos_bol 252) (pos_cnum 256)))
+                        (loc_end
+                         ((pos_fname generated_locations.ml) (pos_lnum 8)
+                          (pos_bol 391) (pos_cnum 405)))
+                        (loc_ghost false)))
+                      (pexp_loc_stack ()) (pexp_attributes ()))))))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname generated_locations.ml) (pos_lnum 6)
+                     (pos_bol 252) (pos_cnum 256)))
+                   (loc_end
+                    ((pos_fname generated_locations.ml) (pos_lnum 8)
+                     (pos_bol 391) (pos_cnum 405)))
+                   (loc_ghost false)))
+                 (pexp_loc_stack ()) (pexp_attributes ()))))
+              (pexp_loc
+               ((loc_start
+                 ((pos_fname generated_locations.ml) (pos_lnum 5)
+                  (pos_bol 181) (pos_cnum 183)))
+                (loc_end
+                 ((pos_fname generated_locations.ml) (pos_lnum 9)
+                  (pos_bol 407) (pos_cnum 436)))
+                (loc_ghost false)))
+              (pexp_loc_stack
+               (((loc_start
+                  ((pos_fname generated_locations.ml) (pos_lnum 5)
+                   (pos_bol 181) (pos_cnum 184)))
+                 (loc_end
+                  ((pos_fname generated_locations.ml) (pos_lnum 8)
+                   (pos_bol 391) (pos_cnum 406)))
+                 (loc_ghost false))
+                ((loc_start
+                  ((pos_fname generated_locations.ml) (pos_lnum 5)
+                   (pos_bol 181) (pos_cnum 185)))
+                 (loc_end
+                  ((pos_fname generated_locations.ml) (pos_lnum 8)
+                   (pos_bol 391) (pos_cnum 405)))
+                 (loc_ghost false))))
+              (pexp_attributes
+               (((attr_name
+                  ((txt reason.preserve_braces)
+                   (loc
+                    ((loc_start
+                      ((pos_fname generated_locations.ml) (pos_lnum 9)
+                       (pos_bol 407) (pos_cnum 411)))
+                     (loc_end
+                      ((pos_fname generated_locations.ml) (pos_lnum 9)
+                       (pos_bol 407) (pos_cnum 433)))
+                     (loc_ghost false)))))
+                 (attr_payload (PStr ()))
+                 (attr_loc
+                  ((loc_start
+                    ((pos_fname generated_locations.ml) (pos_lnum 9)
+                     (pos_bol 407) (pos_cnum 409)))
+                   (loc_end
+                    ((pos_fname generated_locations.ml) (pos_lnum 9)
+                     (pos_bol 407) (pos_cnum 435)))
+                   (loc_ghost false)))))))))
+           (pexp_loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+               (pos_cnum 176)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+               (pos_cnum 436)))
+             (loc_ghost true)))
+           (pexp_loc_stack ()) (pexp_attributes ()))))
+        (pexp_loc
+         ((loc_start
+           ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+            (pos_cnum 156)))
+          (loc_end
+           ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+            (pos_cnum 436)))
+          (loc_ghost true)))
+        (pexp_loc_stack ())
+        (pexp_attributes
+         (((attr_name
+            ((txt warning)
+             (loc
+              ((loc_start
+                ((pos_fname generated_locations.ml) (pos_lnum 4)
+                 (pos_bol 147) (pos_cnum 147)))
+               (loc_end
+                ((pos_fname generated_locations.ml) (pos_lnum 9)
+                 (pos_bol 407) (pos_cnum 456)))
+               (loc_ghost true)))))
+           (attr_payload
+            (PStr
+             (((pstr_desc
+                (Pstr_eval
+                 ((pexp_desc
+                   (Pexp_constant
+                    (Pconst_string -16
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true))
+                     ())))
+                  (pexp_loc
+                   ((loc_start
+                     ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                      (pos_cnum -1)))
+                    (loc_end
+                     ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                      (pos_cnum -1)))
+                    (loc_ghost true)))
+                  (pexp_loc_stack ()) (pexp_attributes ()))
+                 ()))
+               (pstr_loc
+                ((loc_start
+                  ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                 (loc_end
+                  ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                 (loc_ghost true)))))))
+           (attr_loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+               (pos_cnum 147)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+               (pos_cnum 456)))
+             (loc_ghost true))))))))
+      (pvb_attributes ())
+      (pvb_loc
+       ((loc_start
+         ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+          (pos_cnum 147)))
+        (loc_end
+         ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+          (pos_cnum 456)))
+        (loc_ghost false)))))))
+  (pstr_loc
+   ((loc_start
+     ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+      (pos_cnum 147)))
+    (loc_end
+     ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+      (pos_cnum 456)))
+    (loc_ghost false))))
+ ((pstr_desc
+   (Pstr_value Nonrecursive
+    (((pvb_pat
+       ((ppat_desc
+         (Ppat_var
+          ((txt make)
+           (loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+               (pos_cnum 151)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+               (pos_cnum 155)))
+             (loc_ghost false))))))
+        (ppat_loc
+         ((loc_start
+           ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+            (pos_cnum 151)))
+          (loc_end
+           ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+            (pos_cnum 155)))
+          (loc_ghost false)))
+        (ppat_loc_stack ()) (ppat_attributes ())))
+      (pvb_expr
+       ((pexp_desc
+         (Pexp_let Nonrecursive
+          (((pvb_pat
+             ((ppat_desc
+               (Ppat_var
+                ((txt Generated_locations)
+                 (loc
+                  ((loc_start
+                    ((pos_fname generated_locations.ml) (pos_lnum 4)
+                     (pos_bol 147) (pos_cnum 147)))
+                   (loc_end
+                    ((pos_fname generated_locations.ml) (pos_lnum 9)
+                     (pos_bol 407) (pos_cnum 456)))
+                   (loc_ghost true))))))
+              (ppat_loc
+               ((loc_start
+                 ((pos_fname generated_locations.ml) (pos_lnum 4)
+                  (pos_bol 147) (pos_cnum 147)))
+                (loc_end
+                 ((pos_fname generated_locations.ml) (pos_lnum 9)
+                  (pos_bol 407) (pos_cnum 456)))
+                (loc_ghost true)))
+              (ppat_loc_stack ()) (ppat_attributes ())))
+            (pvb_expr
+             ((pexp_desc
+               (Pexp_fun Nolabel ()
+                ((ppat_desc
+                  (Ppat_constraint
+                   ((ppat_desc
+                     (Ppat_var
+                      ((txt Props)
+                       (loc
+                        ((loc_start
+                          ((pos_fname generated_locations.ml) (pos_lnum 4)
+                           (pos_bol 147) (pos_cnum 147)))
+                         (loc_end
+                          ((pos_fname generated_locations.ml) (pos_lnum 9)
+                           (pos_bol 407) (pos_cnum 456)))
+                         (loc_ghost true))))))
+                    (ppat_loc
+                     ((loc_start
+                       ((pos_fname generated_locations.ml) (pos_lnum 4)
+                        (pos_bol 147) (pos_cnum 147)))
+                      (loc_end
+                       ((pos_fname generated_locations.ml) (pos_lnum 9)
+                        (pos_bol 407) (pos_cnum 456)))
+                      (loc_ghost true)))
+                    (ppat_loc_stack ()) (ppat_attributes ()))
+                   ((ptyp_desc
+                     (Ptyp_constr
+                      ((txt (Ldot (Lident Js) t))
+                       (loc
+                        ((loc_start
+                          ((pos_fname generated_locations.ml) (pos_lnum 4)
+                           (pos_bol 147) (pos_cnum 147)))
+                         (loc_end
+                          ((pos_fname generated_locations.ml) (pos_lnum 9)
+                           (pos_bol 407) (pos_cnum 456)))
+                         (loc_ghost true))))
+                      (((ptyp_desc
+                         (Ptyp_object
+                          (((pof_desc
+                             (Otag
+                              ((txt initialValue)
+                               (loc
+                                ((loc_start
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 4) (pos_bol 147) (pos_cnum 147)))
+                                 (loc_end
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 9) (pos_bol 407) (pos_cnum 456)))
+                                 (loc_ghost true))))
+                              ((ptyp_desc
+                                (Ptyp_constr
+                                 ((txt (Lident option))
+                                  (loc
+                                   ((loc_start
+                                     ((pos_fname generated_locations.ml)
+                                      (pos_lnum 4) (pos_bol 147)
+                                      (pos_cnum 158)))
+                                    (loc_end
+                                     ((pos_fname generated_locations.ml)
+                                      (pos_lnum 4) (pos_bol 147)
+                                      (pos_cnum 170)))
+                                    (loc_ghost false))))
+                                 (((ptyp_desc (Ptyp_var initialValue))
+                                   (ptyp_loc
+                                    ((loc_start
+                                      ((pos_fname generated_locations.ml)
+                                       (pos_lnum 4) (pos_bol 147)
+                                       (pos_cnum 158)))
+                                     (loc_end
+                                      ((pos_fname generated_locations.ml)
+                                       (pos_lnum 4) (pos_bol 147)
+                                       (pos_cnum 170)))
+                                     (loc_ghost false)))
+                                   (ptyp_loc_stack ()) (ptyp_attributes ())))))
+                               (ptyp_loc
+                                ((loc_start
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                                 (loc_end
+                                  ((pos_fname generated_locations.ml)
+                                   (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                                 (loc_ghost false)))
+                               (ptyp_loc_stack ()) (ptyp_attributes ()))))
+                            (pof_loc
+                             ((loc_start
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 4) (pos_bol 147) (pos_cnum 147)))
+                              (loc_end
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 9) (pos_bol 407) (pos_cnum 456)))
+                              (loc_ghost true)))
+                            (pof_attributes ())))
+                          Closed))
+                        (ptyp_loc
+                         ((loc_start
+                           ((pos_fname generated_locations.ml) (pos_lnum 4)
+                            (pos_bol 147) (pos_cnum 147)))
+                          (loc_end
+                           ((pos_fname generated_locations.ml) (pos_lnum 9)
+                            (pos_bol 407) (pos_cnum 456)))
+                          (loc_ghost true)))
+                        (ptyp_loc_stack ()) (ptyp_attributes ())))))
+                    (ptyp_loc
+                     ((loc_start
+                       ((pos_fname generated_locations.ml) (pos_lnum 4)
+                        (pos_bol 147) (pos_cnum 147)))
+                      (loc_end
+                       ((pos_fname generated_locations.ml) (pos_lnum 9)
+                        (pos_bol 407) (pos_cnum 456)))
+                      (loc_ghost true)))
+                    (ptyp_loc_stack ()) (ptyp_attributes ()))))
+                 (ppat_loc
+                  ((loc_start
+                    ((pos_fname generated_locations.ml) (pos_lnum 4)
+                     (pos_bol 147) (pos_cnum 147)))
+                   (loc_end
+                    ((pos_fname generated_locations.ml) (pos_lnum 9)
+                     (pos_bol 407) (pos_cnum 456)))
+                   (loc_ghost true)))
+                 (ppat_loc_stack ()) (ppat_attributes ()))
+                ((pexp_desc
+                  (Pexp_apply
+                   ((pexp_desc
+                     (Pexp_ident
+                      ((txt (Lident make))
+                       (loc
+                        ((loc_start
+                          ((pos_fname generated_locations.ml) (pos_lnum 4)
+                           (pos_bol 147) (pos_cnum 147)))
+                         (loc_end
+                          ((pos_fname generated_locations.ml) (pos_lnum 9)
+                           (pos_bol 407) (pos_cnum 456)))
+                         (loc_ghost true))))))
+                    (pexp_loc
+                     ((loc_start
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_end
+                       ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                        (pos_cnum -1)))
+                      (loc_ghost true)))
+                    (pexp_loc_stack ()) (pexp_attributes ()))
+                   (((Optional initialValue)
+                     ((pexp_desc
+                       (Pexp_apply
+                        ((pexp_desc
+                          (Pexp_ident
+                           ((txt (Lident ##))
+                            (loc
+                             ((loc_start
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                              (loc_end
+                               ((pos_fname generated_locations.ml)
+                                (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                              (loc_ghost false))))))
+                         (pexp_loc
+                          ((loc_start
+                            ((pos_fname generated_locations.ml) (pos_lnum 4)
+                             (pos_bol 147) (pos_cnum 158)))
+                           (loc_end
+                            ((pos_fname generated_locations.ml) (pos_lnum 4)
+                             (pos_bol 147) (pos_cnum 170)))
+                           (loc_ghost false)))
+                         (pexp_loc_stack ()) (pexp_attributes ()))
+                        ((Nolabel
+                          ((pexp_desc
+                            (Pexp_ident
+                             ((txt (Lident Props))
+                              (loc
+                               ((loc_start
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                                (loc_end
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                                (loc_ghost false))))))
+                           (pexp_loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                             (loc_ghost false)))
+                           (pexp_loc_stack ()) (pexp_attributes ())))
+                         (Nolabel
+                          ((pexp_desc
+                            (Pexp_ident
+                             ((txt (Lident initialValue))
+                              (loc
+                               ((loc_start
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                                (loc_end
+                                 ((pos_fname generated_locations.ml)
+                                  (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                                (loc_ghost false))))))
+                           (pexp_loc
+                            ((loc_start
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 4) (pos_bol 147) (pos_cnum 158)))
+                             (loc_end
+                              ((pos_fname generated_locations.ml)
+                               (pos_lnum 4) (pos_bol 147) (pos_cnum 170)))
+                             (loc_ghost false)))
+                           (pexp_loc_stack ()) (pexp_attributes ()))))))
+                      (pexp_loc
+                       ((loc_start
+                         ((pos_fname generated_locations.ml) (pos_lnum 4)
+                          (pos_bol 147) (pos_cnum 158)))
+                        (loc_end
+                         ((pos_fname generated_locations.ml) (pos_lnum 4)
+                          (pos_bol 147) (pos_cnum 170)))
+                        (loc_ghost false)))
+                      (pexp_loc_stack ()) (pexp_attributes ())))
+                    (Nolabel
+                     ((pexp_desc
+                       (Pexp_construct
+                        ((txt (Lident "()"))
+                         (loc
+                          ((loc_start
+                            ((pos_fname generated_locations.ml) (pos_lnum 4)
+                             (pos_bol 147) (pos_cnum 147)))
+                           (loc_end
+                            ((pos_fname generated_locations.ml) (pos_lnum 9)
+                             (pos_bol 407) (pos_cnum 456)))
+                           (loc_ghost true))))
+                        ()))
+                      (pexp_loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true)))
+                      (pexp_loc_stack ()) (pexp_attributes ()))))))
+                 (pexp_loc
+                  ((loc_start
+                    ((pos_fname generated_locations.ml) (pos_lnum 4)
+                     (pos_bol 147) (pos_cnum 147)))
+                   (loc_end
+                    ((pos_fname generated_locations.ml) (pos_lnum 9)
+                     (pos_bol 407) (pos_cnum 456)))
+                   (loc_ghost true)))
+                 (pexp_loc_stack ()) (pexp_attributes ()))))
+              (pexp_loc
+               ((loc_start
+                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                (loc_end
+                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                (loc_ghost true)))
+              (pexp_loc_stack ()) (pexp_attributes ())))
+            (pvb_attributes
+             (((attr_name
+                ((txt merlin.hide)
+                 (loc
+                  ((loc_start
+                    ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_end
+                    ((pos_fname _none_) (pos_lnum 1) (pos_bol 0)
+                     (pos_cnum -1)))
+                   (loc_ghost true)))))
+               (attr_payload (PStr ()))
+               (attr_loc
+                ((loc_start
+                  ((pos_fname _none_) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+                 (loc_end
+                  ((pos_fname _none_) (pos_lnum 1) (pos_bol 0) (pos_cnum -1)))
+                 (loc_ghost true))))))
+            (pvb_loc
+             ((loc_start
+               ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+                (pos_cnum 147)))
+              (loc_end
+               ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+                (pos_cnum 456)))
+              (loc_ghost true)))))
+          ((pexp_desc
+            (Pexp_ident
+             ((txt (Lident Generated_locations))
+              (loc
+               ((loc_start
+                 ((pos_fname generated_locations.ml) (pos_lnum 4)
+                  (pos_bol 147) (pos_cnum 147)))
+                (loc_end
+                 ((pos_fname generated_locations.ml) (pos_lnum 9)
+                  (pos_bol 407) (pos_cnum 456)))
+                (loc_ghost true))))))
+           (pexp_loc
+            ((loc_start
+              ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+               (pos_cnum 147)))
+             (loc_end
+              ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+               (pos_cnum 456)))
+             (loc_ghost true)))
+           (pexp_loc_stack ()) (pexp_attributes ()))))
+        (pexp_loc
+         ((loc_start
+           ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+          (loc_end
+           ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+          (loc_ghost true)))
+        (pexp_loc_stack ()) (pexp_attributes ())))
+      (pvb_attributes ())
+      (pvb_loc
+       ((loc_start
+         ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+          (pos_cnum 147)))
+        (loc_end
+         ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+          (pos_cnum 456)))
+        (loc_ghost false)))))))
+  (pstr_loc
+   ((loc_start
+     ((pos_fname generated_locations.ml) (pos_lnum 4) (pos_bol 147)
+      (pos_cnum 147)))
+    (loc_end
+     ((pos_fname generated_locations.ml) (pos_lnum 9) (pos_bol 407)
+      (pos_cnum 456)))
     (loc_ghost true)))))


### PR DESCRIPTION
Fixes #429.

The fix is kind of similar to the one used [in jsoo-react](https://github.com/ml-in-barcelona/jsoo-react/pull/134), but adapted to the current state of this ppx.

It is based on these ideas:

- Avoid using `Location.none`, especially on intermediate ast nodes. Using `Location.none` completely disables merlin ability to find back an ast node for a given location
- Try to build locations in a consistent way with the ast tree. for what "consistent" means, check [this explanation](https://github.com/ocaml/ocaml/pull/8987) by trefis
- Hide subparts of the ast with `merlin.hide` (when we want to hide whole subtree) or `loc_ghost` (for just one node)
- Use `-dparsetree` in tests to both check which locations are set to none or inconsistent, and see how changes in ppx affect the result

~The PR adds some tests using `-dparsetree` to see how changes in the ppx affect locations in real code. Unfortunately I am not able to set up a test that involves merlin as well, so what I do for testing, besides looking at the output in the newly added `ppx/test/output_locations.expected`, is:~
~- Change `reactjs_jsx_ppx.ml`~
~- `make build`~
~- Hover over elements in `test/React__test.re`~

~This is a quite fast workflow.~ Edit: tests using merlin directly are being added in #749.

Here are some gifs to show comparison between `main` and this branch.

### Case 1: Component in `React__test.re`

| `main`  | This branch |
| ------------- | ------------- |
| ![case-1-ppx-locs-before](https://github.com/reasonml/reason-react/assets/220424/b4a9e3d6-bf19-4212-896f-7e2bf6c202cd) | ![case-1-ppx-locs-after](https://github.com/reasonml/reason-react/assets/220424/90ca1df6-81c7-4009-b696-269950fb4741) |

### Case 2: The component reported in original issue #429

| `main`  | This branch |
| ------------- | ------------- |
| ![case-2-ppx-locs-before](https://github.com/reasonml/reason-react/assets/220424/3d780d83-6ba6-49ff-8bff-3e51ec323415) | ![case-2-ppx-locs-after](https://github.com/reasonml/reason-react/assets/220424/85b1cf87-4da7-48f9-8953-ad423eb22830) |