### PR TITLE
Allow "ref" as valid prop, cleanup of Invalid_arguments and improve coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "devDependencies": {
         "jest": "^26.0.1",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^19.0.0-beta-26f2496093-20240514",
+        "react-dom": "^19.0.0-beta-26f2496093-20240514",
         "react-test-renderer": "^18.2.0"
       }
     },
@@ -4414,48 +4414,37 @@
       "dev": true
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "19.0.0-beta-26f2496093-20240514",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0-beta-26f2496093-20240514.tgz",
+      "integrity": "sha512-ZsU/WjNZ6GfzMWsq2DcGjElpV9it8JmETHm9mAJuOJNhuJcWJxt8ltCJabONFRpDFq1A/DP0d0KFj9CTJVM4VA==",
       "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "version": "19.0.0-beta-26f2496093-20240514",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0-beta-26f2496093-20240514.tgz",
+      "integrity": "sha512-UvQ+K1l3DFQ34LDgfFSNuUGi9EC+yfE9tS6MdpNTd5fx7qC7KLfepfC/KpxWMQZ7JfE3axD4ZO6H4cBSpAZpqw==",
       "dev": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "0.25.0-beta-26f2496093-20240514"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "19.0.0-beta-26f2496093-20240514"
       }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.25.0-beta-26f2496093-20240514",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-beta-26f2496093-20240514.tgz",
+      "integrity": "sha512-vDwOytLHFnA3SW2B1lNcbO+/qKVyLCX+KLpm+tRGNDsXpyxzRgkIaYGWmX+S70AJGchUHCtuqQ50GFeFgDbXUw==",
+      "dev": true
     },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
-    },
-    "node_modules/react-shallow-renderer": {
-      "version": "16.15.0",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
-      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
-      "dev": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
     },
     "node_modules/react-test-renderer": {
       "version": "18.2.0",
@@ -4476,6 +4465,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
+    },
+    "node_modules/react-test-renderer/node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "homepage": "https://reasonml.github.io/reason-react/",
   "devDependencies": {
     "jest": "^26.0.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.0.0-beta-26f2496093-20240514",
+    "react-dom": "^19.0.0-beta-26f2496093-20240514",
     "react-test-renderer": "^18.2.0"
   },
   "jest": {

--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -218,14 +218,12 @@ let otherAttrsPure { attr_name = loc; _ } = loc.txt <> "react.component"
 let hasAttrOnBinding { pvb_attributes; _ } =
   find_opt hasAttr pvb_attributes <> None
 
-(* Finds the name of the variable the binding is assigned to, otherwise raises
-   Invalid_argument *)
+(* Finds the name of the variable the binding is assigned to, otherwise raises an error *)
 let getFnName binding =
   match binding with
   | { pvb_pat = { ppat_desc = Ppat_var { txt; _ }; _ }; _ } -> txt
-  | _ ->
-      raise (Invalid_argument "react.component calls cannot be destructured.")
-[@@raises Invalid_argument]
+  | { pvb_loc; _} ->
+      Location.raise_errorf ~loc:pvb_loc "[@react.component] cannot be used with a destructured binding. Please use it on a `let make = ...` binding instead."
 
 let makeNewBinding binding expression newName =
   match binding with

--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -235,9 +235,8 @@ let makeNewBinding binding expression newName =
         pvb_expr = expression;
         pvb_attributes = [ merlinFocus ];
       }
-  | _ ->
-      raise (Invalid_argument "react.component calls cannot be destructured.")
-[@@raises Invalid_argument]
+  | { pvb_loc; _ } ->
+      Location.raise_errorf ~loc:pvb_loc "[@react.component] cannot be used with a destructured binding. Please use it on a `let make = ...` binding instead."
 
 (* Lookup the value of `props` otherwise raise Invalid_argument error *)
 let getPropsNameValue _acc (loc, exp) =

