### PR TITLE
ppx: add merlin tests

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -50,6 +50,10 @@
   (ocaml
    (>= 4.13.0))
   (reason
-   (or (>= 3.6.0) (and (= 3.9.0 :with-test))))
+   (or
+    (>= 3.6.0)
+    (and
+     (= 3.9.0 :with-test))))
   (ppxlib
-   (>= 0.28.0))))
+   (>= 0.28.0))
+  (merlin :with-test)))

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "reason-react",
       "version": "0.11.0",
       "license": "MIT",
       "devDependencies": {

--- a/ppx/test/merlin/dune
+++ b/ppx/test/merlin/dune
@@ -1,0 +1,3 @@
+(cram
+ (package reason-react-ppx)
+ (deps %{bin:dune} %{bin:jq} %{bin:ocamlmerlin}))

--- a/ppx/test/merlin/issue-429.t/component.re
+++ b/ppx/test/merlin/issue-429.t/component.re
@@ -1,5 +1,4 @@
 open React;
-open! ReasonReact;
 
 type state = {
   count: int,

--- a/ppx/test/merlin/issue-429.t/component.re
+++ b/ppx/test/merlin/issue-429.t/component.re
@@ -1,0 +1,37 @@
+open React;
+open! ReasonReact;
+
+type state = {
+  count: int,
+  show: bool,
+};
+
+type action =
+  | Click(int)
+  | Toggle;
+
+let initialState = {count: 0, show: true};
+
+[@react.component]
+let make = (~greeting) => {
+  let (state, dispatch) =
+    useReducer(
+      (state, action) =>
+        switch (action) {
+        | Click(points) => {...state, count: state.count + points}
+        | Toggle => {...state, show: !state.show}
+        },
+      initialState,
+    );
+
+  let message =
+    "You've clicked this " ++ string_of_int(state.count) ++ " times(s)";
+
+  <div>
+    <button onClick={_ => dispatch(Click(10))}> {string(message)} </button>
+    <button onClick={_ => dispatch(Toggle)}>
+      {string("Toggle greeting")}
+    </button>
+    {state.show ? string(greeting) : null}
+  </div>;
+};

--- a/ppx/test/merlin/issue-429.t/run.t
+++ b/ppx/test/merlin/issue-429.t/run.t
@@ -1,7 +1,7 @@
 Test some locations in reason-react components
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.9)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/ppx/test/merlin/issue-429.t/run.t
+++ b/ppx/test/merlin/issue-429.t/run.t
@@ -20,61 +20,61 @@ Let's test hovering over parts of the component
 
 `greeting` prop
 
-  $ ocamlmerlin single type-enclosing -position 16:19 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 15:19 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 `state` in `let (state, dispatch)`
 
-  $ ocamlmerlin single type-enclosing -position 17:11 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 16:11 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 `dispatch` in `let (state, dispatch)`
 
-  $ ocamlmerlin single type-enclosing -position 17:19 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 16:19 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 `message` in `let message`
 
-  $ ocamlmerlin single type-enclosing -position 27:11 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 26:11 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 Wrapping `div`
 
-  $ ocamlmerlin single type-enclosing -position 30:5 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 29:5 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 First child `button`
 
-  $ ocamlmerlin single type-enclosing -position 31:9 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 30:9 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 First child `onClick` prop
 
-  $ ocamlmerlin single type-enclosing -position 31:17 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 30:17 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 First child `onClick` callback argument (event)
 
-  $ ocamlmerlin single type-enclosing -position 31:23 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 30:23 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 First child `onClick` prop `dispatch`
 
-  $ ocamlmerlin single type-enclosing -position 31:30 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 30:30 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 First child `onClick` prop `Click`
 
-  $ ocamlmerlin single type-enclosing -position 31:39 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 30:39 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   [
     {
@@ -93,7 +93,7 @@ First child `onClick` prop `Click`
 
 First child `string`
 
-  $ ocamlmerlin single type-enclosing -position 31:53 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 30:53 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   [
     {
@@ -112,25 +112,25 @@ First child `string`
 
 First child `message`
 
-  $ ocamlmerlin single type-enclosing -position 31:62 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 30:62 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 Third child `state`
 
-  $ ocamlmerlin single type-enclosing -position 35:9 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 34:9 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 Third child `show` in `state.show`
 
-  $ ocamlmerlin single type-enclosing -position 35:15 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 34:15 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 Third child `string`
 
-  $ ocamlmerlin single type-enclosing -position 35:22 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 34:22 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   [
     {
@@ -149,13 +149,13 @@ Third child `string`
 
 Third child `greeting`
 
-  $ ocamlmerlin single type-enclosing -position 35:30 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 34:30 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   []
 
 Third child `null`
 
-  $ ocamlmerlin single type-enclosing -position 35:40 -verbosity 0 \
+  $ ocamlmerlin single type-enclosing -position 34:40 -verbosity 0 \
   > -filename component.re < component.re | jq '.value'
   [
     {

--- a/ppx/test/merlin/issue-429.t/run.t
+++ b/ppx/test/merlin/issue-429.t/run.t
@@ -1,0 +1,173 @@
+Test some locations in reason-react components
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.9)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (melange.emit
+  >  (alias foo)
+  >  (target foo)
+  >  (libraries reason-react)
+  >  (preprocess
+  >   (pps melange.ppx reason-react-ppx)))
+  > EOF
+
+  $ dune build
+
+Let's test hovering over parts of the component
+
+`greeting` prop
+
+  $ ocamlmerlin single type-enclosing -position 16:19 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+`state` in `let (state, dispatch)`
+
+  $ ocamlmerlin single type-enclosing -position 17:11 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+`dispatch` in `let (state, dispatch)`
+
+  $ ocamlmerlin single type-enclosing -position 17:19 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+`message` in `let message`
+
+  $ ocamlmerlin single type-enclosing -position 27:11 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+Wrapping `div`
+
+  $ ocamlmerlin single type-enclosing -position 30:5 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+First child `button`
+
+  $ ocamlmerlin single type-enclosing -position 31:9 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+First child `onClick` prop
+
+  $ ocamlmerlin single type-enclosing -position 31:17 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+First child `onClick` callback argument (event)
+
+  $ ocamlmerlin single type-enclosing -position 31:23 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+First child `onClick` prop `dispatch`
+
+  $ ocamlmerlin single type-enclosing -position 31:30 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+First child `onClick` prop `Click`
+
+  $ ocamlmerlin single type-enclosing -position 31:39 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 31,
+        "col": 35
+      },
+      "end": {
+        "line": 31,
+        "col": 40
+      },
+      "type": "((int)) => action",
+      "tail": "no"
+    }
+  ]
+
+First child `string`
+
+  $ ocamlmerlin single type-enclosing -position 31:53 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 31,
+        "col": 49
+      },
+      "end": {
+        "line": 31,
+        "col": 55
+      },
+      "type": "string => element",
+      "tail": "no"
+    }
+  ]
+
+First child `message`
+
+  $ ocamlmerlin single type-enclosing -position 31:62 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+Third child `state`
+
+  $ ocamlmerlin single type-enclosing -position 35:9 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+Third child `show` in `state.show`
+
+  $ ocamlmerlin single type-enclosing -position 35:15 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+Third child `string`
+
+  $ ocamlmerlin single type-enclosing -position 35:22 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 35,
+        "col": 18
+      },
+      "end": {
+        "line": 35,
+        "col": 24
+      },
+      "type": "string => element",
+      "tail": "no"
+    }
+  ]
+
+Third child `greeting`
+
+  $ ocamlmerlin single type-enclosing -position 35:30 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  []
+
+Third child `null`
+
+  $ ocamlmerlin single type-enclosing -position 35:40 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 35,
+        "col": 37
+      },
+      "end": {
+        "line": 35,
+        "col": 41
+      },
+      "type": "element",
+      "tail": "no"
+    }
+  ]

