### PR TITLE
Format files with OCamlformat 0.27.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version = 0.26.0
+version = 0.27.0

--- a/ppx/reason_react_ppx.ml
+++ b/ppx/reason_react_ppx.ml
@@ -108,7 +108,7 @@ let constantString ~loc str =
 
 let safeTypeFromValue valueStr =
   match getLabel valueStr with
-  | Some valueStr when String.sub valueStr 0 1 = "_" -> ("T" ^ valueStr)
+  | Some valueStr when String.sub valueStr 0 1 = "_" -> "T" ^ valueStr
   | Some valueStr -> valueStr
   | None -> ""
 
@@ -229,8 +229,10 @@ let hasAttrOnBinding { pvb_attributes; _ } =
 let getFnName binding =
   match binding with
   | { pvb_pat = { ppat_desc = Ppat_var { txt; _ }; _ }; _ } -> txt
-  | { pvb_loc; _} ->
-      Location.raise_errorf ~loc:pvb_loc "[@react.component] cannot be used with a destructured binding. Please use it on a `let make = ...` binding instead."
+  | { pvb_loc; _ } ->
+      Location.raise_errorf ~loc:pvb_loc
+        "[@react.component] cannot be used with a destructured binding. Please \
+         use it on a `let make = ...` binding instead."
 
 let makeNewBinding binding expression newName =
   match binding with
@@ -243,7 +245,9 @@ let makeNewBinding binding expression newName =
         pvb_attributes = [ merlinFocus ];
       }
   | { pvb_loc; _ } ->
-      Location.raise_errorf ~loc:pvb_loc "[@react.component] cannot be used with a destructured binding. Please use it on a `let make = ...` binding instead."
+      Location.raise_errorf ~loc:pvb_loc
+        "[@react.component] cannot be used with a destructured binding. Please \
+         use it on a `let make = ...` binding instead."
 
 (* Lookup the value of `props` otherwise raise errorf *)
 let getPropsNameValue _acc (loc, expr) =
@@ -252,7 +256,9 @@ let getPropsNameValue _acc (loc, expr) =
       { pexp_desc = Pexp_ident { txt = Lident str; _ }; _ } ) ->
       { propsName = str }
   | { txt; loc }, _ ->
-      Location.raise_errorf ~loc "[@react.component] only accepts 'props' as a field, given: %s" (Longident.last_exn txt)
+      Location.raise_errorf ~loc
+        "[@react.component] only accepts 'props' as a field, given: %s"
+        (Longident.last_exn txt)
 
 (* Lookup the `props` record or string as part of [@react.component] and store
    the name for use when rewriting *)
@@ -261,22 +267,22 @@ let getPropsAttr payload =
   match payload with
   | Some
       (PStr
-        ({
-           pstr_desc =
-             Pstr_eval ({ pexp_desc = Pexp_record (recordFields, None); _ }, _);
-           _;
-         }
-        :: _rest)) ->
+         ({
+            pstr_desc =
+              Pstr_eval ({ pexp_desc = Pexp_record (recordFields, None); _ }, _);
+            _;
+          }
+         :: _rest)) ->
       List.fold_left getPropsNameValue defaultProps recordFields
   | Some
       (PStr
-        ({
-           pstr_desc =
-             Pstr_eval
-               ({ pexp_desc = Pexp_ident { txt = Lident "props"; _ }; _ }, _);
-           _;
-         }
-        :: _rest)) ->
+         ({
+            pstr_desc =
+              Pstr_eval
+                ({ pexp_desc = Pexp_ident { txt = Lident "props"; _ }; _ }, _);
+            _;
+          }
+         :: _rest)) ->
       { propsName = "props" }
   | Some (PStr ({ pstr_desc = Pstr_eval (_, _); pstr_loc; _ } :: _rest)) ->
       Location.raise_errorf ~loc:pstr_loc
