### PR TITLE
feat(react): add Activity Module

### DIFF
--- a/src/React.re
+++ b/src/React.re
@@ -459,6 +459,26 @@ module Suspense = {
     "Suspense";
 };
 
+module Activity =  {
+  type mode = [ | `visible | `hidden ];
+  [@mel.obj]
+  external makeProps:
+    (~children: element=?, ~mode: mode=?, unit) =>
+    {
+      .
+      "children": option(element),
+      "mode": option(mode),
+    };
+  [@mel.module "react"]
+  external make:
+    component({
+      .
+      "children": option(element),
+      "mode": option(mode),
+    }) =
+    "Activity";
+};
+
 [@mel.set]
 external setDisplayName: (component('props), string) => unit = "displayName";
 

--- a/src/React.rei
+++ b/src/React.rei
@@ -157,6 +157,26 @@ module Suspense: {
     "Suspense";
 };
 
+module Activity: {
+  type mode = [ | `visible | `hidden ];
+  [@mel.obj]
+  external makeProps:
+    (~children: element=?, ~mode: mode=?, unit) =>
+    {
+      .
+      "children": option(element),
+      "mode": option(mode),
+    };
+  [@mel.module "react"]
+  external make:
+    component({
+      .
+      "children": option(element),
+      "mode": option(mode),
+    }) =
+    "Activity";
+};
+
 /* HOOKS */
 
 /*


### PR DESCRIPTION
React API: `<Activity>` Introduced in `[react@v19.2.0](https://github.com/facebook/react/releases/tag/v19.2.0)`