### PR TITLE
test: add react.fragment with key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,9 @@ transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-tr
 * Add `suppressHydrationWarning` to supported props (@davesnx in
 [#721](https://github.com/reasonml/reason-react/pull/721))
 * Rename `reactjs-jsx-ppx` to `reason-react-ppx` ([@davesnx in #732](https://github.com/reasonml/reason-react/pull/732))
-- Fix locations for lower and uppercase components so that merlin / editor
+* Fix locations for lower and uppercase components so that merlin / editor
   integration can get type defs on hover ([@jchavarri in #748](https://github.com/reasonml/reason-react/pull/748))
+* Refine types for `key` attributes ([@anmonteiro in #750](https://github.com/reasonml/reason-react/pull/750))
 
 # 0.11.0
 

--- a/ppx/test/output.expected
+++ b/ppx/test/output.expected
@@ -80,7 +80,9 @@ let lower_children_nested =
                                                                     ReactRouter.push
                                                                     e.path)
                                                                     ())) ())
-                                                                    e.path)))
+                                                                    ~key:(
+                                                                    e.path)
+                                                                    ())))
                                                              |> React.list)
                                                            ()))
                                            ~className:"menu" ()))|])

--- a/src/React.re
+++ b/src/React.re
@@ -29,7 +29,9 @@ external createElementVariadic:
   "createElement";
 
 [@bs.module "react/jsx-runtime"]
-external jsxKeyed: (component('props), 'props, string) => element = "jsx";
+external jsxKeyed:
+  (component('props), 'props, ~key: string=?, unit) => element =
+  "jsx";
 
 [@bs.module "react/jsx-runtime"]
 external jsx: (component('props), 'props) => element = "jsx";
@@ -38,7 +40,9 @@ external jsx: (component('props), 'props) => element = "jsx";
 external jsxs: (component('props), 'props) => element = "jsxs";
 
 [@bs.module "react/jsx-runtime"]
-external jsxsKeyed: (component('props), 'props, string) => element = "jsxs";
+external jsxsKeyed:
+  (component('props), 'props, ~key: string=?, unit) => element =
+  "jsxs";
 
 [@bs.module "react/jsx-runtime"] external jsxFragment: 'element = "Fragment";
 
@@ -122,16 +126,15 @@ external memoCustomCompareProps:
 
 module Fragment = {
   [@bs.obj]
-  external makeProps:
-    (~children: element, ~key: 'key=?, unit) => {. "children": element};
+  external makeProps: (~children: element, unit) => {. "children": element};
+
   [@bs.module "react"]
   external make: component({. "children": element}) = "Fragment";
 };
 
 module StrictMode = {
   [@bs.obj]
-  external makeProps:
-    (~children: element, ~key: 'key=?, unit) => {. "children": element};
+  external makeProps: (~children: element, unit) => {. "children": element};
   [@bs.module "react"]
   external make: component({. "children": element}) = "StrictMode";
 };
@@ -139,7 +142,7 @@ module StrictMode = {
 module Suspense = {
   [@bs.obj]
   external makeProps:
-    (~children: element=?, ~fallback: element=?, ~key: 'key=?, unit) =>
+    (~children: element=?, ~fallback: element=?, unit) =>
     {
       .
       "children": option(element),

--- a/src/ReactDOM.re
+++ b/src/ReactDOM.re
@@ -2136,7 +2136,8 @@ external createDOMElementVariadic:
   "createElement";
 
 [@bs.module "react/jsx-runtime"]
-external jsxKeyed: (string, domProps, string) => React.element = "jsx";
+external jsxKeyed: (string, domProps, ~key: string=?, unit) => React.element =
+  "jsx";
 
 [@bs.module "react/jsx-runtime"]
 external jsx: (string, domProps) => React.element = "jsx";
@@ -2145,4 +2146,5 @@ external jsx: (string, domProps) => React.element = "jsx";
 external jsxs: (string, domProps) => React.element = "jsxs";
 
 [@bs.module "react/jsx-runtime"]
-external jsxsKeyed: (string, domProps, string) => React.element = "jsxs";
+external jsxsKeyed: (string, domProps, ~key: string=?, unit) => React.element =
+  "jsxs";

--- a/test/React__test.re
+++ b/test/React__test.re
@@ -589,6 +589,27 @@ describe("React", () => {
     expect(value.contents)->toEqual("My value");
   });
 
+  test("React.Fragment with key", () => {
+    let container = getContainer(container);
+    let title = Some("foo");
+
+    act(() => {
+      ReactDOM.render(
+        <React.Fragment key=?title>
+          <div> "Child"->React.string </div>
+        </React.Fragment>,
+        container,
+      )
+    });
+
+    expect(
+      container
+      ->DOM.findBySelectorAndPartialTextContent("div", "Child")
+      ->Option.isSome,
+    )
+    ->toBe(true);
+  });
+  
   /* test("ErrorBoundary", () => {
     let container = getContainer(container);
 


### PR DESCRIPTION
It seems there's been a recent regression that involves `React.Fragment` and `key` attribute. It was possible to use `option(string)` before while now the code does not type check.