### PR TITLE
Revert support for "custom children" in uppercase components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,5 @@
 # Unreleased
 
-* BREAKING, ppx: Allow passing an array of custom children to a component
-  without having to wrap in array literal ([@jchavarri in #748](https://github.com/reasonml/reason-react/pull/823))
-
 # 0.15.0
 
 * Add `isValidElement` (@r17x in

--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -487,10 +487,7 @@ let jsxExprAndChildren ~component_type ~loc ~ctxt mapper ~keyProps children =
          children *)
       ( Builder.pexp_ident ~loc { loc; txt = Ldot (ident, "jsxs") },
         None,
-        Some
-          (match component_type with
-          | Uppercase -> children
-          | Lowercase -> Binding.React.array ~loc children) )
+        Some (Binding.React.array ~loc children))
   | None, (label, key) :: _ ->
       ( Builder.pexp_ident ~loc { loc; txt = Ldot (ident, "jsxKeyed") },
         Some (label, key),

--- a/ppx/test/upper.t/run.t
+++ b/ppx/test/upper.t/run.t
@@ -4,7 +4,10 @@
   let upper_children_single = foo =>
     React.jsx(Upper.make, Upper.makeProps(~children=foo, ()));
   let upper_children_multiple = (foo, bar) =>
-    React.jsxs(Upper.make, Upper.makeProps(~children=[|foo, bar|], ()));
+    React.jsxs(
+      Upper.make,
+      Upper.makeProps(~children=React.array([|foo, bar|]), ()),
+    );
   let upper_children =
     React.jsx(
       Page.make,

--- a/test/React__test.re
+++ b/test/React__test.re
@@ -16,17 +16,15 @@ module DummyComponentThatMapsChildren = {
   [@react.component]
   let make = (~children, ()) => {
     <div>
-      {children
-       ->React.array
-       ->React.Children.mapWithIndex((element, index) => {
-           React.cloneElement(
-             element,
-             {
-               "key": string_of_int(index),
-               "role": Int.to_string(index),
-             },
-           )
-         })}
+      {children->React.Children.mapWithIndex((element, index) => {
+         React.cloneElement(
+           element,
+           {
+             "key": string_of_int(index),
+             "role": Int.to_string(index),
+           },
+         )
+       })}
     </div>;
   };
 };
@@ -170,9 +168,11 @@ describe("React", () => {
     let container =
       ReactTestingLibrary.render(
         <DummyComponentThatMapsChildren>
-          <div> 1->React.int </div>
-          <div> 2->React.int </div>
-          <div> 3->React.int </div>
+          {React.array([|
+             <div> 1->React.int </div>,
+             <div> 2->React.int </div>,
+             <div> 3->React.int </div>,
+           |])}
         </DummyComponentThatMapsChildren>,
       );
 
@@ -461,7 +461,7 @@ describe("React", () => {
 
     let container =
       ReactTestingLibrary.render(
-        <Test> {Test.name: "foo"} {name: "bar"} </Test>,
+        <Test> {[|{Test.name: "foo"}, {name: "bar"}|]} </Test>,
       );
 
     let foo = getByRole("foo", container);
@@ -489,10 +489,10 @@ describe("React", () => {
 
     let section = getByRole("container", container);
     expect(section->tagName->Js.String.toLowerCase)->toBe("section");
-    
+
     let child1 = getByRole("child1", container);
     expect(child1->innerHTML)->toBe("child1");
-    
+
     let child2 = getByRole("child2", container);
     expect(child2->innerHTML)->toBe("child2");
   });
@@ -507,12 +507,14 @@ describe("React", () => {
 
     let container =
       ReactTestingLibrary.render(
-        <MyComponent> <div role="child"> {React.string("child")} </div> </MyComponent>,
+        <MyComponent>
+          <div role="child"> {React.string("child")} </div>
+        </MyComponent>,
       );
 
     let section = getByRole("container", container);
     expect(section->tagName->Js.String.toLowerCase)->toBe("section");
-    
+
     let child = getByRole("child", container);
     expect(child->innerHTML)->toBe("child");
   });

--- a/test/React__test.re
+++ b/test/React__test.re
@@ -470,4 +470,50 @@ describe("React", () => {
     let bar = getByRole("bar", container);
     expect(bar->innerHTML)->toBe("bar");
   });
+
+  test("Can render components with multiple children", () => {
+    module MyComponent = {
+      [@react.component]
+      let make = (~children) => {
+        <section role="container"> children </section>;
+      };
+    };
+
+    let container =
+      ReactTestingLibrary.render(
+        <MyComponent>
+          <div role="child1"> {React.string("child1")} </div>
+          <div role="child2"> {React.string("child2")} </div>
+        </MyComponent>,
+      );
+
+    let section = getByRole("container", container);
+    expect(section->tagName->Js.String.toLowerCase)->toBe("section");
+    
+    let child1 = getByRole("child1", container);
+    expect(child1->innerHTML)->toBe("child1");
+    
+    let child2 = getByRole("child2", container);
+    expect(child2->innerHTML)->toBe("child2");
+  });
+
+  test("Can render components with a single child", () => {
+    module MyComponent = {
+      [@react.component]
+      let make = (~children) => {
+        <section role="container"> children </section>;
+      };
+    };
+
+    let container =
+      ReactTestingLibrary.render(
+        <MyComponent> <div role="child"> {React.string("child")} </div> </MyComponent>,
+      );
+
+    let section = getByRole("container", container);
+    expect(section->tagName->Js.String.toLowerCase)->toBe("section");
+    
+    let child = getByRole("child", container);
+    expect(child->innerHTML)->toBe("child");
+  });
 });


### PR DESCRIPTION
Reverts #823.

A user complained in Discord:

> I am currently trying to use the current main branch of reason-react with the new React 19 changes.
> Is it intended, that it is no longer possible to have multiple children in a custom react component without a fragment?

```reason
module MyComponent = {
  [@react.component]
  let make = (~children) => {
    <section> children </section>;
  };
};

<MyComponent>
  <div> {React.string("child1")} </div>
  <div> {React.string("child2")} </div>
</MyComponent>;
```

> This is throwing the error
```
Error: This expression has type < children : React.element array > Js.t
       but an expression was expected of type
         < children : React.element > Js.t
       The method children has type React.element array,
       but the expected method type was React.element
```

> To fix this error you have to wrap the two div in a fragment (<>...</>).
> I guess is coming from this change? https://github.com/reasonml/reason-react/pull/823

I talked to @davesnx online and while we could do some introspection in the ppx to start branching off generated code depending on the kind of children (element vs something else) it seems too much magic for the upsides.