--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -641,11 +641,9 @@ let jsxMapper =
   let rec recursivelyTransformNamedArgsForMake ~ctxt mapper expr list =
     let expr = mapper#expression ctxt expr in
     match expr.pexp_desc with
-    (* TODO: make this show up with a loc. *)
     | Pexp_fun (Labelled "key", _, _, _) | Pexp_fun (Optional "key", _, _, _) ->
-        raise
-          (Invalid_argument
-             "Key cannot be accessed inside of a component. Don't worry - you \
+        Location.raise_errorf ~loc:expr.pexp_loc
+          ("Key cannot be accessed inside of a component. Don't worry - you \
               can always key a component from its parent!")
     | Pexp_fun (Labelled "ref", _, _, _) | Pexp_fun (Optional "ref", _, _, _) ->
         raise

--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -1314,8 +1314,8 @@ let jsxMapper =
               (Invalid_argument
                  "JSX: `createElement` should be preceeded by a module name.")
         (* Foo.createElement(~prop1=foo, ~prop2=bar, ~children=[], ()) *)
-        | { txt = Ldot (modulePath, ("createElement" | "make")); _ } ->
-            transformUppercaseCall3 ~ctxt ~caller:"make" modulePath mapper
+        | { txt = Ldot (modulePath, ("createElement" | "make" as caller)); _ } ->
+            transformUppercaseCall3 ~ctxt ~caller modulePath mapper
               parentExpLoc attrs callArguments
         (* div(~prop1=foo, ~prop2=bar, ~children=[bla], ()) *)
         (* turn that into

--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -643,8 +643,7 @@ let jsxMapper =
     match expr.pexp_desc with
     | Pexp_fun (Labelled "key", _, _, _) | Pexp_fun (Optional "key", _, _, _) ->
         Location.raise_errorf ~loc:expr.pexp_loc
-          ("Key cannot be accessed inside of a component. Don't worry - you \
-              can always key a component from its parent!")
+          ("~key cannot be accessed from the component props. Please set the key where the component is being used.")
     | Pexp_fun
         ( ((Optional label | Labelled label) as arg),
           default,

--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -47,8 +47,8 @@ let labelled str = Labelled str
 let optional str = Optional str
 
 module Binding = struct
-  (* Binding is the interface that the ppx uses to interact with the bindings.
-     Here we define the same APIs as the bindings but it generates Parsetree *)
+  (* Binding is the interface that the ppx relies on to interact with the react bindings.
+     Here we define the same APIs as the bindings but it generates Parsetree nodes *)
   module ReactDOM = struct
     let domProps ~applyLoc ~loc props =
       Builder.pexp_apply ~loc:applyLoc
@@ -58,9 +58,6 @@ module Binding = struct
   end
 
   module React = struct
-    let null ~loc =
-      Builder.pexp_ident ~loc { loc; txt = Ldot (Lident "React", "null") }
-
     let array ~loc children =
       Builder.pexp_apply ~loc
         (Builder.pexp_ident ~loc
@@ -92,8 +89,11 @@ let rec find_opt p = function
   | [] -> None
   | x :: l -> if p x then Some x else find_opt p l
 
-let getLabel str =
+let getLabelOrEmpty str =
   match str with Optional str | Labelled str -> str | Nolabel -> ""
+
+let getLabel str =
+  match str with Optional str | Labelled str -> Some str | Nolabel -> None
 
 let optionIdent = Lident "option"
 
@@ -101,9 +101,10 @@ let constantString ~loc str =
   Builder.pexp_constant ~loc (Pconst_string (str, Location.none, None))
 
 let safeTypeFromValue valueStr =
-  let valueStr = getLabel valueStr in
-  match String.sub valueStr 0 1 with "_" -> "T" ^ valueStr | _ -> valueStr
-[@@raises Invalid_argument]
+  match getLabel valueStr with
+  | Some valueStr when String.sub valueStr 0 1 = "_" -> ("T" ^ valueStr)
+  | Some valueStr -> valueStr
+  | None -> ""
 
 let keyType loc = Builder.ptyp_constr ~loc { loc; txt = Lident "string" } []
 
@@ -238,7 +239,7 @@ let makeNewBinding binding expression newName =
   | { pvb_loc; _ } ->
       Location.raise_errorf ~loc:pvb_loc "[@react.component] cannot be used with a destructured binding. Please use it on a `let make = ...` binding instead."
 
-(* Lookup the value of `props` otherwise raise Invalid_argument error *)
+(* Lookup the value of `props` otherwise raise errorf *)
 let getPropsNameValue _acc (loc, expr) =
   match (loc, expr) with
   | ( { txt = Lident "props"; _ },
@@ -246,7 +247,6 @@ let getPropsNameValue _acc (loc, expr) =
       { propsName = str }
   | { txt; loc }, _ ->
       Location.raise_errorf ~loc "[@react.component] only accepts 'props' as a field, given: %s" (Longident.last_exn txt)
-[@@raises Invalid_argument]
 
 (* Lookup the `props` record or string as part of [@react.component] and store
    the name for use when rewriting *)
@@ -356,7 +356,6 @@ let rec recursivelyMakeNamedArgsForExternal ~types_come_from_signature list args
            | _label, Some type_, _ -> type_)
            args)
   | [] -> args
-[@@raises Invalid_argument]
 
 (* Build an AST node for the [@bs.obj] representing props for a component *)
 let makePropsValue fnName ~types_come_from_signature loc
@@ -386,7 +385,6 @@ let makePropsValue fnName ~types_come_from_signature loc
       ];
     pval_loc = loc;
   }
-[@@raises Invalid_argument]
 
 (* Build an AST node representing an `external` with the definition of the
    [@bs.obj] *)
@@ -399,7 +397,6 @@ let makePropsExternal fnName loc ~component_is_external
         (makePropsValue ~types_come_from_signature:component_is_external fnName
            loc namedArgListWithKeyAndRef propsType);
   }