@@ -487,7 +493,7 @@ let jsxExprAndChildren ~component_type ~loc ~ctxt mapper ~keyProps children =
          children *)
       ( Builder.pexp_ident ~loc { loc; txt = Ldot (ident, "jsxs") },
         None,
-        Some (Binding.React.array ~loc children))
+        Some (Binding.React.array ~loc children) )
   | None, (label, key) :: _ ->
       ( Builder.pexp_ident ~loc { loc; txt = Ldot (ident, "jsxKeyed") },
         Some (label, key),
@@ -645,7 +651,8 @@ let jsxMapper =
     match expr.pexp_desc with
     | Pexp_fun (Labelled "key", _, _, _) | Pexp_fun (Optional "key", _, _, _) ->
         Location.raise_errorf ~loc:expr.pexp_loc
-          ("~key cannot be accessed from the component props. Please set the key where the component is being used.")
+          "~key cannot be accessed from the component props. Please set the \
+           key where the component is being used."
     | Pexp_fun
         ( ((Optional label | Labelled label) as arg),
           default,

--- a/src/ReactDOM.re
+++ b/src/ReactDOM.re
@@ -484,30 +484,35 @@ module Experimental = {
   external preloadOptions:
     (
       ~_as: [
-              | `audio
-              | `document
-              | `embed
-              | `fetch
-              | `font
-              | `image
-              | [@mel.as "object"] `object_
-              | `script
-              | `style
-              | `track
-              | `video
-              | `worker
-            ],
-      ~fetchPriority: [ | `auto | `high | `low]=?,
-      ~referrerPolicy: [
-                         | [@mel.as "no-referrer"] `noReferrer
-                         | [@mel.as "no-referrer-when-downgrade"]
-                           `noReferrerWhenDowngrade
-                         | [@mel.as "origin"] `origin
-                         | [@mel.as "origin-when-cross-origin"]
-                           `originWhenCrossOrigin
-                         | [@mel.as "unsafe-url"] `unsafeUrl
-                       ]
-                         =?,
+        | `audio
+        | `document
+        | `embed
+        | `fetch
+        | `font
+        | `image
+        | [@mel.as "object"] `object_
+        | `script
+        | `style
+        | `track
+        | `video
+        | `worker
+      ],
+      ~fetchPriority:
+        [
+          | `auto
+          | `high
+          | `low
+        ]
+          =?,
+      ~referrerPolicy:
+        [
+          | [@mel.as "no-referrer"] `noReferrer
+          | [@mel.as "no-referrer-when-downgrade"] `noReferrerWhenDowngrade
+          | [@mel.as "origin"] `origin
+          | [@mel.as "origin-when-cross-origin"] `originWhenCrossOrigin
+          | [@mel.as "unsafe-url"] `unsafeUrl
+        ]
+          =?,
       ~imageSrcSet: string=?,
       ~imageSizes: string=?,
       ~crossOrigin: string=?,
@@ -520,11 +525,29 @@ module Experimental = {
   [@deriving jsProperties]
   type preinitOptions = {
     [@mel.as "as"]
-    _as: [ | `script | `style],
+    _as: [
+      | `script
+      | `style
+    ],
     [@mel.optional]
-    fetchPriority: option([ | `auto | `high | `low]),
+    fetchPriority:
+      option(
+        [
+          | `auto
+          | `high
+          | `low
+        ],
+      ),
     [@mel.optional]
-    precedence: option([ | `reset | `low | `medium | `high]),
+    precedence:
+      option(
+        [
+          | `reset
+          | `low
+          | `medium
+          | `high
+        ],
+      ),
     [@mel.optional]
     crossOrigin: option(string),
     [@mel.optional]

--- a/src/ReactDOM.rei
+++ b/src/ReactDOM.rei
@@ -490,42 +490,47 @@ module Experimental: {
   type preloadOptions;
 
   [@mel.obj]
+  /* Its possible values are audio, document, embed, fetch, font, image, object, script, style, track, video, worker. */
   external preloadOptions:
-    /* Its possible values are audio, document, embed, fetch, font, image, object, script, style, track, video, worker. */
     (
       ~_as: [
-              | `audio
-              | `document
-              | `embed
-              | `fetch
-              | `font
-              | `image
-              | [@mel.as "object"] `object_
-              | `script
-              | `style
-              | `track
-              | `video
-              | `worker
-            ],
+        | `audio
+        | `document
+        | `embed
+        | `fetch
+        | `font
+        | `image
+        | [@mel.as "object"] `object_
+        | `script
+        | `style
+        | `track
+        | `video
+        | `worker
+      ],
       /*
           Suggests a relative priority for fetching the resource.
           The possible values are auto (the default), high, and low.
        */
-      ~fetchPriority: [ | `auto | `high | `low]=?,
+      ~fetchPriority:
+        [
+          | `auto
+          | `high
+          | `low
+        ]
+          =?,
       /*
           The Referrer header to send when fetching.
           Its possible values are no-referrer-when-downgrade (the default), no-referrer, origin, origin-when-cross-origin, and unsafe-url.
        */
-      ~referrerPolicy: [
-                         | [@mel.as "no-referrer"] `noReferrer
-                         | [@mel.as "no-referrer-when-downgrade"]
-                           `noReferrerWhenDowngrade
-                         | [@mel.as "origin"] `origin
-                         | [@mel.as "origin-when-cross-origin"]
-                           `originWhenCrossOrigin
-                         | [@mel.as "unsafe-url"] `unsafeUrl
-                       ]
-                         =?,
+      ~referrerPolicy:
+        [
+          | [@mel.as "no-referrer"] `noReferrer
+          | [@mel.as "no-referrer-when-downgrade"] `noReferrerWhenDowngrade
+          | [@mel.as "origin"] `origin
+          | [@mel.as "origin-when-cross-origin"] `originWhenCrossOrigin
+          | [@mel.as "unsafe-url"] `unsafeUrl
+        ]
+          =?,
       /*
           For use only with as: "image". Specifies the source set of the image.
           https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images
@@ -563,20 +568,38 @@ module Experimental: {
   type preinitOptions = {
     /* possible values: "script" or "style" */
     [@mel.as "as"]
-    _as: [ | `script | `style],
+    _as: [
+      | `script
+      | `style
+    ],
     /*
       Suggests a relative priority for fetching the resource.
       The possible values are auto (the default), high, and low.
      */
     [@mel.optional]
-    fetchPriority: option([ | `auto | `high | `low]),
+    fetchPriority:
+      option(
+        [
+          | `auto
+          | `high
+          | `low
+        ],
+      ),
     /*
       Required with Stylesheets (`style). Says where to insert the stylesheet relative to others.
       Stylesheets with higher precedence can override those with lower precedence.
       The possible values are reset, low, medium, high.
      */
     [@mel.optional]
-    precedence: option([ | `reset | `low | `medium | `high]),
+    precedence:
+      option(
+        [
+          | `reset
+          | `low
+          | `medium
+          | `high
+        ],
+      ),
     /*
         a required string. It must be "anonymous", "use-credentials", and "".
         https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin

--- a/test/melange-testing-library/dom/Queries.re
+++ b/test/melange-testing-library/dom/Queries.re
@@ -136,11 +136,12 @@ external getNodeText: Dom.element => string = "getNodeText";
 external _getByLabelText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
   Dom.element =
@@ -157,11 +158,12 @@ let getByLabelText = (~matcher, ~options=?, element) =>
 external _getAllByLabelText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
   array(Dom.element) =
@@ -178,11 +180,12 @@ let getAllByLabelText = (~matcher, ~options=?, element) =>
 external _queryByLabelText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
   Js.null(Dom.element) =
@@ -199,11 +202,12 @@ let queryByLabelText = (~matcher, ~options=?, element) =>
 external _queryAllByLabelText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
   array(Dom.element) =
@@ -220,11 +224,12 @@ let queryAllByLabelText = (~matcher, ~options=?, element) =>
 external _findByLabelText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
   Js.Promise.t(Dom.element) =
@@ -241,11 +246,12 @@ let findByLabelText = (~matcher, ~options=?, element) =>
 external _findAllByLabelText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
   Js.Promise.t(array(Dom.element)) =
@@ -265,11 +271,12 @@ let findAllByLabelText = (~matcher, ~options=?, element) =>
 external _getByPlaceholderText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByPlaceholderTextQuery.options)
   ) =>
   Dom.element =
@@ -286,11 +293,12 @@ let getByPlaceholderText = (~matcher, ~options=?, element) =>
 external _getAllByPlaceholderText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByPlaceholderTextQuery.options)
   ) =>
   array(Dom.element) =
@@ -307,11 +315,12 @@ let getAllByPlaceholderText = (~matcher, ~options=?, element) =>
 external _queryByPlaceholderText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByPlaceholderTextQuery.options)
   ) =>
   Js.null(Dom.element) =
@@ -328,11 +337,12 @@ let queryByPlaceholderText = (~matcher, ~options=?, element) =>
 external _queryAllByPlaceholderText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByPlaceholderTextQuery.options)
   ) =>
   array(Dom.element) =
@@ -349,11 +359,12 @@ let queryAllByPlaceholderText = (~matcher, ~options=?, element) =>
 external _findByPlaceholderText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByPlaceholderTextQuery.options)
   ) =>
   Js.Promise.t(Dom.element) =
@@ -370,11 +381,12 @@ let findByPlaceholderText = (~matcher, ~options=?, element) =>
 external _findAllByPlaceholderText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByPlaceholderTextQuery.options)
   ) =>
   Js.Promise.t(array(Dom.element)) =
@@ -394,11 +406,12 @@ let findAllByPlaceholderText = (~matcher, ~options=?, element) =>
 external _getByText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByTextQuery.options)
   ) =>
   Dom.element =
@@ -411,11 +424,12 @@ let getByText = (~matcher, ~options=?, element) =>
 external _getAllByText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByTextQuery.options)
   ) =>
   array(Dom.element) =
@@ -432,11 +446,12 @@ let getAllByText = (~matcher, ~options=?, element) =>
 external _queryByText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByTextQuery.options)
   ) =>
   Js.null(Dom.element) =
@@ -449,11 +464,12 @@ let queryByText = (~matcher, ~options=?, element) =>
 external _queryAllByText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByTextQuery.options)
   ) =>
   array(Dom.element) =
@@ -470,11 +486,12 @@ let queryAllByText = (~matcher, ~options=?, element) =>
 external _findByText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByTextQuery.options)
   ) =>
   Js.Promise.t(Dom.element) =
@@ -487,11 +504,12 @@ let findByText = (~matcher, ~options=?, element) =>
 external _findAllByText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Str(string)
+        | `RegExp(Js.Re.t)
+        | `Func((string, Dom.element) => bool)
+      ],
     ~options: Js.undefined(ByTextQuery.options)
   ) =>
   Js.Promise.t(array(Dom.element)) =
@@ -511,11 +529,12 @@ let findAllByText = (~matcher, ~options=?, element) =>
 external _getByAltText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByAltTextQuery.options)
   ) =>
   Dom.element =
@@ -532,11 +551,12 @@ let getByAltText = (~matcher, ~options=?, element) =>
 external _getAllByAltText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByAltTextQuery.options)
   ) =>
   array(Dom.element) =
@@ -553,11 +573,12 @@ let getAllByAltText = (~matcher, ~options=?, element) =>
 external _queryByAltText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByAltTextQuery.options)
   ) =>
   Js.null(Dom.element) =
@@ -574,11 +595,12 @@ let queryByAltText = (~matcher, ~options=?, element) =>
 external _queryAllByAltText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByAltTextQuery.options)
   ) =>
   array(Dom.element) =
@@ -595,11 +617,12 @@ let queryAllByAltText = (~matcher, ~options=?, element) =>
 external _findByAltText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByAltTextQuery.options)
   ) =>
   Js.Promise.t(Dom.element) =
@@ -616,11 +639,12 @@ let findByAltText = (~matcher, ~options=?, element) =>
 external _findAllByAltText:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByAltTextQuery.options)
   ) =>
   Js.Promise.t(array(Dom.element)) =
@@ -640,11 +664,12 @@ let findAllByAltText = (~matcher, ~options=?, element) =>
 external _getByTitle:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByTitleQuery.options)
   ) =>
   Dom.element =
@@ -657,11 +682,12 @@ let getByTitle = (~matcher, ~options=?, element) =>
 external _getAllByTitle:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByTitleQuery.options)
   ) =>
   array(Dom.element) =
@@ -678,11 +704,12 @@ let getAllByTitle = (~matcher, ~options=?, element) =>
 external _queryByTitle:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByTitleQuery.options)
   ) =>
   Js.null(Dom.element) =
@@ -699,11 +726,12 @@ let queryByTitle = (~matcher, ~options=?, element) =>
 external _queryAllByTitle:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByTitleQuery.options)
   ) =>
   array(Dom.element) =
@@ -720,11 +748,12 @@ let queryAllByTitle = (~matcher, ~options=?, element) =>
 external _findByTitle:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByTitleQuery.options)
   ) =>
   Js.Promise.t(Dom.element) =
@@ -737,11 +766,12 @@ let findByTitle = (~matcher, ~options=?, element) =>
 external _findAllByTitle:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByTitleQuery.options)
   ) =>
   Js.Promise.t(array(Dom.element)) =
@@ -761,11 +791,12 @@ let findAllByTitle = (~matcher, ~options=?, element) =>
 external _getByDisplayValue:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByDisplayValueQuery.options)
   ) =>
   Dom.element =
@@ -782,11 +813,12 @@ let getByDisplayValue = (~matcher, ~options=?, element) =>
 external _getAllByDisplayValue:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByDisplayValueQuery.options)
   ) =>
   array(Dom.element) =
@@ -803,11 +835,12 @@ let getAllByDisplayValue = (~matcher, ~options=?, element) =>
 external _queryByDisplayValue:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByDisplayValueQuery.options)
   ) =>
   Js.null(Dom.element) =
@@ -824,11 +857,12 @@ let queryByDisplayValue = (~matcher, ~options=?, element) =>
 external _queryAllByDisplayValue:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByDisplayValueQuery.options)
   ) =>
   array(Dom.element) =
@@ -845,11 +879,12 @@ let queryAllByDisplayValue = (~matcher, ~options=?, element) =>
 external _findByDisplayValue:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByDisplayValueQuery.options)
   ) =>
   Js.Promise.t(Dom.element) =
@@ -866,11 +901,12 @@ let findByDisplayValue = (~matcher, ~options=?, element) =>
 external _findAllByDisplayValue:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByDisplayValueQuery.options)
   ) =>
   Js.Promise.t(array(Dom.element)) =
@@ -890,11 +926,12 @@ let findAllByDisplayValue = (~matcher, ~options=?, element) =>
 external _getByRole:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByRoleQuery.options)
   ) =>
   Dom.element =
@@ -907,11 +944,12 @@ let getByRole = (~matcher, ~options=?, element) =>
 external _getAllByRole:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByRoleQuery.options)
   ) =>
   array(Dom.element) =
@@ -928,11 +966,12 @@ let getAllByRole = (~matcher, ~options=?, element) =>
 external _queryByRole:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByRoleQuery.options)
   ) =>
   Js.null(Dom.element) =
@@ -945,11 +984,12 @@ let queryByRole = (~matcher, ~options=?, element) =>
 external _queryAllByRole:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByRoleQuery.options)
   ) =>
   array(Dom.element) =
@@ -966,11 +1006,12 @@ let queryAllByRole = (~matcher, ~options=?, element) =>
 external _findByRole:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByRoleQuery.options)
   ) =>
   Js.Promise.t(Dom.element) =
@@ -983,11 +1024,12 @@ let findByRole = (~matcher, ~options=?, element) =>
 external _findAllByRole:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByRoleQuery.options)
   ) =>
   Js.Promise.t(array(Dom.element)) =
@@ -1007,11 +1049,12 @@ let findAllByRole = (~matcher, ~options=?, element) =>
 external _getByTestId:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByTestIdQuery.options)
   ) =>
   Dom.element =
@@ -1024,11 +1067,12 @@ let getByTestId = (~matcher, ~options=?, element) =>
 external _getAllByTestId:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByTestIdQuery.options)
   ) =>
   array(Dom.element) =
@@ -1045,11 +1089,12 @@ let getAllByTestId = (~matcher, ~options=?, element) =>
 external _queryByTestId:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByTestIdQuery.options)
   ) =>
   Js.null(Dom.element) =
@@ -1066,11 +1111,12 @@ let queryByTestId = (~matcher, ~options=?, element) =>
 external _queryAllByTestId:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByTestIdQuery.options)
   ) =>
   array(Dom.element) =
@@ -1087,11 +1133,12 @@ let queryAllByTestId = (~matcher, ~options=?, element) =>
 external _findByTestId:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByTestIdQuery.options)
   ) =>
   Js.Promise.t(Dom.element) =
@@ -1108,11 +1155,12 @@ let findByTestId = (~matcher, ~options=?, element) =>
 external _findAllByTestId:
   (
     Dom.element,
-    ~matcher: [@mel.unwrap] [
-                | `Func((string, Dom.element) => bool)
-                | `RegExp(Js.Re.t)
-                | `Str(string)
-              ],
+    ~matcher:
+      [@mel.unwrap] [
+        | `Func((string, Dom.element) => bool)
+        | `RegExp(Js.Re.t)
+        | `Str(string)
+      ],
     ~options: Js.undefined(ByTestIdQuery.options)
   ) =>
   Js.Promise.t(array(Dom.element)) =


### PR DESCRIPTION
When running the formatter I was getting an error saying that we had ocamlformat 0.27.0 but wanted to format in 0.26.0 so I updated the `.ocamlformat` to be 0.27.0. Honestly, it seems like that file just makes more, shouldn't it just go ahead and format it to whatever version of ocamlformat you have in your dep tree?

Anyways, this applies consistent formatting across the codebase using ocamlformat 0.27.0