### PR TITLE
test: add to runtest + fix bindings

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1,13 +1,8 @@
 (melange.emit
- (alias jest)
+ (alias runtest)
  (target test)
  (module_systems
   (commonjs bs.js))
  (libraries reason-react reason-react.node jest melange.belt)
  (preprocess
   (pps melange.ppx reason-react-ppx)))
-
-(rule
- (alias runtest)
- (deps (alias_rec jest))
- (action (run npx jest)))


### PR DESCRIPTION
- ~Runs `jest` as part of `runtest` alias~ Edit: see [below](https://github.com/reasonml/reason-react/pull/824#issuecomment-1823087705)
- Fixes some bindings to Document APIs