### PR TITLE
fix method attr name

### DIFF
--- a/src/React.rei
+++ b/src/React.rei
@@ -1820,7 +1820,7 @@ module DOM: {
     media: option(string), /* a valid media query */
     [@mel.optional]
     mediaGroup: option(string),
-    [@mel.optional]
+    [@mel.optional] [@mel.as "method"]
     method: option(string), /* "post" or "get" */
     [@mel.optional]
     min: option(string),

--- a/src/dOM.re
+++ b/src/dOM.re
@@ -314,7 +314,7 @@ type domProps = {
   media: option(string), /* a valid media query */
   [@mel.optional]
   mediaGroup: option(string),
-  [@mel.optional]
+  [@mel.optional] [@mel.as "method"]
   method: option(string), /* "post" or "get" */
   [@mel.optional]
   min: option(string),


### PR DESCRIPTION
Uses of the `method` attribute were producing `method_` in the js output. This adds a mel.as attribute to avoid the escaping of the keyword when converting from reason to ml.