-[@@raises Invalid_argument]
 
 (* Build an AST node for the signature of the `external` definition *)
 let makePropsExternalSig fnName loc namedArgListWithKeyAndRef propsType =
@@ -410,7 +407,6 @@ let makePropsExternalSig fnName loc namedArgListWithKeyAndRef propsType =
         (makePropsValue ~types_come_from_signature:true fnName loc
            namedArgListWithKeyAndRef propsType);
   }
-[@@raises Invalid_argument]
 
 (* Build an AST node for the props name when converted to an object inside the
    function signature *)
@@ -494,7 +490,6 @@ let makeExternalDecl fnName loc namedArgListWithKeyAndRef namedTypeList =
   makePropsExternal ~component_is_external:false fnName loc
     (List.map pluckLabelDefaultLocType namedArgListWithKeyAndRef)
     (makePropsType ~loc namedTypeList)
-[@@raises Invalid_argument]
 
 (* TODO: some line number might still be wrong *)
 let jsxMapper =
@@ -505,7 +500,7 @@ let jsxMapper =
     let argsForMake = argsWithLabels in
     let keyProps, otherProps =
       List.partition
-        (fun (arg_label, _) -> "key" = getLabel arg_label)
+        (fun (arg_label, _) -> "key" = getLabelOrEmpty arg_label)
         argsForMake
     in
     let jsxExpr, key, childrenProp =
