### PR TITLE
opam: correctly mark some deps as build

### DIFF
--- a/reason-react.opam
+++ b/reason-react.opam
@@ -17,11 +17,11 @@ homepage: "https://reasonml.github.io/reason-react"
 doc: "https://reasonml.github.io/reason-react"
 bug-reports: "https://github.com/reasonml/reason-react/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & build}
   "ocaml" {>= "4.13.0"}
-  "melange" {>= "1.0.0"}
-  "reason-react-ppx"
-  "reason" {>= "3.6.0"}
+  "melange" {>= "1.0.0" & build}
+  "reason-react-ppx" {build}
+  "reason" {>= "3.6.0" & build}
   "ocaml-lsp-server" {with-test}
   "opam-check-npm-deps" {= "1.0.0" & with-dev-setup}
   "ocamlformat" {= "0.24.0" & with-dev-setup}


### PR DESCRIPTION
Hey! Started using reason-react and noticed that some deps aren't properly marked as `build` which causes issues with nix.

cc @leojrfs