### PR TITLE
Make explicit array comparison error in useEffectN N>1

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -109,6 +109,18 @@ useEffect1(effect, [|dep|])
 
 However, as the length of the array is not specified, you could pass an array of arbitrary length, including the empty array, `[||]`.
 
+> *NOTE*: When using `useEffectN` for `N` greater than 1, do not try to gather like types into arrays. Instead, leave each item separate in the tuple. 
+> As an example, consider the case where your effect has three deps, with the first and second dep the same type. The reason call:
+> ```reason
+> useEffect1(effect, ([|dep1, dep2|], dep3))
+> ```
+> would be expressed in javascript as:
+> ```javascript
+> useEffect(effect, [[dep1, dep2], dep3])
+> ```
+> Because arrays are compared by reference, this `useEffect` call will identify an update in its dependency array every time. 
+
+
 Reason also always opts for the safest form of a given hook as well. So `React.useState` in JS can take an initial value or a function that returns an initial value. The former cannot be used safely in all situations, so ReasonReact only supports the second form which takes a function and uses the return.
 
 ## Hand-writing components

--- a/docs/components.md
+++ b/docs/components.md
@@ -109,17 +109,10 @@ useEffect1(effect, [|dep|])
 
 However, as the length of the array is not specified, you could pass an array of arbitrary length, including the empty array, `[||]`.
 
-> *NOTE*: When using `useEffectN` for `N` greater than 1, do not try to gather like types into arrays. Instead, leave each item separate in the tuple. 
-> As an example, consider the case where your effect has three deps, with the first and second dep the same type. The reason call:
-> ```reason
-> useEffect2(effect, ([|dep1, dep2|], dep3))
-> ```
-> would be expressed in javascript as:
-> ```javascript
-> useEffect(effect, [[dep1, dep2], dep3])
-> ```
-> Because arrays are compared by reference, this `useEffect` call will identify an update in its dependency array every time. 
-
+> *NOTE*: When using `useEffectN` for `N` greater than 1, be careful not try to gather like types into arrays. Instead, leave each item separate in the tuple.
+> This is because the compiled javascript will compare by object, and thus will always interpret different arrays as unequal, regardless of their content.
+> Thus, use `useEffect3(effect, (dep1, dep2, dep3))` instead of `useEffect2(effect, ([|dep1, dep2|], dep3))`, regardless of the types. 
+> Please refer to the [React docs on Synchronizing with Effects](https://react.dev/learn/synchronizing-with-effects#re-render-with-different-dependencies) for more details. 
 
 Reason also always opts for the safest form of a given hook as well. So `React.useState` in JS can take an initial value or a function that returns an initial value. The former cannot be used safely in all situations, so ReasonReact only supports the second form which takes a function and uses the return.
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -112,7 +112,7 @@ However, as the length of the array is not specified, you could pass an array of
 > *NOTE*: When using `useEffectN` for `N` greater than 1, do not try to gather like types into arrays. Instead, leave each item separate in the tuple. 
 > As an example, consider the case where your effect has three deps, with the first and second dep the same type. The reason call:
 > ```reason
-> useEffect1(effect, ([|dep1, dep2|], dep3))
+> useEffect2(effect, ([|dep1, dep2|], dep3))
 > ```
 > would be expressed in javascript as:
 > ```javascript


### PR DESCRIPTION
I'm working on a project using reason-react and I encountered a mistake which I found hard to solve, and I wanted to contribute to the docs in case anyone else experiences the same issue. 

The gist is that my reading of the docs led me to believe that the use of arrays in `useEffect` are fine in general, rather than just specifically for `useEffect1`. 

So, I tried to be clever by gathering like types into arrays, like so:
```reason
x : int
y : int
z : string
useEffect2(effect, [|x,y|],z);
```

But this doesn't work, as the transpiled javascript code will always result in a comparison `[x,y]==[x,y]` which is `false` always because the arrays are being compared by reference. 

I'm not sure if this is the right place to plop these docs in, but please let me know and I am happy to move it around!