@@ -519,10 +514,12 @@ let jsxMapper =
              (label, mapper#expression ctxt expression))
     in
     let isCap str =
-      let first = String.sub str 0 1 [@@raises Invalid_argument] in
-      let capped = String.uppercase_ascii first in
-      first = capped
-        [@@raises Invalid_argument]
+      match String.length str with
+      | 0 -> false
+      | _ ->
+          let first = String.sub str 0 1 in
+          let capped = String.uppercase_ascii first in
+          first = capped
     in
     let ident =
       match modulePath with
@@ -584,7 +581,7 @@ let jsxMapper =
     let componentNameExpr = constantString ~loc:callerLoc id in
     let keyProps, nonChildrenProps =
       List.partition
-        (fun (arg_label, _) -> "key" = getLabel arg_label)
+        (fun (arg_label, _) -> "key" = getLabelOrEmpty arg_label)
         nonChildrenProps
     in
 
@@ -682,7 +679,6 @@ let jsxMapper =
           "reason-react-ppx: react.component refs only support plain arguments \
            and type annotations."
     | _ -> (list, None)
-      [@@raises Invalid_argument]
   in
 
   let argToType types (name, default, _noLabelName, _alias, loc, type_) =
@@ -704,7 +700,7 @@ let jsxMapper =
           } )
         :: types
     | Some type_, name, Some _default ->
-        ( getLabel name,
+        ( getLabelOrEmpty name,
           [],
           {
             ptyp_desc = Ptyp_constr ({ loc; txt = optionIdent }, [ type_ ]);
@@ -713,7 +709,7 @@ let jsxMapper =
             ptyp_attributes = [];
           } )
         :: types
-    | Some type_, name, _ -> (getLabel name, [], type_) :: types
+    | Some type_, name, _ -> (getLabelOrEmpty name, [], type_) :: types
     | None, Optional label, _ ->
         ( label,
           [],
@@ -745,7 +741,6 @@ let jsxMapper =
           } )
         :: types
     | _ -> types
-      [@@raises Invalid_argument]
   in
 
   let argToConcreteType types (name, loc, type_) =
