### PR TITLE
feat(react): add Profiler module

### DIFF
--- a/src/React.re
+++ b/src/React.re
@@ -440,6 +440,32 @@ module StrictMode = {
   external make: component({. "children": element}) = "StrictMode";
 };
 
+module Profiler = {
+  type phase =
+    | [@mel.as "mount"] Mount
+    | [@mel.as "update"] Update
+    | [@mel.as "nested-update"] NestedUpdate;
+  type onRender = (string, phase, float, float, float, float) => unit;
+  [@mel.obj]
+  external makeProps:
+    (~children: element=?, ~id: string, ~onRender: onRender, unit) =>
+    {
+      .
+      "children": option(element),
+      "id": string,
+      "onRender": onRender,
+    };
+  [@mel.module "react"]
+  external make:
+    component({
+      .
+      "children": option(element),
+      "id": string,
+      "onRender": onRender,
+    }) =
+    "Profiler";
+};
+
 module Suspense = {
   [@mel.obj]
   external makeProps:

--- a/src/React.rei
+++ b/src/React.rei
@@ -138,6 +138,32 @@ module StrictMode: {
   external make: component({. "children": element}) = "StrictMode";
 };
 
+module Profiler: {
+  type phase =
+    | [@mel.as "mount"] Mount
+    | [@mel.as "update"] Update
+    | [@mel.as "nested-update"] NestedUpdate;
+  type onRender = (string, phase, float, float, float, float) => unit;
+  [@mel.obj]
+  external makeProps:
+    (~children: element=?, ~id: string, ~onRender: onRender, unit) =>
+    {
+      .
+      "children": option(element),
+      "id": string,
+      "onRender": onRender,
+    };
+  [@mel.module "react"]
+  external make:
+    component({
+      .
+      "children": option(element),
+      "id": string,
+      "onRender": onRender,
+    }) =
+    "Profiler";
+};
+
 module Suspense: {
   [@mel.obj]
   external makeProps:


### PR DESCRIPTION
React API: `<Profiler>` component Introduced in [react@v19.2.0](https://github.com/facebook/react/releases/tag/v19.2.0) 

Usage Documentation: https://react.dev/reference/react/Profiler