### PR TITLE
Fix multi-child fragment

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version = 0.26.0
+version = 0.26.2

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version = 0.26.2
+version = 0.26.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,8 @@
 * Convert `ReasonReactErrorBoundary` to Reason instead of `%raw` JS. This has
   the benefit of skipping a hardcoded `require('react')` call (@anmonteiro in
   [#839](https://github.com/reasonml/reason-react/pull/839))
-
+* Fix: Remove "unique `key` prop" warnings from multi-child fragment elements
+  (@jchavarri in https://github.com/reasonml/reason-react/pull/852)
 
 # 0.14.1
 

--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -1402,24 +1402,7 @@ let jsxMapper =
          [@JSX][foo]
          This will match either <> </> or <> foo </> *)
       | {
-          pexp_desc =
-            ( Pexp_construct ({ txt = Lident "[]"; loc }, None)
-            | Pexp_construct
-                ( { txt = Lident "::"; loc },
-                  Some
-                    {
-                      pexp_desc =
-                        Pexp_tuple
-                          [
-                            _;
-                            {
-                              pexp_desc =
-                                Pexp_construct ({ txt = Lident "[]"; _ }, None);
-                              _;
-                            };
-                          ];
-                      _;
-                    } ) );
+          pexp_desc = Pexp_construct ({ txt = Lident ("[]" | "::"); loc }, lst);
           pexp_attributes;
           _;
         } as listItems -> (
@@ -1431,50 +1414,34 @@ let jsxMapper =
           match (jsxAttribute, nonJSXAttributes) with
           (* no JSX attribute *)
           | [], _ -> super#expression ctxt expr
-          | _, nonJSXAttributes ->
+          | _, nonJSXAttributes -> (
               let childrenExpr =
                 transformChildrenIfList ~loc ~ctxt ~mapper:self listItems
               in
               (* throw away the [@JSX] attribute and keep the others, if any *)
-              Binding.React.jsxFragment ~loc ~attrs:nonJSXAttributes
-                (Binding.React.array ~loc childrenExpr))
-      (* Fragment with two or more children: <> foo bar </> *)
-      | {
-          pexp_desc =
-            Pexp_construct
-              ( { txt = Lident "::"; loc },
-                Some
+              match lst with
+              | None
+              | Some
                   {
                     pexp_desc =
                       Pexp_tuple
                         [
-                          _firstElement;
+                          _;
                           {
                             pexp_desc =
-                              Pexp_construct ({ txt = Lident "::"; _ }, Some _);
+                              Pexp_construct ({ txt = Lident "[]"; _ }, None);
                             _;
                           };
                         ];
                     _;
-                  } );
-          pexp_attributes;
-          _;
-        } as listItems -> (
-          let jsxAttribute, nonJSXAttributes =
-            List.partition
-              (fun { attr_name = attribute; _ } -> attribute.txt = "JSX")
-              pexp_attributes
-          in
-          match (jsxAttribute, nonJSXAttributes) with
-          (* no JSX attribute *)
-          | [], _ -> super#expression ctxt expr
-          | _, nonJSXAttributes ->
-              let childrenExpr =
-                transformChildrenIfList ~loc ~ctxt ~mapper:self listItems
-              in
-              (* throw away the [@JSX] attribute and keep the others, if any *)
-              Binding.React.jsxsFragment ~loc ~attrs:nonJSXAttributes
-                (Binding.React.array ~loc childrenExpr))
+                  } ->
+                  Binding.React.jsxFragment ~loc ~attrs:nonJSXAttributes
+                    (Binding.React.array ~loc childrenExpr)
+              | Some { pexp_desc = Pexp_tuple (_ :: _); _ } ->
+                  (* Fragment with two or more children: <> foo bar </> *)
+                  Binding.React.jsxsFragment ~loc ~attrs:nonJSXAttributes
+                    (Binding.React.array ~loc childrenExpr)
+              | _ -> assert false))
       (* Delegate to the default mapper, a deep identity traversal *)
       | e -> super#expression ctxt e
     [@@raises Invalid_argument]

--- a/ppx/test/component.t/run.t
+++ b/ppx/test/component.t/run.t
@@ -27,7 +27,7 @@ We need to output ML syntax here, otherwise refmt could not parse it.
           ""[@@mel.obj ]
       let make =
         ((fun ?(name= "") ->
-            React.jsx React.jsxFragment
+            React.jsxs React.jsxFragment
               (((ReactDOM.domProps)[@merlin.hide ])
                  ~children:(React.array
                               [|(ReactDOM.jsx "div"

--- a/ppx/test/fragment.t/run.t
+++ b/ppx/test/fragment.t/run.t
@@ -11,7 +11,7 @@
       ([@merlin.hide] ReactDOM.domProps)(~children=React.array([|bar|]), ()),
     );
   let poly_children_fragment = (foo, bar) =>
-    React.jsx(
+    React.jsxs(
       React.jsxFragment,
       ([@merlin.hide] ReactDOM.domProps)(
         ~children=React.array([|foo, bar|]),
@@ -19,13 +19,13 @@
       ),
     );
   let nested_fragment = (foo, bar, baz) =>
-    React.jsx(
+    React.jsxs(
       React.jsxFragment,
       ([@merlin.hide] ReactDOM.domProps)(
         ~children=
           React.array([|
             foo,
-            React.jsx(
+            React.jsxs(
               React.jsxFragment,
               ([@merlin.hide] ReactDOM.domProps)(
                 ~children=React.array([|bar, baz|]),


### PR DESCRIPTION
Currently, this code `<> <div/> <div/> </>` will trigger the infamous warning: `Each child in a list should have a unique "key" prop`.

This PR modifies the expression switch for fragments so that those with 0 or 1 child use `jsx` and those with 2 or more children use `jsxs`.