### PR TITLE
Add locations-check test

### DIFF
--- a/ppx/test/location.t/run.t
+++ b/ppx/test/location.t/run.t
@@ -2177,9 +2177,9 @@
                 ((pos_fname output.ml) (pos_lnum 3) (pos_bol 151)
                  (pos_cnum 179)))
                (loc_end
-                ((pos_fname output.ml) (pos_lnum 3) (pos_bol 151)
-                 (pos_cnum 181)))
-               (loc_ghost false)))
+                ((pos_fname output.ml) (pos_lnum 7) (pos_bol 359)
+                 (pos_cnum 371)))
+               (loc_ghost true)))
              (pexp_loc_stack ()) (pexp_attributes ()))))
           (pexp_loc
            ((loc_start

--- a/ppx/test/locations-check.t
+++ b/ppx/test/locations-check.t
@@ -1,0 +1,66 @@
+Test the preprocessed reason-react components have well-formed locations.
+Uses https://github.com/ocaml-ppx/ppxlib/blob/44583fc14c3cc39ee6269ffd69f52146283f72c0/src/location_check.mli
+
+With no annotations (ppx does nothing)
+
+  $ cat >input.ml <<EOF
+  > let make ~foo ~bar =
+  >   (div
+  >      ~children:[ React.string foo; bar |> string_of_int |> React.string ]
+  >      ())
+  > EOF
+
+  $ reason-react-ppx -check -locations-check input.ml
+  let make ~foo  ~bar  =
+    div ~children:[React.string foo; (bar |> string_of_int) |> React.string] ()
+
+With JSX annotation
+
+  $ cat >input.ml <<EOF
+  > let make ~foo ~bar =
+  >   (div
+  >      ~children:[ React.string foo; bar |> string_of_int |> React.string ]
+  >      () [@JSX])
+  > EOF
+
+  $ reason-react-ppx -check -locations-check input.ml
+  File "input.ml", line 2, characters 3-6:
+  2 |   (div
+         ^^^
+  Error: invalid output from ppx, expression overlaps with expression at location:
+  File "input.ml", line 2, characters 2-96:
+  [1]
+
+With @react.component annotation
+
+  $ cat >input.ml <<EOF
+  > let[@react.component] make ~foo ~bar =
+  >   (div
+  >      ~children:[ React.string foo; bar |> string_of_int |> React.string ]
+  >      () [@JSX])
+  > EOF
+
+  $ reason-react-ppx -check -locations-check input.ml
+  File "input.ml", line 1, characters 33-36:
+  1 | let[@react.component] make ~foo ~bar =
+                                       ^^^
+  Error: invalid output from ppx, core type overlaps with core type at location:
+  File "input.ml", line 1, characters 33-36:
+  [1]
+
+Everything
+
+  $ cat >input.ml <<EOF
+  > let[@react.component] make ~foo ~bar =
+  >   (div
+  >      ~children:[ React.string foo; bar |> string_of_int |> React.string ]
+  >      () [@JSX])
+  > EOF
+
+  $ reason-react-ppx -check -locations-check input.ml
+  File "input.ml", line 1, characters 33-36:
+  1 | let[@react.component] make ~foo ~bar =
+                                       ^^^
+  Error: invalid output from ppx, core type overlaps with core type at location:
+  File "input.ml", line 1, characters 33-36:
+  [1]


### PR DESCRIPTION
I found out today that ppxlib has some `-check -locations-check` flag that one can use to make sure a ppx generates an AST with valid locations ("valid" in the sense of following the Merlin rules).

I thought this could serve as an alternative to tests like the one @anmonteiro adds in #842 and the many other merlin-based tests that we have.

Rather than building the test based on what merlin returns, we can just make sure the tree is well formed. But it turns out the check doesn't successfully pass (even in 5.1), because there are too many overlaps.

Maybe we can keep the test as is for now and over time solve all issues until we make sure it passed this check. @davesnx @anmonteiro wdyt?