--- a/ppx/test/merlin/issue-429.t/run.t
+++ b/ppx/test/merlin/issue-429.t/run.t
@@ -79,11 +79,11 @@ First child `onClick` prop `Click`
   [
     {
       "start": {
-        "line": 31,
+        "line": 30,
         "col": 35
       },
       "end": {
-        "line": 31,
+        "line": 30,
         "col": 40
       },
       "type": "((int)) => action",
@@ -98,11 +98,11 @@ First child `string`
   [
     {
       "start": {
-        "line": 31,
+        "line": 30,
         "col": 49
       },
       "end": {
-        "line": 31,
+        "line": 30,
         "col": 55
       },
       "type": "string => element",
@@ -135,11 +135,11 @@ Third child `string`
   [
     {
       "start": {
-        "line": 35,
+        "line": 34,
         "col": 18
       },
       "end": {
-        "line": 35,
+        "line": 34,
         "col": 24
       },
       "type": "string => element",
@@ -160,11 +160,11 @@ Third child `null`
   [
     {
       "start": {
-        "line": 35,
+        "line": 34,
         "col": 37
       },
       "end": {
-        "line": 35,
+        "line": 34,
         "col": 41
       },
       "type": "element",

--- a/ppx/test/merlin/simple.t/component.re
+++ b/ppx/test/merlin/simple.t/component.re
@@ -1,0 +1,10 @@
+module DummyStatefulComponent = {
+  [@react.component]
+  let make = (~initialValue=0, ()) => {
+    let (value, setValue) = React.useState(() => initialValue);
+
+    <button onClick={_ => setValue(value => value + 1)}>
+      value->React.int
+    </button>;
+  };
+};

--- a/ppx/test/merlin/simple.t/run.t
+++ b/ppx/test/merlin/simple.t/run.t
@@ -1,0 +1,418 @@
+Test some locations in reason-react components
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.9)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (melange.emit
+  >  (alias foo)
+  >  (target foo)
+  >  (libraries reason-react)
+  >  (preprocess
+  >   (pps melange.ppx reason-react-ppx)))
+  > EOF
+
+  $ dune build
+
+Let's test hovering over parts of the component
+
+`<button`
+
+  $ ocamlmerlin single type-enclosing -position 6:8 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: (~initialValue: int=?, unit) => React.element;\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 0
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    }
+  ]
+
+`onClick` prop
+
+  $ ocamlmerlin single type-enclosing -position 6:17 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: (~initialValue: int=?, unit) => React.element;\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 0
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    }
+  ]
+
+`onClick` callback argument (the event)
+
+  $ ocamlmerlin single type-enclosing -position 6:23 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: (~initialValue: int=?, unit) => React.element;\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 0
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    }
+  ]
+
+`setValue`
+
+  $ ocamlmerlin single type-enclosing -position 6:29 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: (~initialValue: int=?, unit) => React.element;\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 0
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    }
+  ]
+
+`setValue` callback param
+
+  $ ocamlmerlin single type-enclosing -position 6:39 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: (~initialValue: int=?, unit) => React.element;\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 0
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    }
+  ]
+
+`setValue` callback body
+
+  $ ocamlmerlin single type-enclosing -position 6:47 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: (~initialValue: int=?, unit) => React.element;\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 0
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    }
+  ]
+
+`value` in `value->React.int`
+
+  $ ocamlmerlin single type-enclosing -position 7:9 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: (~initialValue: int=?, unit) => React.element;\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 0
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    }
+  ]
+
+`int` in `value->React.int`
+
+  $ ocamlmerlin single type-enclosing -position 7:22 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 7,
+        "col": 13
+      },
+      "end": {
+        "line": 7,
+        "col": 22
+      },
+      "type": "int => React.element",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: (~initialValue: int=?, unit) => React.element;\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 0
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    }
+  ]
+
+Closing `</button>`
+
+  $ ocamlmerlin single type-enclosing -position 8:10 -verbosity 0 \
+  > -filename component.re < component.re | jq '.value'
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: (~initialValue: int=?, unit) => React.element;\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 32
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 1,
+        "col": 0
+      },
+      "end": {
+        "line": 10,
+        "col": 1
+      },
+      "type": "{\n  external makeProps:\n    (~initialValue: 'initialValue=?, ~key: string=?, unit) =>\n    {. initialValue: option('initialValue)} = \"\"\n    \"����\u0000\u0000\u0000!\u0000\u0000\u0000\u000b\u0000\u0000\u0000!\u0000\u0000\u0000\u001f���A�,initialValue@��A�#key@��@@@\";\n  let make: {. initialValue: option(int)} => React.element;\n}",
+      "tail": "no"
+    }
+  ]

--- a/ppx/test/merlin/simple.t/run.t
+++ b/ppx/test/merlin/simple.t/run.t
@@ -1,7 +1,7 @@
 Test some locations in reason-react components
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.9)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/reason-react-ppx.opam
+++ b/reason-react-ppx.opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml" {>= "4.13.0"}
   "reason" {>= "3.6.0" | "3.9.0" = with-test}
   "ppxlib" {>= "0.28.0"}
+  "merlin" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/reason-react.opam
+++ b/reason-react.opam
@@ -20,8 +20,8 @@ depends: [
   "dune" {>= "3.8"}
   "ocaml" {>= "4.13.0"}
   "melange" {>= "1.0.0"}
-  "reason" {>= "3.6.0"}
   "reason-react-ppx"
+  "reason" {>= "3.6.0"}
   "ocaml-lsp-server" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Related to #748.

This PR adds a test suite leveraging Dune cram tests where `ocamlmerlin` is called directly to gather type information by sending some locations in reason-react components.

This approach is much less noisy than the one with `-dparsetree` originally used in #748. Ideally this PR should be merged before that one, so we can evaluate the changes after the location improvements over there.