### PR TITLE
depexts: expand to react 17

### DIFF
--- a/reason-react.opam
+++ b/reason-react.opam
@@ -42,6 +42,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/reasonml/reason-react.git"
 depexts: [
-  ["react"] {npm-version = "^16.0.0"}
-  ["react-dom"] {npm-version = "^16.0.0"}
+  ["react"] {npm-version = "^16.0.0 || ^17.0.0"}
+  ["react-dom"] {npm-version = "^16.0.0 || ^17.0.0"}
 ]

--- a/reason-react.opam.template
+++ b/reason-react.opam.template
@@ -1,4 +1,4 @@
 depexts: [
-  ["react"] {npm-version = "^16.0.0"}
-  ["react-dom"] {npm-version = "^16.0.0"}
+  ["react"] {npm-version = "^16.0.0 || ^17.0.0"}
+  ["react-dom"] {npm-version = "^16.0.0 || ^17.0.0"}
 ]


### PR DESCRIPTION
follow up on #760.

In #712, react 17 is added a peer dep, makes sense to add it to `depexts`.