### PR TITLE
fix: use `Js.t` explicitly now that it's abstract in Melange

### DIFF
--- a/src/ReactDOM.rei
+++ b/src/ReactDOM.rei
@@ -469,7 +469,7 @@ module Server: {
 
   type pipeableStream = {
     /* Using empty object instead of Node.stream since Melange don't provide a binding to node's Stream (https://nodejs.org/api/stream.html) */
-    pipe: {.} => unit,
+    pipe: Js.t({.}) => unit,
     abort: unit => unit,
   };
 

--- a/test/ReactTestRenderer__test.re
+++ b/test/ReactTestRenderer__test.re
@@ -12,7 +12,7 @@ describe("ReactTestRenderer", () => {
 
   test("create returns ReactTestInstance", () => {
     let component = ReactTestRenderer.create(<Tester />);
-    let keys = Js.Obj.keys(component);
+    let keys = Js.Obj.keys(Obj.magic(component): Js.t({..}));
 
     expect(keys)
     ->toEqual(


### PR DESCRIPTION
following https://github.com/melange-re/melange/pull/786, this fixes the reason-react build. `Js.t` is now abstract and can't be the same as OCaml-style objects anymore