@@ -1078,7 +1073,7 @@ let jsxMapper =
             in
             let pluckArg (label, _, _, alias, loc, _) =
               ( label,
-                match getLabel label with
+                match getLabelOrEmpty label with
                 | "" -> Builder.pexp_ident ~loc { txt = Lident alias; loc }
                 | labelString ->
                     Builder.pexp_apply ~loc

--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -1309,8 +1309,8 @@ let jsxMapper =
               (Invalid_argument
                  "JSX: `createElement` should be preceeded by a module name.")
         (* Foo.createElement(~prop1=foo, ~prop2=bar, ~children=[], ()) *)
-        | { txt = Ldot (modulePath, ("createElement" | "make" as caller)); _ } ->
-            transformUppercaseCall3 ~ctxt ~caller modulePath mapper
+        | { txt = Ldot (modulePath, ("createElement" | "make")); _ } ->
+            transformUppercaseCall3 ~ctxt ~caller:"make" modulePath mapper
               parentExpLoc attrs callArguments
         (* div(~prop1=foo, ~prop2=bar, ~children=[bla], ()) *)
         (* turn that into

--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -645,11 +645,6 @@ let jsxMapper =
         Location.raise_errorf ~loc:expr.pexp_loc
           ("Key cannot be accessed inside of a component. Don't worry - you \
               can always key a component from its parent!")
-    | Pexp_fun (Labelled "ref", _, _, _) | Pexp_fun (Optional "ref", _, _, _) ->
-        raise
-          (Invalid_argument
-             "Ref cannot be passed as a normal prop. Please use `forwardRef` \
-              API instead.")
     | Pexp_fun
         ( ((Optional label | Labelled label) as arg),
           default,

--- a/ppx/test/component-without-make.t/input.re
+++ b/ppx/test/component-without-make.t/input.re
@@ -1,0 +1,17 @@
+module Component_with_x_as_main_function = {
+  [@react.component]
+  let x = () => <div />;
+};
+
+module Component_with_createElement_as_main_function = {
+  [@react.component]
+  let createElement = (~lola) => <div> {React.string(lola)} </div>;
+};
+
+module Parent_rendering = {
+  [@react.component]
+  let make = () => {
+    <Component_with_x_as_main_function.x />;
+    <Component_with_createElement_as_main_function lola="lola" />;
+  };
+};

--- a/ppx/test/component-without-make.t/run.t
+++ b/ppx/test/component-without-make.t/run.t
@@ -1,0 +1,42 @@
+Since we generate invalid syntax for the argument of the make fn `(Props : <>)`
+We need to output ML syntax here, otherwise refmt could not parse it.
+  $ ../ppx.sh --output ml input.re
+  module Component_with_x_as_main_function =
+    struct
+      external xProps : ?key:string -> unit -> <  >  Js.t = ""[@@mel.obj ]
+      let x () = ReactDOM.jsx "div" (((ReactDOM.domProps)[@merlin.hide ]) ())
+      let x =
+        let Output$Component_with_x_as_main_function$x (Props : <  >  Js.t) =
+          x () in
+        Output$Component_with_x_as_main_function$x
+    end
+  module Component_with_createElement_as_main_function =
+    struct
+      external createElementProps :
+        lola:'lola -> ?key:string -> unit -> < lola: 'lola   >  Js.t = ""
+      [@@mel.obj ]
+      let createElement =
+        ((fun ~lola ->
+            ReactDOM.jsx "div"
+              (((ReactDOM.domProps)[@merlin.hide ])
+                 ~children:(React.string lola) ()))
+        [@warning "-16"])
+      let createElement =
+        let Output$Component_with_createElement_as_main_function$createElement
+          (Props : < lola: 'lola   >  Js.t) =
+          createElement ~lola:(Props ## lola) in
+        Output$Component_with_createElement_as_main_function$createElement
+    end
+  module Parent_rendering =
+    struct
+      external makeProps : ?key:string -> unit -> <  >  Js.t = ""[@@mel.obj ]
+      let make () =
+        React.jsx Component_with_x_as_main_function.x
+          (Component_with_x_as_main_function.xProps ());
+        React.jsx Component_with_createElement_as_main_function.make
+          (Component_with_createElement_as_main_function.makeProps ~lola:"lola"
+             ())
+      let make =
+        let Output$Parent_rendering (Props : <  >  Js.t) = make () in
+        Output$Parent_rendering
+    end

--- a/ppx/test/component.t/input.re
+++ b/ppx/test/component.t/input.re
@@ -17,21 +17,21 @@ module Upper_case_with_fragment_as_root = {
 };
 
 /* module Using_React_memo = {
-  [@react.component]
-  let make =
-    React.memo((~a) =>
-      <div> {Printf.sprintf("`a` is %s", a) |> React.string} </div>
-    );
-};
+     [@react.component]
+     let make =
+       React.memo((~a) =>
+         <div> {Printf.sprintf("`a` is %s", a) |> React.string} </div>
+       );
+   };
 
-module Using_memo_custom_compare_Props = {
-  [@react.component]
-  let make =
-    React.memoCustomCompareProps(
-      (~a) => <div> {Printf.sprintf("`a` is %d", a) |> React.string} </div>,
-      (prevPros, nextProps) => false,
-    );
-}; */
+   module Using_memo_custom_compare_Props = {
+     [@react.component]
+     let make =
+       React.memoCustomCompareProps(
+         (~a) => <div> {Printf.sprintf("`a` is %d", a) |> React.string} </div>,
+         (prevPros, nextProps) => false,
+       );
+   }; */
 
 module Forward_Ref = {
   [@react.component]
@@ -39,6 +39,13 @@ module Forward_Ref = {
     React.forwardRef((~children, ~buttonRef) => {
       <button ref=buttonRef className="FancyButton"> children </button>
     });
+};
+
+module Ref_as_prop = {
+  [@react.component]
+  let make = (~children, ~ref) => {
+    <button ref className="FancyButton"> children </button>;
+  };
 };
 
 module Onclick_handler_button = {

--- a/ppx/test/component.t/run.t
+++ b/ppx/test/component.t/run.t
@@ -68,6 +68,27 @@ We need to output ML syntax here, otherwise refmt could not parse it.
              make ~buttonRef:(Props ## buttonRef) ~children:(Props ## children) in
            Output$Forward_Ref)
     end
+  module Ref_as_prop =
+    struct
+      external makeProps :
+        children:'children ->
+          ref:'ref ->
+            ?key:string -> unit -> < children: 'children  ;ref: 'ref   >  Js.t
+          = ""[@@mel.obj ]
+      let make =
+        ((fun ~children ->
+            ((fun ~ref ->
+                ReactDOM.jsx "button"
+                  (((ReactDOM.domProps)[@merlin.hide ]) ~children ~ref
+                     ~className:"FancyButton" ()))
+            [@warning "-16"]))
+        [@warning "-16"])
+      let make =
+        let Output$Ref_as_prop
+          (Props : < children: 'children  ;ref: 'ref   >  Js.t) =
+          make ~ref:(Props ## ref) ~children:(Props ## children) in
+        Output$Ref_as_prop
+    end
   module Onclick_handler_button =
     struct
       external makeProps :

--- a/ppx/test/components-destructured-error.t/component.re
+++ b/ppx/test/components-destructured-error.t/component.re
@@ -1,0 +1,3 @@
+[@react.component]
+let (pageState, setPageState) = React.useState(_ => 0);
+let make = (~children, ()) => <div> children </div>;

--- a/ppx/test/components-destructured-error.t/run.t
+++ b/ppx/test/components-destructured-error.t/run.t
@@ -1,0 +1,22 @@
+Test some locations in reason-react components
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (melange.emit
+  >  (alias foo)
+  >  (target foo)
+  >  (libraries reason-react)
+  >  (preprocess
+  >   (pps melange.ppx reason-react-ppx)))
+  > EOF
+
+  $ dune build
+  File "component.re", lines 1-2, characters 0-54:
+  1 | [@react.component]
+  2 | let (pageState, setPageState) = React.useState(_ => 0).
+  Error: react.component calls cannot be destructured.
+  [1]

--- a/ppx/test/components-destructured-error.t/run.t
+++ b/ppx/test/components-destructured-error.t/run.t
@@ -18,5 +18,5 @@ Test some locations in reason-react components
   File "component.re", lines 1-2, characters 0-54:
   1 | [@react.component]
   2 | let (pageState, setPageState) = React.useState(_ => 0).
-  Error: react.component calls cannot be destructured.
+  Error: [@react.component] cannot be used with a destructured binding. Please use it on a `let make = ...` binding instead.
   [1]

--- a/ppx/test/create-element.t/input.re
+++ b/ppx/test/create-element.t/input.re
@@ -1,0 +1,11 @@
+module Foo = {
+  [@react.component]
+  let createElement = (~lola) => <div> {React.string(lola)} </div>;
+};
+
+module Bar = {
+  [@react.component]
+  let make = (~lola) => {
+    <Foo lola />;
+  };
+};

--- a/ppx/test/create-element.t/run.t
+++ b/ppx/test/create-element.t/run.t
@@ -1,8 +1,0 @@
-Since we generate invalid syntax for the argument of the make fn `(Props : <>)`
-We need to output ML syntax here, otherwise refmt could not parse it.
-  $ ../ppx.sh --output ml input.re
-  File "output.ml", line 4, characters 27-35:
-  4 |       [@@react.component { no_props = string }]
-                                 ^^^^^^^^
-  Error: [@react.component] only accepts 'props' as a field, given: no_props
-  [1]

--- a/ppx/test/create-element.t/run.t
+++ b/ppx/test/create-element.t/run.t
@@ -1,0 +1,8 @@
+Since we generate invalid syntax for the argument of the make fn `(Props : <>)`
+We need to output ML syntax here, otherwise refmt could not parse it.
+  $ ../ppx.sh --output ml input.re
+  File "output.ml", line 4, characters 27-35:
+  4 |       [@@react.component { no_props = string }]
+                                 ^^^^^^^^
+  Error: [@react.component] only accepts 'props' as a field, given: no_props
+  [1]

--- a/ppx/test/key-as-prop-error.t/component.re
+++ b/ppx/test/key-as-prop-error.t/component.re
@@ -1,0 +1,2 @@
+[@react.component]
+let make = (~key) => <div> key->React.string </div>;

--- a/ppx/test/key-as-prop-error.t/run.t
+++ b/ppx/test/key-as-prop-error.t/run.t
@@ -1,0 +1,17 @@
+Test some locations in reason-react components
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (melange.emit
+  >  (alias foo)
+  >  (target foo)
+  >  (libraries reason-react)
+  >  (preprocess
+  >   (pps melange.ppx reason-react-ppx)))
+  > EOF
+
+  $ dune build

--- a/ppx/test/key-as-prop-error.t/run.t
+++ b/ppx/test/key-as-prop-error.t/run.t
@@ -15,3 +15,8 @@ Test some locations in reason-react components
   > EOF
 
   $ dune build
+  File "component.re", line 2, characters 11-51:
+  2 | let make = (~key) => <div> key->React.string </div>;
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Key cannot be accessed inside of a component. Don't worry - you can always key a component from its parent!
+  [1]

--- a/ppx/test/key-as-prop-error.t/run.t
+++ b/ppx/test/key-as-prop-error.t/run.t
@@ -18,5 +18,5 @@ Test some locations in reason-react components
   File "component.re", line 2, characters 11-51:
   2 | let make = (~key) => <div> key->React.string </div>;
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Key cannot be accessed inside of a component. Don't worry - you can always key a component from its parent!
+  Error: ~key cannot be accessed from the component props. Please set the key where the component is being used.
   [1]

--- a/ppx/test/keys.t/component.re
+++ b/ppx/test/keys.t/component.re
@@ -7,4 +7,6 @@ module Author = {
 
 [@react.component]
 let make = (~author) =>
-  <tr key={author.Author.name}> <td> <img src={author.Author.imageUrl} /> </td> </tr>;
+  <tr key={author.Author.name}>
+    <td> <img src={author.Author.imageUrl} /> </td>
+  </tr>;

--- a/ppx/test/record-props-error.t/input.re
+++ b/ppx/test/record-props-error.t/input.re
@@ -1,0 +1,6 @@
+module Record_props = {
+  [@react.component {no_props: string}]
+  let make = (~lola) => {
+    <div> {React.string(lola)} </div>;
+  };
+};

--- a/ppx/test/record-props-error.t/run.t
+++ b/ppx/test/record-props-error.t/run.t
@@ -1,0 +1,8 @@
+Since we generate invalid syntax for the argument of the make fn `(Props : <>)`
+We need to output ML syntax here, otherwise refmt could not parse it.
+  $ ../ppx.sh --output ml input.re
+  File "output.ml", line 4, characters 27-35:
+  4 |       [@@react.component { no_props = string }]
+                                 ^^^^^^^^
+  Error: [@react.component] only accepts 'props' as a field, given: no_props
+  [1]

--- a/ppx/test/record-props.t/input.re
+++ b/ppx/test/record-props.t/input.re
@@ -1,0 +1,6 @@
+module Record_props = {
+  [@react.component {props: string}]
+  let make = (~lola) => {
+    <div> {React.string(lola)} </div>;
+  };
+};

--- a/ppx/test/record-props.t/run.t
+++ b/ppx/test/record-props.t/run.t
@@ -1,0 +1,19 @@
+Since we generate invalid syntax for the argument of the make fn `(Props : <>)`
+We need to output ML syntax here, otherwise refmt could not parse it.
+  $ ../ppx.sh --output ml input.re
+  module Record_props =
+    struct
+      external makeProps :
+        lola:'lola -> ?key:string -> unit -> < lola: 'lola   >  Js.t = ""
+      [@@mel.obj ]
+      let make =
+        ((fun ~lola ->
+            ReactDOM.jsx "div"
+              (((ReactDOM.domProps)[@merlin.hide ])
+                 ~children:(React.string lola) ()))
+        [@warning "-16"])
+      let make =
+        let Output$Record_props (string : < lola: 'lola   >  Js.t) =
+          make ~lola:(string ## lola) in
+        Output$Record_props
+    end

--- a/ppx/test/uppercase.t/component.re
+++ b/ppx/test/uppercase.t/component.re
@@ -1,17 +1,13 @@
 module Box = {
   [@react.component]
   let make = (~children) => {
-    <div>
-      {children}
-    </div>;
+    <div> children </div>;
   };
 };
 
 module Uppercase = {
   [@react.component]
   let make = (~children) => {
-    <Box>
-      {children}
-    </Box>;
+    <Box> children </Box>;
   };
 };

--- a/src/ReactDOMServer.rei
+++ b/src/ReactDOMServer.rei
@@ -4,5 +4,3 @@ external renderToString: React.element => string = "renderToString";
 [@mel.module "react-dom/server"]
 external renderToStaticMarkup: React.element => string =
   "renderToStaticMarkup";
-
-

--- a/test/Ref__test.re
+++ b/test/Ref__test.re
@@ -1,0 +1,43 @@
+open Jest;
+open Jest.Expect;
+open ReactDOMTestUtils;
+open Belt;
+
+/* https://react.dev/blog/2022/03/08/react-18-upgrade-guide#configuring-your-testing-environment */
+[%%mel.raw "globalThis.IS_REACT_ACT_ENVIRONMENT = true"];
+
+module Button_with_ref = {
+  [@react.component]
+  let make = (~children, ~ref) => {
+    <button ref className="FancyButton"> children </button>;
+  };
+};
+
+describe("React - Ref", () => {
+  let container = ref(None);
+
+  beforeEach(prepareContainer(container));
+  afterEach(cleanupContainer(container));
+
+  test("can render DOM elements", () => {
+    let container = getContainer(container);
+    let root = ReactDOM.Client.createRoot(container);
+    let domRef = React.createRef();
+
+    act(() => {
+      ReactDOM.Client.render(
+        root,
+        <Button_with_ref ref={ReactDOM.Ref.domRef(domRef)}>
+          "Click me"->React.string
+        </Button_with_ref>,
+      )
+    });
+
+    expect(
+      container
+      ->DOM.findBySelectorAndTextContent("button", "Click me")
+      ->Option.isSome,
+    )
+    ->toBe(true);
+  });
+});

--- a/test/jest/Expect.re
+++ b/test/jest/Expect.re
@@ -17,7 +17,8 @@ external toBeGreaterThanOrEqual: (t('a), 'a) => unit =
   "toBeGreaterThanOrEqual";
 [@mel.send]
 external toBeLessThanOrEqual: (t('a), 'a) => unit = "toBeLessThanOrEqual";
-[@mel.send] external toHaveLength: (t(array('a)), 'a) => unit = "toHaveLength";
+[@mel.send]
+external toHaveLength: (t(array('a)), 'a) => unit = "toHaveLength";
 
 [@mel.get]
 external rejects: t(Js.Promise.t('a)) => t(unit => 'a) = "rejects";


### PR DESCRIPTION
- Allows to have a prop with `~ref`
- Took the chance to cleanup all `raise Invalid_argument` into `Location.raise_errorf` (which isn't ideal from the ppxlib standpoint, since it fails a Parseetree generation and only shows one error) but the refactor to this is massive.
  - I added tests for the Invalid_argument that I could reproduce and removed, but for the ones I couldn't I left them like they were before. I don't want to introduce a breaking change doing this work.
- Took the chance to improve/fix this https://github.com/reasonml/reason-react/issues/843