### PR TITLE
fix: remove redundant check related to option(_) labelled props

### DIFF
--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -639,29 +639,6 @@ let jsxMapper =
           default,
           pattern,
           expression ) ->
-        let () =
-          match (arg, pattern, default) with
-          | Optional _, { ppat_desc = Ppat_constraint (_, { ptyp_desc }) }, None -> (
-              match ptyp_desc with
-              | Ptyp_constr ({ txt = Lident "option" }, [ _ ]) -> ()
-              | _ ->
-                  let currentType =
-                    match ptyp_desc with
-                    | Ptyp_constr ({ txt }, []) ->
-                        String.concat "." (Longident.flatten_exn txt)
-                    | Ptyp_constr ({ txt }, _innerTypeArgs) ->
-                        String.concat "." (Longident.flatten_exn txt) ^ "(...)"
-                    | _ -> "..."
-                  in
-                  Ocaml_common.Location.prerr_warning pattern.ppat_loc
-                    (Preprocessor
-                       (Printf.sprintf
-                          "reason-react-ppx: optional argument annotations \
-                           must have an explicit `option` type. Did you mean \
-                           `option(%s)=?`?"
-                          currentType)))
-          | _ -> ()
-        in
         let alias =
           match pattern with
           | { ppat_desc = Ppat_alias (_, { txt }) | Ppat_var { txt } } -> txt

--- a/ppx/test/optional-arg-check.t
+++ b/ppx/test/optional-arg-check.t
@@ -25,10 +25,6 @@ Show the error message when an optionally labelled argument has the wrong type
   File "x.re", line 3, characters 15-27:
   3 |   let make = (~myProp: bool=?) => React.null;
                      ^^^^^^^^^^^^
-  Warning 22 [preprocessor]: react-jsx-ppx: optional argument annotations must have an explicit `option` type. Did you mean `option(bool)=?`?
-  File "x.re", line 3, characters 15-27:
-  3 |   let make = (~myProp: bool=?) => React.null;
-                     ^^^^^^^^^^^^
   Error: This pattern matches values of type bool
          but a pattern was expected which matches values of type 'a option
   [1]

--- a/ppx/test/optional-arg-check.t
+++ b/ppx/test/optional-arg-check.t
@@ -1,0 +1,34 @@
+Show the error message when an optionally labelled argument has the wrong type
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (alias mel)
+  >  (emit_stdlib false)
+  >  (libraries reason-react)
+  >  (preprocess (pps melange.ppx reason-react-ppx)))
+  > EOF
+
+  $ cat > x.re <<EOF
+  > module App = {
+  >   [@react.component]
+  >   let make = (~myProp: bool=?) => React.null;
+  > };
+  > EOF
+
+  $ dune build @mel
+  File "x.re", line 3, characters 15-27:
+  3 |   let make = (~myProp: bool=?) => React.null;
+                     ^^^^^^^^^^^^
+  Warning 22 [preprocessor]: react-jsx-ppx: optional argument annotations must have an explicit `option` type. Did you mean `option(bool)=?`?
+  File "x.re", line 3, characters 15-27:
+  3 |   let make = (~myProp: bool=?) => React.null;
+                     ^^^^^^^^^^^^
+  Error: This pattern matches values of type bool
+         but a pattern was expected which matches values of type 'a option
+  [1]


### PR DESCRIPTION
I don't think this check is necessary anymore, since #776 and #791. 

After those PRs we infer the types correctly for optionally labelled arguments.