### PR TITLE
refactor(ppx): use pattern matching that can check exhaustively

### DIFF
--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -640,8 +640,8 @@ let jsxMapper =
           pattern,
           expression ) ->
         let () =
-          match (isOptional arg, pattern, default) with
-          | true, { ppat_desc = Ppat_constraint (_, { ptyp_desc }) }, None -> (
+          match (arg, pattern, default) with
+          | Optional _, { ppat_desc = Ppat_constraint (_, { ptyp_desc }) }, None -> (
               match ptyp_desc with
               | Ptyp_constr ({ txt = Lident "option" }, [ _ ]) -> ()
               | _ ->


### PR DESCRIPTION
This removes a pattern used in the PPX that favored `when ..` guards in pattern matching rather than matching on constructors. The latter is more useful for exhaustiveness checking.